### PR TITLE
Prevent IllegalArgumentException in SaveCredentialsActivity

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/account_link/SaveCredentialsActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/account_link/SaveCredentialsActivity.java
@@ -104,6 +104,10 @@ public class SaveCredentialsActivity extends AppCompatBase
                 }
                 if (translatedProvider != null) {
                     builder.setAccountType(translatedProvider);
+                } else {
+                    Log.e(TAG, "Unable to save null credential!");
+                    finish(RESULT_FIRST_USER, getIntent());
+                    return;
                 }
             }
         }


### PR DESCRIPTION
#141 

This doesn't fix the root problem, but it will prevent the crash.