### PR TITLE
Removed casting of inflated layout to ViewGroup

### DIFF
--- a/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
@@ -164,7 +164,7 @@ public abstract class FirebaseRecyclerAdapter<T, VH extends RecyclerView.ViewHol
 
     @Override
     public VH onCreateViewHolder(ViewGroup parent, int viewType) {
-        ViewGroup view = (ViewGroup) LayoutInflater.from(parent.getContext()).inflate(viewType, parent, false);
+        View view = LayoutInflater.from(parent.getContext()).inflate(viewType, parent, false);
         try {
             Constructor<VH> constructor = mViewHolderClass.getConstructor(View.class);
             return constructor.newInstance(view);


### PR DESCRIPTION
Hello,
in current implementation this cast prevents from inflating just simple `TextView` as a list item (such as `android.R.layout.simple_list_item_1` etc.).
