### PR TITLE
Have FirebaseArray accessible from subclasses

### DIFF
--- a/database/src/main/java/com/firebase/ui/database/FirebaseListAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseListAdapter.java
@@ -52,7 +52,7 @@ public abstract class FirebaseListAdapter<T> extends BaseAdapter {
     private final Class<T> mModelClass;
     protected int mLayout;
     protected Activity mActivity;
-    FirebaseArray mSnapshots;
+    protected FirebaseArray mSnapshots;
 
 
     /**


### PR DESCRIPTION
Problem:
Currently, I think, It's not possible to remove items from the FirebaseListAdapter without removing it also on firebase db. 

Proposal:
I think (not sure) that having access directly to FirebaseArray would allow to create in the subclass custom adapter a method to remove items **only** on the adpater and not in db.