### PR TITLE
Add link to Android Config file generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ If you're using Google authentication, add the following to your `<application>`
  ```
 
 **Note:** If you're using Google Sign-in you'll also need to ensure that your `google-services.json` file is created
-and placed in your app folder.
+and placed in your app folder. To get one for your project, you can do so [on this link]
+(https://developers.google.com/identity/sign-in/android/start).
 
 ### Inherit from FirebaseLoginBaseActivity
 


### PR DESCRIPTION
For seasoned developers, knowing where to get the `google-services.json` is basic knowledge. 
However, for people who are just getting started, it is simpler to send them there with a link, 
just like the [FirebaseUI for iOS does]
(https://github.com/firebase/firebaseui-ios#firebasegoogleauthprovider).

cc. @puf @mcdonamp 