### PR TITLE
resolve lint error for register_email_layout.xml

### DIFF
--- a/auth/src/main/res/layout/register_email_layout.xml
+++ b/auth/src/main/res/layout/register_email_layout.xml
@@ -4,7 +4,7 @@
     android:layout_height="match_parent"
     android:layout_width="match_parent">
 
-    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <RelativeLayout
                   style="@style/FirebaseUI.WrapperStyle"
                   android:layout_width="match_parent"
                   android:layout_height="wrap_content">


### PR DESCRIPTION
Currently lint fails because an extra xmlns:android declaration is found in the register_email_layout.xml.  This pull request removes the extra declaration.