### PR TITLE
Check mEmail for empty String to prevent "credential identifier cannot be empty" error

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/account_link/SaveCredentialsActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/account_link/SaveCredentialsActivity.java
@@ -89,7 +89,7 @@ public class SaveCredentialsActivity extends AppCompatBase
 
     @Override
     public void onConnected(@Nullable Bundle bundle) {
-        if (mEmail == null) {
+        if (mEmail == null || mEmail.equals("")) {
             Log.e(TAG, "Unable to save null credential!");
             finish(RESULT_FIRST_USER, getIntent());
             return;


### PR DESCRIPTION
made code more robust, should fix #141 
