### PR TITLE
Fix facebook permissions

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
@@ -36,6 +36,7 @@ import com.google.firebase.auth.FacebookAuthProvider;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -83,7 +84,7 @@ public class FacebookProvider implements IDPProvider, FacebookCallback<LoginResu
         loginManager.registerCallback(mCallbackManager, this);
 
         String[] permissions = activity.getResources().getStringArray(R.array.facebook_permissions);
-        List<String> permissionsList = Arrays.asList(permissions);
+        List<String> permissionsList = new ArrayList<>(Arrays.asList(permissions));
 
         // Ensure we have email and public_profile scopes
         if (!permissionsList.contains(EMAIL)) {


### PR DESCRIPTION
Well I didn't think I'd be learning something new about `java.util.List` today, but I did.  Apparently `List#add()` is an "optional" operation and when you do `Arrays.asList()` you get a `List` that does not support this operation.

This addresses issue #290 and will require a `0.5.3` release.