### PR TITLE
handle ACTIVITY_RESULT_OTHER_ACCOUNT

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/ChooseAccountActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/ChooseAccountActivity.java
@@ -31,6 +31,7 @@ import com.firebase.ui.auth.util.CredentialsApiHelper;
 import com.firebase.ui.auth.util.EmailFlowUtil;
 import com.firebase.ui.auth.util.PlayServicesHelper;
 import com.google.android.gms.auth.api.credentials.Credential;
+import com.google.android.gms.auth.api.credentials.CredentialsApi;
 import com.google.android.gms.auth.api.credentials.IdentityProviders;
 import com.google.android.gms.common.api.Status;
 import com.google.android.gms.tasks.OnCompleteListener;
@@ -207,7 +208,8 @@ public class ChooseAccountActivity extends ActivityBase {
                             mCredentialsApi.getPasswordFromCredential(),
                             mCredentialsApi.getAccountTypeFromCredential()
                     );
-                } else if (resultCode == RESULT_CANCELED) {
+                } else if (resultCode == RESULT_CANCELED
+                        || resultCode == CredentialsApi.ACTIVITY_RESULT_OTHER_ACCOUNT) {
                     // Smart lock selector cancelled, go to the AuthMethodPicker screen
                     startAuthMethodChoice(mActivityHelper);
                 } else if (resultCode == RESULT_FIRST_USER) {


### PR DESCRIPTION
The returned result when clicking "None of the above" has changed to make it consistent between the credential picker and the hint picker.  This changes ensures that we handle the new value correctly.