### PR TITLE
Facebook permissions are taken from an array resource

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
@@ -77,8 +77,11 @@ public class FacebookProvider implements IDPProvider, FacebookCallback<LoginResu
         mCallbackManager = CallbackManager.Factory.create();
         LoginManager loginManager = LoginManager.getInstance();
         loginManager.registerCallback(mCallbackManager, this);
+
+        String[] permissions = activity.getResources().getStringArray(R.array.facebook_permissions);
+
         loginManager.logInWithReadPermissions(
-                activity, Arrays.asList("public_profile", "email"));
+                activity, Arrays.asList(permissions));
     }
 
     @Override

--- a/auth/src/main/res/values/config.xml
+++ b/auth/src/main/res/values/config.xml
@@ -9,6 +9,13 @@
     -->
     <string name="facebook_application_id" translatable="false">CHANGE-ME</string>
 
+    <!-- The facebook permissions that the app will request from the user -->
+    <array name="facebook_permissions">
+        <item>CHANGE-ME</item>
+        <item>CHANGE-ME-TOO</item>
+    </array>
+
+
     <!--
     The Google web client ID associated with this Android application. The
     google-services gradle plugin will automatically provide this value.


### PR DESCRIPTION
Up till now, the code was using the hardcoded permissions "public_profile" and "email". This pull request allows client apps to define the permissions that the want to request, as per issue #197.