### PR TITLE
Fix for: Wrong result code after password reset flow

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/SignInActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/SignInActivity.java
@@ -148,7 +148,6 @@ public class SignInActivity extends AppCompatBase implements View.OnClickListene
                     this,
                     mActivityHelper.getFlowParams(),
                     mEmailEditText.getText().toString()));
-            finish(RESULT_OK, new Intent());
             return;
         }
     }


### PR DESCRIPTION
Cancelling the password reset flow, or sending the password reset email no longer returns with the incorrect RESULT_OK status.  It now returns the user to the sign in form.