### PR TITLE
Solve Google logout/login issue.

### DIFF
--- a/library/src/main/java/com/firebase/ui/auth/google/GoogleAuthProvider.java
+++ b/library/src/main/java/com/firebase/ui/auth/google/GoogleAuthProvider.java
@@ -116,12 +116,8 @@ public class GoogleAuthProvider extends FirebaseAuthProvider implements
     }
 
     public void login() {
-        if (mGoogleApiClient.isConnected()) {
             Intent signInIntent = Auth.GoogleSignInApi.getSignInIntent(mGoogleApiClient);
             mActivity.startActivityForResult(signInIntent, GoogleActions.SIGN_IN);
-        } else {
-            onConnectedAction = GoogleActions.SIGN_IN;
-        }
     }
     private void revokeAccess() {
         Auth.GoogleSignInApi.revokeAccess(mGoogleApiClient).setResultCallback(


### PR DESCRIPTION
Solves issue #34 

Logging out with Google account causes the mGoogleApiClient to be disconnected.
But this caused a blocking spinner, and reconnect of mGoogleApiClient  doesnt happen anymore.

After testing it seems that starting the signInIntent is not a problem when the mGoogleApiClient is disconnected, solving issue #34 