### PR TITLE
debug log not error log

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/util/CredentialsAPI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/CredentialsAPI.java
@@ -163,7 +163,7 @@ public class CredentialsAPI implements
         } else {
             // Email/password account
             String status = String.format("Signed in as %s", credential.getId());
-            Log.e(TAG, status);
+            Log.d(TAG, status);
         }
     }
 


### PR DESCRIPTION
A log is falsely displayed as an error even though it is just a debugging log entry.  This pull request corrects it.