### PR TITLE
Refactor error handling

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/AuthCredentialHelper.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/AuthCredentialHelper.java
@@ -14,6 +14,8 @@
 
 package com.firebase.ui.auth.ui;
 
+import android.support.annotation.Nullable;
+
 import com.firebase.ui.auth.provider.FacebookProvider;
 import com.firebase.ui.auth.provider.GoogleProvider;
 import com.firebase.ui.auth.provider.IDPResponse;
@@ -22,6 +24,8 @@ import com.google.firebase.auth.FacebookAuthProvider;
 import com.google.firebase.auth.GoogleAuthProvider;
 
 public class AuthCredentialHelper {
+
+    @Nullable
     public static AuthCredential getAuthCredential(IDPResponse idpResponse) {
         switch (idpResponse.getProviderType()) {
             case GoogleAuthProvider.PROVIDER_ID:
@@ -32,4 +36,5 @@ public class AuthCredentialHelper {
                 return null;
         }
     }
+
 }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/ConfirmRecoverPasswordActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/ConfirmRecoverPasswordActivity.java
@@ -17,17 +17,21 @@ package com.firebase.ui.auth.ui.email;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.TextView;
 
 import com.firebase.ui.auth.R;
 import com.firebase.ui.auth.ui.ActivityHelper;
-import com.firebase.ui.auth.ui.AppCompatBase;
 import com.firebase.ui.auth.ui.ExtraConstants;
 import com.firebase.ui.auth.ui.FlowParameters;
 
-public class ConfirmRecoverPasswordActivity extends android.support.v7.app.AppCompatActivity
+/**
+ * Dialog activity to confirm successful email sending in {@link RecoverPasswordActivity}.
+ */
+public class ConfirmRecoverPasswordActivity extends AppCompatActivity
         implements View.OnClickListener {
+
     private ActivityHelper mActivityHelper;
 
     @Override
@@ -38,17 +42,12 @@ public class ConfirmRecoverPasswordActivity extends android.support.v7.app.AppCo
 
         setContentView(R.layout.confirm_recovery_layout);
         String email = getIntent().getStringExtra(ExtraConstants.EXTRA_EMAIL);
-        boolean isSuccess = getIntent().getBooleanExtra(ExtraConstants.EXTRA_SUCCESS, true);
 
-        if (isSuccess) {
-            String text = String.format(
-                    getResources().getString(R.string.confirm_recovery_body),
-                    email
-            );
-            ((TextView) findViewById(R.id.body_text)).setText(text);
-        } else {
-            ((TextView) findViewById(R.id.body_text)).setText(R.string.recovery_fail_body);
-        }
+        String text = String.format(
+                getResources().getString(R.string.confirm_recovery_body),
+                email);
+        ((TextView) findViewById(R.id.body_text)).setText(text);
+
         findViewById(R.id.button_done).setOnClickListener(this);
     }
 
@@ -62,11 +61,9 @@ public class ConfirmRecoverPasswordActivity extends android.support.v7.app.AppCo
     public static Intent createIntent(
             Context context,
             FlowParameters flowParams,
-            boolean success,
             String email) {
         return ActivityHelper.createBaseIntent(context, ConfirmRecoverPasswordActivity.class,
                 flowParams)
-                .putExtra(ExtraConstants.EXTRA_SUCCESS, success)
                 .putExtra(ExtraConstants.EXTRA_EMAIL, email);
     }
 

--- a/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
@@ -19,7 +19,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
-import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 
@@ -70,8 +69,7 @@ public class AuthMethodPickerActivity
         super.onCreate(savedInstanceState);
         setContentView(R.layout.auth_method_picker_layout);
 
-        Button emailButton = (Button) findViewById(R.id.email_provider);
-        emailButton.setOnClickListener(this);
+        findViewById(R.id.email_provider).setOnClickListener(this);
 
         populateIdpList(mActivityHelper.getFlowParams().providerInfo);
 
@@ -104,6 +102,7 @@ public class AuthMethodPickerActivity
                     }
             }
         }
+
         LinearLayout btnHolder = (LinearLayout) findViewById(R.id.btn_holder);
         for (final IDPProvider provider: mIdpProviders) {
             View loginButton = null;

--- a/auth/src/main/java/com/firebase/ui/auth/ui/idp/CredentialSignInHandler.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/idp/CredentialSignInHandler.java
@@ -15,7 +15,6 @@
 package com.firebase.ui.auth.ui.idp;
 
 import android.app.Activity;
-import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
@@ -26,6 +25,7 @@ import com.firebase.ui.auth.ui.account_link.WelcomeBackIDPPrompt;
 import com.firebase.ui.auth.ui.account_link.WelcomeBackPasswordPrompt;
 import com.firebase.ui.auth.util.SmartlockUtil;
 import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.auth.AuthResult;
@@ -59,30 +59,30 @@ public class CredentialSignInHandler implements OnCompleteListener<AuthResult> {
     @Override
     public void onComplete(@NonNull Task <AuthResult> task) {
         if (!task.isSuccessful()) {
-            if (task.getException().getClass() ==
-                    FirebaseAuthUserCollisionException.class) {
+            if (task.getException() instanceof FirebaseAuthUserCollisionException) {
                 final String email = mResponse.getEmail();
                 FirebaseAuth firebaseAuth = mActivityHelper.getFirebaseAuth();
                 firebaseAuth.fetchProvidersForEmail(email)
                         .addOnFailureListener(new TaskFailureLogger(
                                 TAG, "Error fetching providers for email"))
-                        .addOnSuccessListener(new StartWelcomeBackFlow(email));
+                        .addOnSuccessListener(new StartWelcomeBackFlow(email))
+                        .addOnFailureListener(new OnFailureListener() {
+                            @Override
+                            public void onFailure(@NonNull Exception e) {
+                                // TODO: What to do when signing in with Credential fails
+                                // and we can't continue to Welcome back flow without
+                                // knowing providers?
+                            }
+                        });
             } else {
                 mActivityHelper.dismissDialog();
-                Log.e(
-                        TAG,
-                        "Unexpected exception when signing in with credential",
+                Log.e(TAG, "Unexpected exception when signing in with credential",
                         task.getException());
             }
         } else {
-            FirebaseUser firebaseUser = task.getResult().getUser();
-            String photoUrl = null;
-            Uri photoUri = firebaseUser.getPhotoUrl();
-            if (photoUri != null) {
-                photoUrl = photoUri.toString();
-            }
             mActivityHelper.dismissDialog();
 
+            FirebaseUser firebaseUser = task.getResult().getUser();
             SmartlockUtil.saveCredentialOrFinish(mActivity, mSaveCredentialsResultCode,
                     mActivityHelper.getFlowParams(), firebaseUser,
                     null /* password */, mResponse.getProviderType());
@@ -98,9 +98,11 @@ public class CredentialSignInHandler implements OnCompleteListener<AuthResult> {
 
         @Override
         public void onSuccess(@NonNull ProviderQueryResult result) {
+            mActivityHelper.dismissDialog();
+
             String provider = result.getProviders().get(0);
             if (provider.equals(EmailAuthProvider.PROVIDER_ID)) {
-                mActivityHelper.dismissDialog();
+                // Start email welcome back flow
                 mActivity.startActivityForResult(
                         WelcomeBackPasswordPrompt.createIntent(
                                 mActivityHelper.getApplicationContext(),
@@ -109,7 +111,7 @@ public class CredentialSignInHandler implements OnCompleteListener<AuthResult> {
                         ), mAccountLinkResultCode);
     
             } else {
-                mActivityHelper.dismissDialog();
+                // Start IDP welcome back flow
                 mActivity.startActivityForResult(
                         WelcomeBackIDPPrompt.createIntent(
                                 mActivityHelper.getApplicationContext(),

--- a/auth/src/main/res/values/strings.xml
+++ b/auth/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="app_name">ui_flow</string>
+
     <string name="default_toolbar_title">@string/app_name</string>
     <string name="title_welcome_back_password_prompt">@string/sign_in</string>
     <string name="title_sign_in_activity">@string/sign_in</string>
@@ -8,6 +9,7 @@
     <string name="title_register_email_activity">@string/create_account_title</string>
     <string name="title_recover_password_activity">@string/recover_password_title</string>
     <string name="title_confirm_recover_password_activity">@string/check_your_email</string>
+
     <string name="email_hint">Email</string>
     <string name="sign_in_no_password_title">Put an email to use for sign in</string>
     <string name="password_hint">Password</string>
@@ -22,12 +24,14 @@
         and numbers</string>
     <string name="invalid_email_address">That email address isn\'t correct</string>
     <string name="missing_email_address">Enter your email address to continue</string>
+    <string name="error_weak_password">Password not strong enough. Use at least 6 characters and a mix of letters and numbers.</string>
+    <string name="error_user_collision">An account already exists with that email address.</string>
     <string name="button_text_send">Send</string>
     <string name="button_text_save">Save</string>
     <string name="require_email_text">Please input email address</string>
     <string name="confirm_recovery_body">Follow the instructions sent to %1$s to recover your
         password.</string>
-    <string name="recovery_fail_body">That email address doesn\'t match an existing account</string>
+    <string name="error_email_does_not_exist">That email address doesn\'t match an existing account</string>
     <string name="account_welcomeback">Welcome back</string>
     <string name="finding_credential">Finding a credential…</string>
     <string name="do_delete">Delete</string>
@@ -57,6 +61,7 @@
     <string name="login_error">Login unsuccessful</string>
     <string name="email_account_creation_error">Email account registration unsuccessful</string>
     <string name="missing_password_email_toast">Missing password or email</string>
+
     <string name="progress_dialog_loading">Loading…</string>
     <string name="progress_dialog_sending">Sending…</string>
     <string name="progress_dialog_signing_in">Signing in…</string>

--- a/auth/src/test/java/com/firebase/ui/auth/test_helpers/AutoCompleteTask.java
+++ b/auth/src/test/java/com/firebase/ui/auth/test_helpers/AutoCompleteTask.java
@@ -108,7 +108,7 @@ public class AutoCompleteTask<TResult> extends Task {
     @NonNull
     @Override
     public Task addOnFailureListener(@NonNull Activity activity, @NonNull OnFailureListener onFailureListener) {
-        throw new RuntimeException("Method not implemented");
+        return addOnFailureListener(onFailureListener);
     }
 
     @Override

--- a/common/constants.gradle
+++ b/common/constants.gradle
@@ -3,7 +3,7 @@ project.ext.support_library_version = '23.4.0'
 
 project.ext.submodules = ['database', 'auth']
 project.ext.group = "com.firebaseui"
-project.ext.version = '0.5.2'
+project.ext.version = '0.5.3-SNAPSHOT'
 project.ext.pomdesc = 'Firebase UI Android'
 project.ext.buildtools = '23.0.3'
 project.ext.compileSdk = 23


### PR DESCRIPTION
Went through and looked at all error handling that uses `TaskFailureLogger` to ensure that each case has some sensible error handling beyond logging.  In most cases I split `onCompleteListener` into separate `onSuccessListener` and `onFailureListener`s.

Also fixed a crash that can come from repeated uses of `GoogleApiClientTaskHelper`.

This addresses the following issues:
  * #257 
  * #287