### PR TITLE
Facebook permissions are taken from an array resource

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
@@ -77,8 +77,11 @@ public class FacebookProvider implements IDPProvider, FacebookCallback<LoginResu
         mCallbackManager = CallbackManager.Factory.create();
         LoginManager loginManager = LoginManager.getInstance();
         loginManager.registerCallback(mCallbackManager, this);
+
+        String[] permissions = activity.getResources().getStringArray(R.array.facebook_permissions);
+
         loginManager.logInWithReadPermissions(
-                activity, Arrays.asList("public_profile", "email"));
+                activity, Arrays.asList(permissions));
     }
 
     @Override

--- a/auth/src/main/res/values/config.xml
+++ b/auth/src/main/res/values/config.xml
@@ -9,6 +9,22 @@
     -->
     <string name="facebook_application_id" translatable="false">CHANGE-ME</string>
 
+
+    <!--
+    The facebook permissions that this Android Application will request from the
+    user. Users of FirebaseUI auth can add additional items with the additional
+    permissions they want to request.
+
+    See:
+    https://developers.facebook.com/docs/facebook-login/android
+    https://developers.facebook.com/docs/facebook-login/permissions
+    -->
+    <array name="facebook_permissions">
+        <item>public_profile</item>
+        <item>email</item>
+    </array>
+
+
     <!--
     The Google web client ID associated with this Android application. The
     google-services gradle plugin will automatically provide this value.


### PR DESCRIPTION
Instead of using the hardcoded permissions "public_profile" and "email", this pull request allows client apps to define any permissions they want, as requested in issue #197.