### PR TITLE
Fix for 'Sign In with Email' Shadow

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@
 # The email address is not required for organizations.
 
 Google Inc.
+Marios Harrane <marios@harrane.me>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,3 +13,4 @@ Frank van Puffelen <puf@google.com>
 Abraham Haskins <abehaskins@google.com>
 David East <deast@google.com>
 Mike McDonald <mpmcdonald@google.com>
+Marios Harrane <marios@harrane.me>

--- a/auth/src/main/res/values/styles.xml
+++ b/auth/src/main/res/values/styles.xml
@@ -104,7 +104,7 @@
     </style>
 
     <!-- Common styles -->
-    <style name="FirebaseUI.Text.TextInputLayout" >
+    <style name="FirebaseUI.Text.TextInputLayout">
         <item name="android:paddingTop">8dp</item>
     </style>
 
@@ -200,6 +200,7 @@
     <style name="FirebaseUI.AuthMethodPicker.ButtonHolder">
         <item name="android:orientation">vertical</item>
         <item name="android:paddingBottom">56dp</item>
+        <item name="android:clipToPadding">false</item>
         <item name="android:layout_width">220dp</item>
         <item name="android:layout_height">wrap_content</item>
     </style>


### PR DESCRIPTION
Shadow for the 'Sign In with Email' button was cut at the bottom in portrait orientation when pressed.

![button_issue](https://cloud.githubusercontent.com/assets/6030099/15435944/20ef71e8-1eb7-11e6-8952-bb43237befa0.png)


