### PR TITLE
Add Twitter as an IDP

### DIFF
--- a/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
@@ -33,6 +33,8 @@ import com.firebase.uidemo.R;
 import com.google.firebase.auth.FirebaseAuth;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -68,6 +70,9 @@ public class AuthUiActivity extends AppCompatActivity {
 
     @BindView(R.id.facebook_provider)
     CheckBox mUseFacebookProvider;
+
+    @BindView(R.id.twitter_provider)
+    CheckBox mUseTwitterProvider;
 
     @BindView(R.id.google_tos)
     RadioButton mUseGoogleTos;
@@ -118,9 +123,16 @@ public class AuthUiActivity extends AppCompatActivity {
             mUseFacebookProvider.setText(R.string.facebook_label_missing_config);
         }
 
-        if (!isGoogleConfigured() || !isFacebookConfigured()) {
+        if (!isTwitterConfigured()) {
+            mUseTwitterProvider.setChecked(false);
+            mUseTwitterProvider.setEnabled(false);
+            mUseTwitterProvider.setText(R.string.twitter_label_missing_config);
+        }
+
+        if (!isGoogleConfigured() || !isFacebookConfigured() || !isTwitterConfigured()) {
             showSnackbar(R.string.configuration_required);
         }
+
     }
 
     @OnClick(R.id.sign_in)
@@ -204,6 +216,10 @@ public class AuthUiActivity extends AppCompatActivity {
             selectedProviders.add(AuthUI.GOOGLE_PROVIDER);
         }
 
+        if (mUseTwitterProvider.isChecked()) {
+            selectedProviders.add(AuthUI.TWITTER_PROVIDER);
+        }
+
         return selectedProviders.toArray(new String[selectedProviders.size()]);
     }
 
@@ -226,6 +242,17 @@ public class AuthUiActivity extends AppCompatActivity {
     private boolean isFacebookConfigured() {
         return !UNCHANGED_CONFIG_VALUE.equals(
                 getResources().getString(R.string.facebook_application_id));
+    }
+
+    @MainThread
+    private boolean isTwitterConfigured() {
+        List<String> twitterConfigs = Arrays.asList(
+                getResources().getString(R.string.twitter_app_id),
+                getResources().getString(R.string.twitter_consumer_key),
+                getResources().getString(R.string.twitter_consumer_secret)
+        );
+
+        return !twitterConfigs.contains(UNCHANGED_CONFIG_VALUE);
     }
 
     @MainThread

--- a/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
@@ -247,7 +247,6 @@ public class AuthUiActivity extends AppCompatActivity {
     @MainThread
     private boolean isTwitterConfigured() {
         List<String> twitterConfigs = Arrays.asList(
-                getResources().getString(R.string.twitter_app_id),
                 getResources().getString(R.string.twitter_consumer_key),
                 getResources().getString(R.string.twitter_consumer_secret)
         );

--- a/app/src/main/res/layout/auth_ui_layout.xml
+++ b/app/src/main/res/layout/auth_ui_layout.xml
@@ -91,6 +91,12 @@
             android:layout_height="wrap_content"
             android:text="@string/google_label" />
 
+        <CheckBox
+            android:id="@+id/twitter_provider"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/twitter_label" />
+
         <TextView
             style="@style/Base.TextAppearance.AppCompat.Subhead"
             android:layout_width="wrap_content"

--- a/app/src/main/res/values/config.xml
+++ b/app/src/main/res/values/config.xml
@@ -14,13 +14,8 @@
 
 
     <!--
-    Your Twitter app id. To use Twitter accounts with the demo application, register an application
-    with Twitter and provide the following three values.
-    -->
-    <string name="twitter_app_id" translatable="false">CHANGE-ME</string>
-
-    <!--
-    Your Twitter Consumer Key
+    Your Twitter Consumer Key. To use Twitter accounts with the demo application, register an
+    application with Twitter and provide the following two values.
     -->
     <string name="twitter_consumer_key" translatable="false">CHANGE-ME</string>
 

--- a/app/src/main/res/values/config.xml
+++ b/app/src/main/res/values/config.xml
@@ -10,4 +10,22 @@
     Facebook Application ID, prefixed by 'fb'.  Enables Chrome Custom tabs.
     -->
     <string name="facebook_login_protocol_scheme" translatable="false">fbYOUR_APP_ID</string>
+
+
+
+    <!--
+    Your Twitter app id. To use Twitter accounts with the demo application, register an application
+    with Twitter and provide the following three values.
+    -->
+    <string name="twitter_app_id" translatable="false">CHANGE-ME</string>
+
+    <!--
+    Your Twitter Consumer Key
+    -->
+    <string name="twitter_consumer_key" translatable="false">CHANGE-ME</string>
+
+    <!--
+    Your Twitter Consumer Secret
+    -->
+    <string name="twitter_consumer_secret" translatable="false">CHANGE-ME</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,8 @@
     <string name="email_label">Email</string>
     <string name="facebook_label">Facebook</string>
     <string name="facebook_label_missing_config">Facebook - configuration missing</string>
+    <string name="twitter_label">Twitter</string>
+    <string name="twitter_label_missing_config">Twitter - configuration missing</string>
     <string name="google_label">Google</string>
     <string name="google_label_missing_config">Google - configuration missing</string>
     <string name="google_tos_label">Google TOS</string>

--- a/auth/README.md
+++ b/auth/README.md
@@ -60,7 +60,7 @@ If instead your project uses Maven, add:
 
 ### Identity provider configuration
 
-In order to use either Google or Facebook accounts with your app, ensure that
+In order to use either Google, Facebook or Twitter accounts with your app, ensure that
 these authentication methods are first configured in the Firebase console.
 
 FirebaseUI client-side configuration for Google sign-in is then provided
@@ -75,6 +75,19 @@ the [Facebook developer dashboard](https://developers.facebook.com):
   <!-- ... -->
   <string name="facebook_application_id" translatable="false">APPID</string>
 </resources>
+```
+
+If support for Twitter Sign-in is also required, define the resource strings twitter_app_id,
+twitter_consumer_key, and twitter_consumer_secret to match the values of your Twitter app as
+reported by the [Twitter application manager](https://dev.twitter.com/apps).
+
+```
+<resources>
+  <string name="twitter_app_id" translatable="false">YOURAPPID</string>
+  <string name="twitter_consumer_key" translatable="false">YOURCONSUMERKEY</string>
+  <string name="twitter_consumer_secret" translatable="false">YOURCONSUMERSECRET</string>
+</resources>
+
 ```
 
 ## Using FirebaseUI for Authentication

--- a/auth/README.md
+++ b/auth/README.md
@@ -77,13 +77,12 @@ the [Facebook developer dashboard](https://developers.facebook.com):
 </resources>
 ```
 
-If support for Twitter Sign-in is also required, define the resource strings twitter_app_id,
-twitter_consumer_key, and twitter_consumer_secret to match the values of your Twitter app as
+If support for Twitter Sign-in is also required, define the resource strings
+twitter_consumer_key and twitter_consumer_secret to match the values of your Twitter app as
 reported by the [Twitter application manager](https://dev.twitter.com/apps).
 
 ```
 <resources>
-  <string name="twitter_app_id" translatable="false">YOURAPPID</string>
   <string name="twitter_consumer_key" translatable="false">YOURCONSUMERKEY</string>
   <string name="twitter_consumer_secret" translatable="false">YOURCONSUMERSECRET</string>
 </resources>

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'checkstyle'
+apply plugin: 'io.fabric'
 
 android {
     compileSdkVersion project.ext.compileSdk
@@ -34,6 +35,9 @@ dependencies {
     testCompile "org.robolectric:robolectric:3.1.1"
     compile "com.android.support:appcompat-v7:${project.ext.support_library_version}"
     compile 'com.facebook.android:facebook-android-sdk:4.14.1'
+    compile("com.twitter.sdk.android:twitter:2.0.0@aar") {
+        transitive = true;
+    }
     compile "com.android.support:design:${project.ext.support_library_version}"
 
     compile "com.google.firebase:firebase-auth:${project.ext.firebase_version}"

--- a/auth/src/main/AndroidManifest.xml
+++ b/auth/src/main/AndroidManifest.xml
@@ -79,10 +79,5 @@
                 <data android:scheme="@string/facebook_login_protocol_scheme" />
             </intent-filter>
         </activity>
-
-        <meta-data
-            android:name="io.fabric.ApiKey"
-            android:value="@string/twitter_app_id"
-            />
     </application>
 </manifest>

--- a/auth/src/main/AndroidManifest.xml
+++ b/auth/src/main/AndroidManifest.xml
@@ -80,5 +80,9 @@
             </intent-filter>
         </activity>
 
+        <meta-data
+            android:name="io.fabric.ApiKey"
+            android:value="@string/twitter_app_id"
+            />
     </application>
 </manifest>

--- a/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
@@ -231,6 +231,11 @@ public class AuthUI {
     public static final String FACEBOOK_PROVIDER = "facebook";
 
     /**
+     * Provider identifier for Twitter, for use with {@link SignInIntentBuilder#setProviders}.
+     */
+    public static final String TWITTER_PROVIDER = "twitter";
+
+    /**
      * Default value for logo resource, omits the logo from the
      * {@link AuthMethodPickerActivity}
      */
@@ -243,7 +248,8 @@ public class AuthUI {
             Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
                     EMAIL_PROVIDER,
                     GOOGLE_PROVIDER,
-                    FACEBOOK_PROVIDER
+                    FACEBOOK_PROVIDER,
+                    TWITTER_PROVIDER
             )));
 
     private static final IdentityHashMap<FirebaseApp, AuthUI> INSTANCES = new IdentityHashMap<>();

--- a/auth/src/main/java/com/firebase/ui/auth/provider/TwitterProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/TwitterProvider.java
@@ -1,0 +1,96 @@
+package com.firebase.ui.auth.provider;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.firebase.ui.auth.R;
+import com.google.firebase.auth.AuthCredential;
+import com.google.firebase.auth.TwitterAuthProvider;
+import com.twitter.sdk.android.Twitter;
+import com.twitter.sdk.android.core.Callback;
+import com.twitter.sdk.android.core.Result;
+import com.twitter.sdk.android.core.TwitterAuthConfig;
+import com.twitter.sdk.android.core.TwitterException;
+import com.twitter.sdk.android.core.TwitterSession;
+import com.twitter.sdk.android.core.identity.TwitterAuthClient;
+
+import io.fabric.sdk.android.Fabric;
+
+public class TwitterProvider extends Callback<TwitterSession> implements IDPProvider {
+    public static final String EXTRA_AUTH_TOKEN = "extra_auth_token";
+    public static final String EXTRA_AUTH_SECRET = "extra_auth_secret";
+    private static final String EXTRA_CONSUMER_KEY = "extra_consumer_key";
+    private static final String EXTRA_CONSUMER_SECRET = "extra_consumer_secret";
+    private IDPCallback mCallbackObject;
+    private TwitterAuthClient mTwitterAuthClient;
+
+    public TwitterProvider(Context appContext, IDPProviderParcel twitterParcel) {
+        TwitterAuthConfig authConfig = new TwitterAuthConfig(
+                appContext.getString(R.string.twitter_consumer_key),
+                appContext.getString(R.string.twitter_consumer_secret));
+        Fabric.with(appContext, new Twitter(authConfig));
+        mTwitterAuthClient = new TwitterAuthClient();
+    }
+
+    public static IDPProviderParcel createTwitterParcel(String consumerKey, String consumerSecret) {
+        Bundle extra = new Bundle();
+        extra.putString(EXTRA_CONSUMER_KEY, consumerKey);
+        extra.putString(EXTRA_CONSUMER_SECRET, consumerSecret);
+        return new IDPProviderParcel(TwitterAuthProvider.PROVIDER_ID, extra);
+    }
+
+    @Override
+    public String getName(Context context) {
+        return context.getString(R.string.idp_name_twitter);
+    }
+
+    @Override
+    public String getProviderId() {
+        return TwitterAuthProvider.PROVIDER_ID;
+    }
+
+    @Override
+    public void setAuthenticationCallback(IDPCallback callback) {
+        this.mCallbackObject = callback;
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        mTwitterAuthClient.onActivityResult(requestCode, resultCode, data);
+    }
+
+    @Override
+    public void startLogin(Activity activity) {
+        mTwitterAuthClient.authorize(activity, this);
+    }
+
+    @Override
+    public void success(Result<TwitterSession> result) {
+        mCallbackObject.onSuccess(createIDPResponse(result.data));
+    }
+
+    @Override
+    public void failure(TwitterException exception) {
+        mCallbackObject.onFailure(new Bundle());
+    }
+
+    public static AuthCredential createAuthCredential(IDPResponse response) {
+        if (!response.getProviderType().equalsIgnoreCase(TwitterAuthProvider.PROVIDER_ID)){
+            return null;
+        }
+        return TwitterAuthProvider.getCredential(
+                response.getResponse().getString(EXTRA_AUTH_TOKEN),
+                response.getResponse().getString(EXTRA_AUTH_SECRET));
+    }
+
+
+    private IDPResponse createIDPResponse(TwitterSession twitterSession) {
+        Bundle response = new Bundle();
+        response.putString(EXTRA_AUTH_TOKEN, twitterSession.getAuthToken().token);
+        response.putString(EXTRA_AUTH_SECRET, twitterSession.getAuthToken().secret);
+        return new IDPResponse(TwitterAuthProvider.PROVIDER_ID, twitterSession.getUserName(), response);
+    }
+
+}

--- a/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
@@ -31,6 +31,7 @@ import com.firebase.ui.auth.provider.GoogleProvider;
 import com.firebase.ui.auth.provider.IDPProvider;
 import com.firebase.ui.auth.provider.IDPProviderParcel;
 import com.firebase.ui.auth.provider.IDPResponse;
+import com.firebase.ui.auth.provider.TwitterProvider;
 import com.firebase.ui.auth.ui.ActivityHelper;
 import com.firebase.ui.auth.ui.FlowParameters;
 import com.firebase.ui.auth.ui.TaskFailureLogger;
@@ -41,6 +42,7 @@ import com.google.firebase.auth.EmailAuthProvider;
 import com.google.firebase.auth.FacebookAuthProvider;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.GoogleAuthProvider;
+import com.google.firebase.auth.TwitterAuthProvider;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -97,6 +99,9 @@ public class AuthMethodPickerActivity
                 case EmailAuthProvider.PROVIDER_ID:
                     findViewById(R.id.email_provider).setVisibility(View.VISIBLE);
                     break;
+                case TwitterAuthProvider.PROVIDER_ID:
+                    mIdpProviders.add(new TwitterProvider(this, providerParcel));
+                    break;
                 default:
                     if (BuildConfig.DEBUG) {
                         Log.d(TAG, "Encountered unknown IDPProvider parcel with type: "
@@ -115,6 +120,10 @@ public class AuthMethodPickerActivity
                 case FacebookAuthProvider.PROVIDER_ID:
                     loginButton = getLayoutInflater()
                             .inflate(R.layout.idp_button_facebook, btnHolder, false);
+                    break;
+                case TwitterAuthProvider.PROVIDER_ID:
+                    loginButton = getLayoutInflater()
+                            .inflate(R.layout.idp_button_twitter, btnHolder, false);
                     break;
                 default:
                     Log.e(TAG, "No button for provider " + provider.getProviderId());

--- a/auth/src/main/java/com/firebase/ui/auth/ui/idp/IDPBaseActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/idp/IDPBaseActivity.java
@@ -17,10 +17,12 @@ package com.firebase.ui.auth.ui.idp;
 import com.firebase.ui.auth.provider.FacebookProvider;
 import com.firebase.ui.auth.provider.GoogleProvider;
 import com.firebase.ui.auth.provider.IDPResponse;
+import com.firebase.ui.auth.provider.TwitterProvider;
 import com.firebase.ui.auth.ui.AppCompatBase;
 import com.google.firebase.auth.AuthCredential;
 import com.google.firebase.auth.FacebookAuthProvider;
 import com.google.firebase.auth.GoogleAuthProvider;
+import com.google.firebase.auth.TwitterAuthProvider;
 
 public class IDPBaseActivity extends AppCompatBase {
     protected AuthCredential createCredential(IDPResponse idpSignInResponse) {
@@ -29,6 +31,10 @@ public class IDPBaseActivity extends AppCompatBase {
         } else if (idpSignInResponse.getProviderType().equalsIgnoreCase(GoogleAuthProvider
                 .PROVIDER_ID)) {
             return GoogleProvider.createAuthCredential(idpSignInResponse);
+        } else if (idpSignInResponse
+                .getProviderType()
+                .equalsIgnoreCase(TwitterAuthProvider.PROVIDER_ID)) {
+            return TwitterProvider.createAuthCredential(idpSignInResponse);
         }
         return null;
     }

--- a/auth/src/main/java/com/firebase/ui/auth/util/ProviderHelper.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/ProviderHelper.java
@@ -22,6 +22,7 @@ import com.firebase.ui.auth.R;
 import com.firebase.ui.auth.provider.FacebookProvider;
 import com.firebase.ui.auth.provider.GoogleProvider;
 import com.firebase.ui.auth.provider.IDPProviderParcel;
+import com.firebase.ui.auth.provider.TwitterProvider;
 import com.google.firebase.auth.EmailAuthProvider;
 
 import java.util.ArrayList;
@@ -39,6 +40,10 @@ public class ProviderHelper {
             } else if (provider.equalsIgnoreCase(AuthUI.GOOGLE_PROVIDER)) {
                 providerInfo.add(GoogleProvider.createParcel(
                         context.getString(R.string.default_web_client_id)));
+            } else if (provider.equalsIgnoreCase(AuthUI.TWITTER_PROVIDER)) {
+                providerInfo.add(TwitterProvider.createTwitterParcel(
+                        context.getString(R.string.twitter_consumer_key),
+                        context.getString(R.string.twitter_consumer_secret)));
             } else if (provider.equalsIgnoreCase(AuthUI.EMAIL_PROVIDER)) {
                 providerInfo.add(
                         new IDPProviderParcel(EmailAuthProvider.PROVIDER_ID, new Bundle())

--- a/auth/src/main/res/drawable/idp_button_background_twitter.xml
+++ b/auth/src/main/res/drawable/idp_button_background_twitter.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item >
+        <shape android:shape="rectangle" >
+            <corners android:radius="3dp" />
+            <solid android:color="@color/tw__blue_default"/>
+        </shape>
+    </item>
+</selector>

--- a/auth/src/main/res/layout/idp_button_twitter.xml
+++ b/auth/src/main/res/layout/idp_button_twitter.xml
@@ -1,0 +1,6 @@
+<Button
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/FirebaseUI.Button.AccountChooser.TwitterButton"
+    android:text="@string/sign_in_with_twitter"
+    android:id="@+id/twitter_button"
+    />

--- a/auth/src/main/res/values/config.xml
+++ b/auth/src/main/res/values/config.xml
@@ -44,4 +44,21 @@
     https://developers.google.com/android/guides/google-services-plugin
     -->
     <string name="default_web_client_id" translatable="false">CHANGE-ME</string>
+
+
+    <!--
+    Your Twitter app id. To use Twitter accounts with the demo application, register an application
+    with Twitter and provide the following three values.
+    -->
+    <string name="twitter_app_id" translatable="false">CHANGE-ME</string>
+
+    <!--
+    Your Twitter Consumer Key
+    -->
+    <string name="twitter_consumer_key" translatable="false">CHANGE-ME</string>
+
+    <!--
+    Your Twitter Consumer Secret
+    -->
+    <string name="twitter_consumer_secret" translatable="false">CHANGE-ME</string>
 </resources>

--- a/auth/src/main/res/values/config.xml
+++ b/auth/src/main/res/values/config.xml
@@ -47,13 +47,8 @@
 
 
     <!--
-    Your Twitter app id. To use Twitter accounts with the demo application, register an application
-    with Twitter and provide the following three values.
-    -->
-    <string name="twitter_app_id" translatable="false">CHANGE-ME</string>
-
-    <!--
-    Your Twitter Consumer Key
+    Your Twitter Consumer Key. To use Twitter accounts with the demo application, register an
+    application with Twitter and provide the following two values.
     -->
     <string name="twitter_consumer_key" translatable="false">CHANGE-ME</string>
 

--- a/auth/src/main/res/values/strings.xml
+++ b/auth/src/main/res/values/strings.xml
@@ -51,9 +51,11 @@
     <string name="password_word">Password</string>
     <string name="idp_name_google">Google</string>
     <string name="idp_name_facebook">Facebook</string>
+    <string name="idp_name_twitter">Twitter</string>
     <string name="create_account_preamble">"By tapping SAVE you are indicating that you agree to the "</string>
     <string name="terms_of_service">Terms of Service</string>
     <string name="sign_in_with_email">Sign in with email</string>
+    <string name="sign_in_with_twitter">Sign in with Twitter</string>
     <string name="login_error">Login unsuccessful</string>
     <string name="email_account_creation_error">Email account registration unsuccessful</string>
     <string name="missing_password_email_toast">Missing password or email</string>

--- a/auth/src/main/res/values/styles.xml
+++ b/auth/src/main/res/values/styles.xml
@@ -244,6 +244,13 @@
         <item name="android:textColor">@color/com_facebook_button_text_color</item>
     </style>
 
+    <style name="FirebaseUI.Button.AccountChooser.TwitterButton">
+        <item name="android:drawableLeft">@drawable/tw__ic_logo_default</item>
+        <item name="android:paddingLeft">4dp</item>
+        <item name="android:drawablePadding">8dp</item>
+        <item name="android:background">@drawable/idp_button_background_twitter</item>
+        <item name="android:textColor">@color/tw__solid_white</item>
+    </style>
 
     <style name="Theme.AppCompat.Transparent">
         <item name="android:windowNoTitle">true</item>

--- a/auth/src/test/java/com/firebase/ui/auth/test_helpers/GoogleProviderShadow.java
+++ b/auth/src/test/java/com/firebase/ui/auth/test_helpers/GoogleProviderShadow.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.when;
 
 import android.app.Activity;
 import android.os.Bundle;
-import android.util.Log;
 
 import com.firebase.ui.auth.provider.GoogleProvider;
 import com.firebase.ui.auth.provider.IDPProvider;
@@ -54,7 +53,7 @@ public class GoogleProviderShadow {
     public void __constructor__(Activity activity, IDPProviderParcel parcel, String email) {}
 
 
-        @Implementation
+    @Implementation
     public void setAuthenticationCallback(IDPProvider.IDPCallback idpCallback) {
         mCallback = idpCallback;
     }

--- a/auth/src/test/java/com/firebase/ui/auth/ui/provider/TwitterProviderTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/provider/TwitterProviderTest.java
@@ -1,0 +1,112 @@
+package com.firebase.ui.auth.ui.provider;
+
+import android.os.Bundle;
+
+import com.firebase.ui.auth.BuildConfig;
+import com.firebase.ui.auth.provider.IDPProvider;
+import com.firebase.ui.auth.provider.IDPResponse;
+import com.firebase.ui.auth.provider.TwitterProvider;
+import com.firebase.ui.auth.test_helpers.CustomRobolectricGradleTestRunner;
+import com.firebase.ui.auth.test_helpers.FacebookProviderShadow;
+import com.firebase.ui.auth.test_helpers.FirebaseAuthWrapperImplShadow;
+import com.firebase.ui.auth.test_helpers.GoogleProviderShadow;
+import com.twitter.sdk.android.core.Result;
+import com.twitter.sdk.android.core.TwitterAuthToken;
+import com.twitter.sdk.android.core.TwitterException;
+import com.twitter.sdk.android.core.TwitterSession;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.util.concurrent.CountDownLatch;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+@RunWith(CustomRobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class,
+        shadows = {
+                FirebaseAuthWrapperImplShadow.class,
+                GoogleProviderShadow.class,
+                FacebookProviderShadow.class
+        }, sdk = 21)
+public class TwitterProviderTest {
+    private static final String FAKE_KEY = "fakeKey";
+    private static final String FAKE_SECRET = "fakeSecret";
+    private static final String FAKE_AUTH_TOKEN = "fakeAuthToken";
+    private static final String FAKE_AUTH_SECRET = "fakeAuthSecret";
+    private static final long FAKE_USER_ID = 555;
+    private static final String FAKE_USER_NAME = "testAccountName";
+
+    private static class AssertResultCallback implements IDPProvider.IDPCallback {
+        private CountDownLatch mCountDownLatch;
+        private boolean mAssertSuccess;
+
+        public AssertResultCallback(boolean assertSuccess) {
+            mCountDownLatch = new CountDownLatch(1);
+            mAssertSuccess = assertSuccess;
+        }
+
+        private void await() throws InterruptedException {
+            mCountDownLatch.await();
+        }
+
+        @Override
+        public void onSuccess(IDPResponse idpResponse) {
+            assertTrue(mAssertSuccess);
+            mCountDownLatch.countDown();
+        }
+
+        @Override
+        public void onFailure(Bundle extra) {
+            assertFalse(mAssertSuccess);
+            mCountDownLatch.countDown();
+        }
+    }
+
+    @Test
+    public void testSuccessCallsCallback() {
+        TwitterProvider twitterProvider = new TwitterProvider(
+                RuntimeEnvironment.application,
+                TwitterProvider.createTwitterParcel(FAKE_KEY, FAKE_SECRET));
+
+        AssertResultCallback assertResultCallback = new AssertResultCallback(true);
+        twitterProvider.setAuthenticationCallback(assertResultCallback);
+
+        TwitterAuthToken twitterAuthToken = new TwitterAuthToken(FAKE_AUTH_TOKEN, FAKE_AUTH_SECRET);
+        TwitterSession twitterSession = new TwitterSession(
+                twitterAuthToken,
+                FAKE_USER_ID,
+                FAKE_USER_NAME);
+
+        Result<TwitterSession> result = new Result<>(twitterSession, null);
+        twitterProvider.success(result);
+
+        try {
+            assertResultCallback.await();
+        } catch (InterruptedException e) {
+            assertTrue("Interrupted waiting for result", false);
+        }
+    }
+
+    @Test
+    public void testFailureCallsCallback() {
+        TwitterProvider twitterProvider = new TwitterProvider(
+                RuntimeEnvironment.application,
+                TwitterProvider.createTwitterParcel(FAKE_KEY, FAKE_SECRET));
+
+        AssertResultCallback assertResultCallback = new AssertResultCallback(false);
+        twitterProvider.setAuthenticationCallback(assertResultCallback);
+
+        TwitterException twitterException = new TwitterException("Fake exception");
+        twitterProvider.failure(twitterException);
+
+        try {
+            assertResultCallback.await();
+        } catch (InterruptedException e) {
+            assertTrue("Interrupted waiting for result", false);
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -4,11 +4,12 @@ buildscript {
     repositories {
         jcenter()
         mavenLocal()
+        maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.1.3'
         classpath 'com.google.gms:google-services:3.0.0'
-
+        classpath 'io.fabric.tools:gradle:1.+'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2'
     }
@@ -19,6 +20,7 @@ allprojects {
         jcenter()
         mavenLocal()
         mavenCentral()
+        maven { url 'https://maven.fabric.io/public' }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:2.1.3'
         classpath 'com.google.gms:google-services:3.0.0'
-        classpath 'io.fabric.tools:gradle:1.+'
+        classpath 'io.fabric.tools:gradle:1.21.7'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2'
     }


### PR DESCRIPTION
Add Twitter as a provider in response to issue #157 

I am not entirely sure how this will fit in with our feature parity plans with other platforms, we may have to wait for iOS to implement it before we can actually release.

Also, the Twitter Client Secret is stored in a resources file, which is not ideal but without writing a custom back-end server to coordinate with I'm not sure there is a better alternative (just obfuscation techniques) though I'm open to any suggestions.

 