### PR TITLE
Add class that handles ServerValue

### DIFF
--- a/database/src/main/java/com/firebase/ui/database/Timestamp.java
+++ b/database/src/main/java/com/firebase/ui/database/Timestamp.java
@@ -10,7 +10,7 @@ public class Timestamp {
     private long mTimestamp;
 
     @PropertyName("timestamp")
-    private Map<String, String> getServerValue() {
+    protected Map<String, String> getServerValue() {
         return ServerValue.TIMESTAMP;
     }
 
@@ -19,7 +19,7 @@ public class Timestamp {
         return mTimestamp;
     }
 
-    private void setTimestamp(long time) {
+    protected void setTimestamp(long time) {
         mTimestamp = time;
     }
 }

--- a/database/src/main/java/com/firebase/ui/database/Timestamp.java
+++ b/database/src/main/java/com/firebase/ui/database/Timestamp.java
@@ -1,0 +1,25 @@
+package com.firebase.ui.database;
+
+import com.google.firebase.database.Exclude;
+import com.google.firebase.database.PropertyName;
+import com.google.firebase.database.ServerValue;
+
+import java.util.Map;
+
+public class Timestamp {
+    private long mTimestamp;
+
+    @PropertyName("timestamp")
+    private Map<String, String> getServerValue() {
+        return ServerValue.TIMESTAMP;
+    }
+
+    @Exclude
+    public long getTimestamp() {
+        return mTimestamp;
+    }
+
+    private void setTimestamp(long time) {
+        mTimestamp = time;
+    }
+}


### PR DESCRIPTION
 * If this has been discussed in an issue, make sure to mention the issue number here.  If not, go file an issue about this to make sure this is a desirable change.
  * #19 
 * If this is a new feature please co-ordinate with someone on [FirebaseUI-iOS](https://github.com/firebase/firebaseui-ios) to make sure that we can implement this on both platforms and maintain feature parity.
  * Anyone?

Example usage:
```java
// After calling ref.getValue(Team.class)

public class Team extends Timestamp {
    public Team() {
        // Example with no config
        getTimestamp();
    }

    // Example getter override
    @PropertyName("timestamp" /* Or any other name as long as you create your own
    getters and setters, but then there is no point in extending Timestamp */)
    public Map<String, String> getCustomTimestamp() {
        if (mShouldUpdateTimestamp) {
            return ServerValue.TIMESTAMP;
        } else {
            return null;
        }
    }
```