### PR TITLE
Allow users to set a custom toolbar title.

### DIFF
--- a/auth/src/main/AndroidManifest.xml
+++ b/auth/src/main/AndroidManifest.xml
@@ -3,36 +3,57 @@
     package="com.firebase.ui.auth">
 
     <application>
-        <activity android:theme="@style/FirebaseUI.Dialog"
-                  android:name="com.firebase.ui.auth.ui.email.ConfirmRecoverPasswordActivity">
-        </activity>
-        <activity android:theme="@style/FirebaseUI.Translucent" android:name="com.firebase.ui.auth.ui.email.EmailHintContainerActivity" >
-        </activity>
-        <activity android:theme="@style/FirebaseUI" android:name="com.firebase.ui.auth.ui.email.RecoverPasswordActivity" >
-        </activity>
-        <activity android:theme="@style/FirebaseUI" android:name="com.firebase.ui.auth.ui.email.RegisterEmailActivity" >
-        </activity>
-        <activity android:theme="@style/FirebaseUI" android:name="com.firebase.ui.auth.ui.email.SignInNoPasswordActivity" >
-        </activity>
-        <activity android:theme="@style/FirebaseUI" android:name="com.firebase.ui.auth.ui.email.SignInActivity" >
-        </activity>
-        <activity android:theme="@style/FirebaseUI.Translucent"
-                  android:name="com.firebase.ui.auth.ui.account_link.SaveCredentialsActivity">
-        </activity>
-        <activity android:theme="@style/FirebaseUI" android:name="com.firebase.ui.auth.ui.account_link.AccountLinkInitActivity" >
-        </activity>
-        <activity android:theme="@style/FirebaseUI" android:name="com.firebase.ui.auth.ui.account_link.WelcomeBackIDPPrompt" >
-        </activity>
-        <activity android:theme="@style/FirebaseUI" android:name="com.firebase.ui.auth.ui.account_link.WelcomeBackPasswordPrompt" >
-        </activity>
-        <activity android:theme="@style/FirebaseUI" android:name=".ui.idp.AuthMethodPickerActivity" >
-        </activity>
-        <activity android:theme="@style/FirebaseUI.Translucent"
-                  android:name="com.firebase.ui.auth.ui.idp.IDPSignInContainerActivity" >
-        </activity>
-        <activity android:theme="@style/FirebaseUI.Translucent"
-                   android:name=".ui.ChooseAccountActivity" >
-        </activity>
+        <activity
+            android:name="com.firebase.ui.auth.ui.email.ConfirmRecoverPasswordActivity"
+            android:label="@string/title_confirm_recover_password_activity"
+            android:theme="@style/FirebaseUI.Dialog" />
+        <activity
+            android:name="com.firebase.ui.auth.ui.email.EmailHintContainerActivity"
+            android:label="@string/default_toolbar_title"
+            android:theme="@style/FirebaseUI.Translucent" />
+        <activity
+            android:name="com.firebase.ui.auth.ui.email.RecoverPasswordActivity"
+            android:label="@string/title_recover_password_activity"
+            android:theme="@style/FirebaseUI" />
+        <activity
+            android:name="com.firebase.ui.auth.ui.email.RegisterEmailActivity"
+            android:label="@string/title_register_email_activity"
+            android:theme="@style/FirebaseUI" />
+        <activity
+            android:name="com.firebase.ui.auth.ui.email.SignInNoPasswordActivity"
+            android:label="@string/title_sign_in_no_password_activity"
+            android:theme="@style/FirebaseUI" />
+        <activity
+            android:name="com.firebase.ui.auth.ui.email.SignInActivity"
+            android:label="@string/title_sign_in_activity"
+            android:theme="@style/FirebaseUI" />
+        <activity
+            android:name="com.firebase.ui.auth.ui.account_link.SaveCredentialsActivity"
+            android:label="@string/default_toolbar_title"
+            android:theme="@style/FirebaseUI.Translucent" />
+        <activity
+            android:name="com.firebase.ui.auth.ui.account_link.AccountLinkInitActivity"
+            android:theme="@style/FirebaseUI" />
+        <activity
+            android:name="com.firebase.ui.auth.ui.account_link.WelcomeBackIDPPrompt"
+            android:label="@string/title_welcome_back_idp_prompt"
+            android:theme="@style/FirebaseUI" />
+        <activity
+            android:name="com.firebase.ui.auth.ui.account_link.WelcomeBackPasswordPrompt"
+            android:label="@string/title_welcome_back_password_prompt"
+            android:theme="@style/FirebaseUI" />
+        <activity
+            android:name=".ui.idp.AuthMethodPickerActivity"
+            android:label="@string/default_toolbar_title"
+            android:theme="@style/FirebaseUI" />
+        <activity
+            android:name="com.firebase.ui.auth.ui.idp.IDPSignInContainerActivity"
+            android:label="@string/default_toolbar_title"
+            android:theme="@style/FirebaseUI.Translucent" />
+        <activity
+            android:name=".ui.ChooseAccountActivity"
+            android:label="@string/default_toolbar_title"
+            android:theme="@style/FirebaseUI.Translucent" />
 
         <activity
             android:name="com.facebook.FacebookActivity"
@@ -46,8 +67,10 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
+
                 <data android:scheme="@string/facebook_login_protocol_scheme" />
             </intent-filter>
         </activity>

--- a/auth/src/main/java/com/firebase/ui/auth/ui/account_link/WelcomeBackIDPPrompt.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/account_link/WelcomeBackIDPPrompt.java
@@ -58,7 +58,6 @@ public class WelcomeBackIDPPrompt extends AppCompatBase
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setTitle(getResources().getString(R.string.sign_in));
         mProviderId = getProviderIdFromIntent();
         mPrevIdpResponse = getIntent().getParcelableExtra(ExtraConstants.EXTRA_IDP_RESPONSE);
         setContentView(R.layout.welcome_back_idp_prompt_layout);

--- a/auth/src/main/java/com/firebase/ui/auth/ui/account_link/WelcomeBackPasswordPrompt.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/account_link/WelcomeBackPasswordPrompt.java
@@ -61,7 +61,6 @@ public class WelcomeBackPasswordPrompt extends AppCompatBase implements View.OnC
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setTitle(R.string.sign_in);
         setContentView(R.layout.welcome_back_password_prompt_layout);
         mPasswordLayout = (TextInputLayout) findViewById(R.id.password_layout);
         mIdpResponse = getIntent().getParcelableExtra(ExtraConstants.EXTRA_IDP_RESPONSE);

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/ConfirmRecoverPasswordActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/ConfirmRecoverPasswordActivity.java
@@ -37,7 +37,6 @@ public class ConfirmRecoverPasswordActivity extends android.support.v7.app.AppCo
         // intentionally do not configure the theme on this activity, it is a dialog
 
         setContentView(R.layout.confirm_recovery_layout);
-        setTitle(R.string.check_your_email);
         String email = getIntent().getStringExtra(ExtraConstants.EXTRA_EMAIL);
         boolean isSuccess = getIntent().getBooleanExtra(ExtraConstants.EXTRA_SUCCESS, true);
 

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/RecoverPasswordActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/RecoverPasswordActivity.java
@@ -43,7 +43,6 @@ public class RecoverPasswordActivity extends AppCompatBase implements View.OnCli
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setTitle(R.string.recover_password_title);
         setContentView(R.layout.forgot_password_layout);
         String email = getIntent().getStringExtra(ExtraConstants.EXTRA_EMAIL);
 

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/RegisterEmailActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/RegisterEmailActivity.java
@@ -61,7 +61,6 @@ public class RegisterEmailActivity extends AppCompatBase implements View.OnClick
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setTitle(R.string.create_account_title);
         setContentView(R.layout.register_email_layout);
 
         String email = getIntent().getStringExtra(ExtraConstants.EXTRA_EMAIL);

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/SignInActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/SignInActivity.java
@@ -53,7 +53,6 @@ public class SignInActivity extends AppCompatBase implements View.OnClickListene
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setTitle(R.string.sign_in);
         setContentView(R.layout.sign_in_layout);
 
         String email = getIntent().getStringExtra(ExtraConstants.EXTRA_EMAIL);

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/SignInNoPasswordActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/SignInNoPasswordActivity.java
@@ -40,7 +40,6 @@ public class SignInNoPasswordActivity extends AppCompatBase implements View.OnCl
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         mAcquireEmailHelper = new AcquireEmailHelper(mActivityHelper);
-        setTitle(R.string.sign_in_with_email);
         setContentView(R.layout.signin_no_password_layout);
 
         String email = getIntent().getStringExtra(ExtraConstants.EXTRA_EMAIL);

--- a/auth/src/main/res/values/strings.xml
+++ b/auth/src/main/res/values/strings.xml
@@ -1,5 +1,13 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="app_name">ui_flow</string>
+    <string name="default_toolbar_title">@string/app_name</string>
+    <string name="title_welcome_back_password_prompt">@string/sign_in</string>
+    <string name="title_sign_in_activity">@string/sign_in</string>
+    <string name="title_sign_in_no_password_activity">@string/sign_in_with_email</string>
+    <string name="title_welcome_back_idp_prompt">@string/sign_in</string>
+    <string name="title_register_email_activity">@string/create_account_title</string>
+    <string name="title_recover_password_activity">@string/recover_password_title</string>
+    <string name="title_confirm_recover_password_activity">@string/check_your_email</string>
     <string name="email_hint">Email</string>
     <string name="sign_in_no_password_title">Put an email to use for sign in</string>
     <string name="password_hint">Password</string>


### PR DESCRIPTION
FirebaseUI right now uses the app's name to set the Toolbar title in ```AuthMethodPickerActivity``` and ```EmailHintContainerActivity```.

This pull allows users to **set their own custom title** using
``` <string name="toolbar_title">"Custom title"</string> ```
in their app's ```strings.xml```.

*Result example:*
![screenshot_1471277900](https://cloud.githubusercontent.com/assets/5623301/17671441/49b12a00-6317-11e6-8b60-633aa87b2863.png)
