### PR TITLE
storage: fix link syntax

### DIFF
--- a/storage/README.md
+++ b/storage/README.md
@@ -2,14 +2,14 @@
 
 ## Using FirebaseUI to download and display images
 
-[Firebase Storage](firebase-storage) provides secure file uploads and downloads for your Firebase apps,
+[Firebase Storage][firebase-storage] provides secure file uploads and downloads for your Firebase apps,
 regardless of network quality. You can use it to store images, audio, video, or other
 user-generated content. Firebase Storage is backed by Google Cloud Storage, a powerful, simple,
 and cost-effective object storage service.
 
 FirebaseUI provides bindings to download an image file stored in Firebase Storage
-from a [`StorageReference`](storage-reference) and display it using the popular
-[Glide](glide) library. This technique allows you to get all of Glide's performance
+from a [`StorageReference`][storage-reference] and display it using the popular
+[Glide][glide] library. This technique allows you to get all of Glide's performance
 benefits while leveraging Firebase Storage's authenticated storage capabilities.
 
 To load an image from a `StorageReference`, simply use the `FirebaseImageLoader` class:
@@ -30,7 +30,7 @@ To load an image from a `StorageReference`, simply use the `FirebaseImageLoader`
 
 Images displayed using `FirebaseImageLoader` are cached by their path in Firebase Storage, so
 repeated loads will be fast and conserve bandwidth. For more information on caching in Glide,
-see [this guide](glide-caching)
+see [this guide][glide-caching].
 
 ## Known Issues
 


### PR DESCRIPTION
This is not super intuitive compared to other linking syntaxes.
Here are all the ways linking is supported:
https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#links
I could not find other instances of this error in the rest of the code base.