### PR TITLE
Make RecyclerViewDemoActivity.ChatHolder public 

### DIFF
--- a/app/src/main/java/com/firebase/uidemo/RecyclerViewDemoActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/RecyclerViewDemoActivity.java
@@ -41,7 +41,9 @@ public class RecyclerViewDemoActivity extends AppCompatActivity {
             }
         });
 
-        FirebaseRecyclerViewAdapter<Chat, ChatHolder> adapter = new FirebaseRecyclerViewAdapter<Chat, ChatHolder>(Chat.class, android.R.layout.two_line_list_item, ChatHolder.class, ref) {
+        FirebaseRecyclerViewAdapter<Chat, ChatHolder> adapter =
+                new FirebaseRecyclerViewAdapter<Chat, ChatHolder>(
+                        Chat.class, android.R.layout.two_line_list_item, ChatHolder.class, ref) {
             @Override
             public void populateViewHolder(ChatHolder chatView, Chat chat) {
                 chatView.messageText.setText(chat.getMessage());
@@ -63,7 +65,7 @@ public class RecyclerViewDemoActivity extends AppCompatActivity {
     }
 
 
-    static class Chat {
+    public static class Chat {
         String name;
         String message;
 
@@ -84,7 +86,7 @@ public class RecyclerViewDemoActivity extends AppCompatActivity {
         }
     }
 
-    static class ChatHolder extends RecyclerView.ViewHolder {
+    public static class ChatHolder extends RecyclerView.ViewHolder {
         TextView nameText, messageText;
 
         public ChatHolder(View itemView) {

--- a/app/src/main/java/com/firebase/uidemo/RecyclerViewDemoActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/RecyclerViewDemoActivity.java
@@ -65,7 +65,7 @@ public class RecyclerViewDemoActivity extends AppCompatActivity {
     }
 
 
-    public static class Chat {
+    static class Chat {
         String name;
         String message;
 


### PR DESCRIPTION
Fix the bug that ChatHolder is not public so it could not be accessed, which causes crash.

@puf Can you review? Thanks!