### PR TITLE
use a consistent and latest version for support library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,10 +25,10 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.2.1'
-    compile 'com.android.support:design:23.2.1'
-    compile 'com.android.support:recyclerview-v7:23.2.1'
-    compile 'com.android.support:support-v4:23.2.1'
+    compile "com.android.support:appcompat-v7:${project.ext.support_library_version}"
+    compile "com.android.support:design:${project.ext.support_library_version}"
+    compile "com.android.support:recyclerview-v7:${project.ext.support_library_version}"
+    compile "com.android.support:support-v4:${project.ext.support_library_version}"
 
     compile project(path: ':auth')
     compile project(path: ':database')

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -23,9 +23,9 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile "org.robolectric:robolectric:3.1-rc1"
-    compile 'com.android.support:appcompat-v7:23.3.0'
+    compile "com.android.support:appcompat-v7:${project.ext.support_library_version}"
     compile 'com.facebook.android:facebook-android-sdk:4.11.0'
-    compile "com.android.support:design:23.3.0"
+    compile "com.android.support:design:${project.ext.support_library_version}"
 
     compile "com.google.firebase:firebase-auth:${project.ext.firebase_version}"
     compile "com.google.android.gms:play-services-auth:${project.ext.firebase_version}"

--- a/common/constants.gradle
+++ b/common/constants.gradle
@@ -1,4 +1,5 @@
 project.ext.firebase_version = '9.0.2'
+project.ext.support_library_version = '23.4.0'
 
 project.ext.submodules = ['database', 'auth']
 project.ext.group = "com.firebaseui"

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -19,8 +19,8 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.2.1'
-    compile 'com.android.support:recyclerview-v7:23.2.1'
+    compile "com.android.support:appcompat-v7:${project.ext.support_library_version}"
+    compile "com.android.support:recyclerview-v7:${project.ext.support_library_version}"
 
     compile "com.google.firebase:firebase-database:${project.ext.firebase_version}"
 }


### PR DESCRIPTION
Support libraries are using inconsistent versions all over the place, which makes it difficult for applications to manage their dependencies.  This pull request makes all support library versions consistent.