### PR TITLE
Fix link in proguard-rules.pro

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -17,7 +17,7 @@
 #}
 
 # See:
-# https://firebase-dot-devsite.googleplex.com/docs/auth/android/start/#proguard
+# https://firebase.google.com/docs/auth/android/start/#proguard
 -keepattributes Signature
 -keepattributes *Annotation*
 


### PR DESCRIPTION
The link for the documentation on proguard seems to be an internal one. Swapped for the public one instead.