### PR TITLE
Fix bug in welcome back activity

### DIFF
--- a/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
@@ -40,6 +40,8 @@ import butterknife.OnClick;
 
 public class AuthUiActivity extends AppCompatActivity {
 
+    private static final String TAG = "AuthUIActivity";
+
     private static final String UNCHANGED_CONFIG_VALUE = "CHANGE-ME";
 
     private static final String GOOGLE_TOS_URL =

--- a/auth/src/main/java/com/firebase/ui/auth/ui/AcquireEmailHelper.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/AcquireEmailHelper.java
@@ -16,7 +16,6 @@ package com.firebase.ui.auth.ui;
 
 import android.content.Intent;
 import android.support.annotation.NonNull;
-import android.util.Log;
 
 import com.firebase.ui.auth.R;
 import com.firebase.ui.auth.ui.account_link.WelcomeBackIDPPrompt;
@@ -111,7 +110,7 @@ public class AcquireEmailHelper {
 
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (REQUEST_CODES.contains(requestCode)) {
-            mActivityHelper.finish(resultCode, new Intent());
+            mActivityHelper.finish(resultCode, data);
         }
     }
 }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/account_link/WelcomeBackIDPPrompt.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/account_link/WelcomeBackIDPPrompt.java
@@ -94,6 +94,7 @@ public class WelcomeBackIDPPrompt extends AppCompatBase
                     "Firebase login successful. Account linking failed due to provider not "
                             + "enabled by application");
             finish(RESULT_CANCELED, getIntent());
+            return;
         }
 
         ((TextView) findViewById(R.id.welcome_back_idp_prompt))


### PR DESCRIPTION
Missing return can cause crashes when there is account email overlap.