### PR TITLE
Update FacebookAuthProvider.java

### DIFF
--- a/library/src/main/java/com/firebase/ui/auth/facebook/FacebookAuthProvider.java
+++ b/library/src/main/java/com/firebase/ui/auth/facebook/FacebookAuthProvider.java
@@ -88,7 +88,7 @@ public class FacebookAuthProvider extends FirebaseAuthProvider {
 
     public void login() {
         if (isReady) {
-            Collection<String> permissions = Arrays.asList("public_profile");
+            Collection<String> permissions = Arrays.asList("public_profile", "email");
             mLoginManager.logInWithReadPermissions((Activity)getContext(), permissions);
         }
     }


### PR DESCRIPTION
Updated permission for facebook logInWithReadPermissions to include email.
The email permission is included for iOS FirebaseUI but not in Android FirebaseUI.