### PR TITLE
Make tests run/pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-23.4.0
+    - build-tools-23.0.3
     - android-23
     - extra-google-google_play_services
     - extra-google-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ android:
     - 'android-sdk-license-.+'
     - 'google-gdk-license-.+'
 script:
-  - ./gradlew clean test :library:prepareArtifacts
+  - ./gradlew clean :library:testAll :library:prepareArtifacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-24.0.1
-    - android-24
+    - build-tools-23.4.0
+    - android-23
     - extra-google-google_play_services
     - extra-google-m2repository
     - extra-android-m2repository
@@ -16,4 +16,4 @@ android:
     - 'android-sdk-license-.+'
     - 'google-gdk-license-.+'
 script:
-  - ./gradlew clean :library:prepareArtifacts
+  - ./gradlew clean test :library:prepareArtifacts

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,13 +3,13 @@ apply plugin: 'com.neenbedankt.android-apt'
 apply from: "../common/constants.gradle"
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion project.ext.compileSdk
     buildToolsVersion "${project.ext.buildtools}"
 
     defaultConfig {
         applicationId "com.firebase.uidemo"
         minSdkVersion 16
-        targetSdkVersion 24
+        targetSdkVersion project.ext.targetSdk
         versionCode 1
         versionName "1.0"
     }

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'checkstyle'
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion project.ext.compileSdk
     buildToolsVersion "${project.ext.buildtools}"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 24
+        targetSdkVersion project.ext.targetSdk
         versionCode 1
         versionName "1.0"
     }
@@ -22,7 +22,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile "org.robolectric:robolectric:3.1-rc1"
+    testCompile "org.robolectric:robolectric:3.1.1"
     compile "com.android.support:appcompat-v7:${project.ext.support_library_version}"
     compile 'com.facebook.android:facebook-android-sdk:4.14.1'
     compile "com.android.support:design:${project.ext.support_library_version}"

--- a/auth/src/main/AndroidManifest.xml
+++ b/auth/src/main/AndroidManifest.xml
@@ -3,6 +3,11 @@
     package="com.firebase.ui.auth">
 
     <application>
+
+        <meta-data
+            android:name="com.google.android.gms.version"
+            android:value="@integer/google_play_services_version" />
+
         <activity
             android:name="com.firebase.ui.auth.ui.email.ConfirmRecoverPasswordActivity"
             android:label="@string/title_confirm_recover_password_activity"

--- a/auth/src/main/java/com/firebase/ui/auth/util/CredentialsAPI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/CredentialsAPI.java
@@ -49,6 +49,7 @@ public class CredentialsAPI implements
     private ProgressDialog mProgressDialog;
     private Credential mCredential;
     private final CallbackInterface mCallback;
+    private PlayServicesHelper mPlayServicesHelper;
 
     public interface CallbackInterface {
         void onAsyncTaskFinished();
@@ -59,13 +60,14 @@ public class CredentialsAPI implements
         mSignInResolutionNeeded = false;
         mActivity = activity;
         mCallback = callback;
+        mPlayServicesHelper = PlayServicesHelper.getInstance(mActivity);
 
         initGoogleApiClient(null);
         requestCredentials(true /* shouldResolve */, false /* onlyPasswords */);
     }
 
     public boolean isPlayServicesAvailable() {
-        return PlayServicesHelper.isPlayServicesAvailable(mActivity);
+        return mPlayServicesHelper.isPlayServicesAvailable();
     }
 
     public boolean isCredentialsAvailable() {
@@ -167,7 +169,7 @@ public class CredentialsAPI implements
     }
 
     public void requestCredentials(final boolean shouldResolve, boolean onlyPasswords) {
-        if (!PlayServicesHelper.isPlayServicesAvailable(mActivity)) {
+        if (!mPlayServicesHelper.isPlayServicesAvailable()) {
             // TODO(samstern): it would probably be better to not actually call the method
             // in this case.
             return;

--- a/auth/src/main/java/com/firebase/ui/auth/util/PlayServicesHelper.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/PlayServicesHelper.java
@@ -5,6 +5,7 @@ import android.app.Dialog;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.util.Log;
 
 import com.google.android.gms.common.ConnectionResult;
@@ -18,31 +19,40 @@ public class PlayServicesHelper {
 
     private static final String TAG = "PlayServicesHelper";
 
-    private static final GoogleApiAvailability sApiAvailability =
-            GoogleApiAvailability.getInstance();
+    @VisibleForTesting
+    public static GoogleApiAvailability sApiAvailability;
+
+    private final Context mContext;
+
+    public static PlayServicesHelper getInstance(Context context) {
+        return new PlayServicesHelper(context);
+    }
+
+    private PlayServicesHelper(Context context) {
+        this.mContext = context;
+    }
 
     /**
      * Returns {@code true} if Google Play Services is available and at the correct version,
      * false otherwise.
      */
-    public static boolean isPlayServicesAvailable(Context context) {
-        int playServicesAvailable = sApiAvailability.isGooglePlayServicesAvailable(context);
+    public boolean isPlayServicesAvailable() {
+        int playServicesAvailable = sApiAvailability.isGooglePlayServicesAvailable(mContext);
         return playServicesAvailable == ConnectionResult.SUCCESS;
     }
 
     /**
      * Returns {@code true} if Google Play Services is either already available or can be made
      * available with user action, {@code false} otherwise.
-     * @param context the calling context.
      */
-    public static boolean canMakePlayServicesAvailable(Context context) {
+    public boolean canMakePlayServicesAvailable() {
         // Check if already available
-        if (isPlayServicesAvailable(context)) {
+        if (isPlayServicesAvailable()) {
             return true;
         }
 
         // Check if error is resolvable
-        int availabilityCode = sApiAvailability.isGooglePlayServicesAvailable(context);
+        int availabilityCode = sApiAvailability.isGooglePlayServicesAvailable(mContext);
         boolean isUserResolvable = sApiAvailability.isUserResolvableError(availabilityCode);
 
         // Although the API considers SERVICE_INVALID to be resolvable, it can cause crashes
@@ -59,18 +69,18 @@ public class PlayServicesHelper {
      * @return {@code true} if a resolution is launched or if a resolution was not necessary,
      *         {@code false otherwise}.
      */
-    public static boolean makePlayServicesAvailable(
+    public boolean makePlayServicesAvailable(
             @NonNull Activity activity,
             int requestCode,
             @Nullable Dialog.OnCancelListener cancelListener) {
 
         // Check if already available
-        if (isPlayServicesAvailable(activity)) {
+        if (isPlayServicesAvailable()) {
             return true;
         }
 
         // Check if error is resolvable
-        if (!canMakePlayServicesAvailable(activity)) {
+        if (!canMakePlayServicesAvailable()) {
             return false;
         }
 

--- a/auth/src/main/java/com/firebase/ui/auth/util/SmartlockUtil.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/SmartlockUtil.java
@@ -37,10 +37,7 @@ public class SmartlockUtil {
         }
 
         // If Play Services is not available, finish the Activity
-
-        if(!FirebaseAuthWrapperFactory
-                .getFirebaseAuthWrapper(parameters.appName)
-                .isPlayServicesAvailable(activity)) {
+        if(!PlayServicesHelper.getInstance(activity).isPlayServicesAvailable()) {
             finishActivity(activity);
             return;
         }

--- a/auth/src/test/java/com/firebase/ui/auth/test_helpers/TestHelper.java
+++ b/auth/src/test/java/com/firebase/ui/auth/test_helpers/TestHelper.java
@@ -19,12 +19,15 @@ import android.content.Context;
 import com.firebase.ui.auth.AuthUI;
 import com.firebase.ui.auth.ui.FlowParameters;
 import com.firebase.ui.auth.util.ProviderHelper;
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.auth.FirebaseUser;
 
 import java.util.List;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -63,5 +66,13 @@ public class TestHelper {
         when(mockFirebaseUser.getDisplayName()).thenReturn(TestConstants.NAME);
         when(mockFirebaseUser.getPhotoUrl()).thenReturn(TestConstants.PHOTO_URI);
         return mockFirebaseUser;
+    }
+
+    public static GoogleApiAvailability makeMockGoogleApiAvailability() {
+        GoogleApiAvailability availability = mock(GoogleApiAvailability.class);
+        when(availability.isGooglePlayServicesAvailable(any(Context.class)))
+                .thenReturn(ConnectionResult.SUCCESS);
+
+        return availability;
     }
 }

--- a/auth/src/test/java/com/firebase/ui/auth/ui/ChooseAccountActivityTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/ChooseAccountActivityTest.java
@@ -14,12 +14,6 @@
 
 package com.firebase.ui.auth.ui;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import android.content.Intent;
 
 import com.firebase.ui.auth.AuthUI;
@@ -51,6 +45,12 @@ import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowActivity;
 
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 @RunWith(CustomRobolectricGradleTestRunner.class)
 @Config(constants = BuildConfig.class, shadows = {ActivityHelperShadow.class}, sdk = 21)
 public class ChooseAccountActivityTest {
@@ -66,27 +66,32 @@ public class ChooseAccountActivityTest {
         when(mCredentialsAPI.isPlayServicesAvailable()).thenReturn(true);
         when(mCredentialsAPI.isCredentialsAvailable()).thenReturn(true);
         when(mCredentialsAPI.isAutoSignInAvailable()).thenReturn(true);
-
     }
 
     private Intent createStartIntent() {
-        return AuthUI
-                .getInstance(mFirebaseApp).createSignInIntentBuilder()
+        return AuthUI.getInstance(mFirebaseApp)
+                .createSignInIntentBuilder()
                 .setProviders(AuthUI.EMAIL_PROVIDER, AuthUI.GOOGLE_PROVIDER)
+                .setIsSmartLockEnabled(true)
                 .build();
     }
 
     @Test
     public void testAutoSignInWithSavedUsernameAndPassword_signsIn() {
+        Intent startIntent = createStartIntent();
         ChooseAccountActivity chooseAccountActivity =
                 Robolectric.buildActivity(ChooseAccountActivity.class)
                         .withIntent(createStartIntent()).create().get();
+
         when(mCredentialsAPI.getEmailFromCredential()).thenReturn(TestConstants.EMAIL);
         when(mCredentialsAPI.getPasswordFromCredential()).thenReturn(TestConstants.PASSWORD);
         when(mCredentialsAPI.getAccountTypeFromCredential()).thenReturn(
                 EmailAuthProvider.PROVIDER_ID);
 
         when(mActivityHelper.getFirebaseAuth()).thenReturn(mFirebaseAuth);
+        when(mActivityHelper.getFlowParams()).thenReturn(
+                (FlowParameters) startIntent.getParcelableExtra(ExtraConstants.EXTRA_FLOW_PARAMS));
+
         when(mFirebaseAuth.signInWithEmailAndPassword(
                 TestConstants.EMAIL,
                 TestConstants.PASSWORD))

--- a/auth/src/test/java/com/firebase/ui/auth/ui/email/RegisterEmailActivityTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/email/RegisterEmailActivityTest.java
@@ -14,27 +14,24 @@
 
 package com.firebase.ui.auth.ui.email;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.when;
-
 import android.content.Intent;
 import android.support.design.widget.TextInputLayout;
 import android.widget.Button;
 import android.widget.EditText;
 
-import com.firebase.ui.auth.test_helpers.ActivityHelperShadow;
 import com.firebase.ui.auth.AuthUI;
-import com.firebase.ui.auth.test_helpers.AutoCompleteTask;
 import com.firebase.ui.auth.BuildConfig;
+import com.firebase.ui.auth.R;
+import com.firebase.ui.auth.test_helpers.ActivityHelperShadow;
+import com.firebase.ui.auth.test_helpers.AutoCompleteTask;
 import com.firebase.ui.auth.test_helpers.CustomRobolectricGradleTestRunner;
 import com.firebase.ui.auth.test_helpers.FakeAuthResult;
 import com.firebase.ui.auth.test_helpers.FirebaseAuthWrapperImplShadow;
-import com.firebase.ui.auth.R;
 import com.firebase.ui.auth.test_helpers.TestConstants;
 import com.firebase.ui.auth.test_helpers.TestHelper;
 import com.firebase.ui.auth.ui.ExtraConstants;
 import com.firebase.ui.auth.ui.account_link.SaveCredentialsActivity;
+import com.firebase.ui.auth.util.PlayServicesHelper;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.auth.UserProfileChangeRequest;
 
@@ -49,6 +46,10 @@ import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowActivity;
 
 import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
 
 
 @RunWith(CustomRobolectricGradleTestRunner.class)
@@ -69,6 +70,7 @@ public class RegisterEmailActivityTest {
     @Before
     public void setUp() {
         TestHelper.initializeApp(RuntimeEnvironment.application);
+        PlayServicesHelper.sApiAvailability = TestHelper.makeMockGoogleApiAvailability();
     }
 
     @Test

--- a/auth/src/test/java/com/firebase/ui/auth/ui/email/SignInActivityTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/email/SignInActivityTest.java
@@ -14,12 +14,6 @@
 
 package com.firebase.ui.auth.ui.email;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import android.content.Intent;
 import android.support.design.widget.TextInputLayout;
 import android.widget.Button;
@@ -36,6 +30,7 @@ import com.firebase.ui.auth.test_helpers.TestConstants;
 import com.firebase.ui.auth.test_helpers.TestHelper;
 import com.firebase.ui.auth.ui.ExtraConstants;
 import com.firebase.ui.auth.ui.account_link.SaveCredentialsActivity;
+import com.firebase.ui.auth.util.PlayServicesHelper;
 import com.google.firebase.auth.FirebaseUser;
 
 import org.junit.Before;
@@ -49,6 +44,12 @@ import org.robolectric.shadows.ShadowActivity;
 
 import java.util.Collections;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 @RunWith(CustomRobolectricGradleTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21)
 public class SignInActivityTest {
@@ -56,6 +57,7 @@ public class SignInActivityTest {
     @Before
     public void setUp() {
         TestHelper.initializeApp(RuntimeEnvironment.application);
+        PlayServicesHelper.sApiAvailability = TestHelper.makeMockGoogleApiAvailability();
     }
 
     private SignInActivity createActivity() {

--- a/auth/src/test/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivityTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivityTest.java
@@ -14,11 +14,6 @@
 
 package com.firebase.ui.auth.ui.idp;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Mockito.when;
-
 import android.content.Intent;
 import android.view.View;
 import android.widget.Button;
@@ -27,7 +22,6 @@ import android.widget.LinearLayout;
 import com.firebase.ui.auth.AuthUI;
 import com.firebase.ui.auth.BuildConfig;
 import com.firebase.ui.auth.R;
-import com.firebase.ui.auth.provider.GoogleProvider;
 import com.firebase.ui.auth.test_helpers.ActivityHelperShadow;
 import com.firebase.ui.auth.test_helpers.AutoCompleteTask;
 import com.firebase.ui.auth.test_helpers.CustomRobolectricGradleTestRunner;
@@ -40,6 +34,7 @@ import com.firebase.ui.auth.test_helpers.TestHelper;
 import com.firebase.ui.auth.ui.ExtraConstants;
 import com.firebase.ui.auth.ui.account_link.SaveCredentialsActivity;
 import com.firebase.ui.auth.ui.email.EmailHintContainerActivity;
+import com.firebase.ui.auth.util.PlayServicesHelper;
 import com.google.firebase.auth.AuthCredential;
 import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.FacebookAuthProvider;
@@ -58,6 +53,11 @@ import org.robolectric.shadows.ShadowActivity;
 import java.util.Arrays;
 import java.util.List;
 
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.when;
+
 @RunWith(CustomRobolectricGradleTestRunner.class)
 @Config(constants = BuildConfig.class,
         shadows = {
@@ -68,7 +68,9 @@ import java.util.List;
 public class AuthMethodPickerActivityTest {
 
     @Before
-    public void setUp() {}
+    public void setUp() {
+        PlayServicesHelper.sApiAvailability = TestHelper.makeMockGoogleApiAvailability();
+    }
 
     @Test
     public void testAllProvidersArePopulated() {

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ allprojects { project ->
         // So that we can resolve 'android' variable
         project.apply plugin: 'com.android.library'
         android {
-            compileSdkVersion 24
+            compileSdkVersion project.ext.compileSdk
             buildToolsVersion "${project.ext.buildtools}"
         }
 

--- a/common/constants.gradle
+++ b/common/constants.gradle
@@ -1,8 +1,10 @@
 project.ext.firebase_version = '9.4.0'
-project.ext.support_library_version = '24.0.0'
+project.ext.support_library_version = '23.4.0'
 
 project.ext.submodules = ['database', 'auth']
 project.ext.group = "com.firebaseui"
 project.ext.version = '0.4.4'
 project.ext.pomdesc = 'Firebase UI Android'
-project.ext.buildtools = '24.0.1'
+project.ext.buildtools = '23.0.3'
+project.ext.compileSdk = 23
+project.ext.targetSdk = 23

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion project.ext.compileSdk
     buildToolsVersion "${project.ext.buildtools}"
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 24
+        targetSdkVersion project.ext.targetSdk
         versionCode 1
         versionName "1.0"
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion project.ext.compileSdk
     buildToolsVersion "${project.ext.buildtools}"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 24
+        targetSdkVersion project.ext.targetSdk
         versionCode 1
         versionName "0.3.1"
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -57,6 +57,15 @@ def bintrayUploadTasks() {
 }
 
 /**
+ * Returns a list of tasks names to test submodules.
+ */
+def testTasks() {
+    return project.ext.submodules.collect { name ->
+        ":${name}:test"
+    }.toArray()
+}
+
+/**
  * Prepare artifacts for this an all sub-projects.
  */
 task prepareArtifacts(dependsOn: [
@@ -92,4 +101,10 @@ task bintrayUploadAll(dependsOn: [
         'bintrayUpload',
         bintrayUploadTasks()]) {
 
+}
+
+/**
+ * Test all submodules.
+ */
+task testAll(dependsOn: [testTasks()]) {
 }


### PR DESCRIPTION
@amandle PTAL

Embarassingly we haven't been running our tests at all, so much so that I only now realized that Robolectric does not support API 24.

I made some changes to make all the tests pass again, but it requires a downgrade of the compileSdkVersion (and therefore a downgrade of the support libraries).

Since we have no Android N features I don't **think** this should cause any problems, and developers can always override our support lib dependency if they are using N features heavily.

WDYT?  I think having green tests on Travis is worth it.