### PR TITLE
Update Readme Enable Authentication Providers 

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,10 @@ public class MainActivity extends FirebaseLoginBaseActivity {
     protected void onStart() {
         super.onStart();
         // All providers are optional! Remove any you don't want.
-        setEnabledAuthProvider(AuthProviderType.FACEBOOK);
-        setEnabledAuthProvider(AuthProviderType.TWITTER);
-        setEnabledAuthProvider(AuthProviderType.GOOGLE);
-        setEnabledAuthProvider(AuthProviderType.PASSWORD);
+        setEnabledAuthProvider(SocialProvider.facebook);
+        setEnabledAuthProvider(SocialProvider.twitter);
+        setEnabledAuthProvider(SocialProvider.google);
+        setEnabledAuthProvider(SocialProvider.password);
     }
 ```
 


### PR DESCRIPTION
Enable Authentication Providers

In the code example to Enable Authentication Providers.
instead of calling AuthProvider.FACEBOOK, I had to use SocialProvider.facebook
AuthProvider was giving me a syntax error when trying to use AuthProvier