### PR TITLE
Flip incorrect assertEquals statements

### DIFF
--- a/auth/src/test/java/com/firebase/ui/auth/AuthUITest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/AuthUITest.java
@@ -25,12 +25,13 @@ import com.firebase.ui.auth.ui.ExtraConstants;
 import com.firebase.ui.auth.ui.FlowParameters;
 import com.google.firebase.FirebaseApp;
 
-import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
+
+import java.util.Arrays;
 
 import static junit.framework.Assert.assertEquals;
 
@@ -89,9 +90,9 @@ public class AuthUITest {
         FlowParameters flowParameters = startIntent.getParcelableExtra(
                 ExtraConstants.EXTRA_FLOW_PARAMS);
 
-        assertEquals(flowParameters.providerInfo.size(), 2);
-        assertEquals(flowParameters.appName, mFirebaseApp.getName());
-        assertEquals(flowParameters.termsOfServiceUrl, TestConstants.TOS_URL);
-        assertEquals(flowParameters.themeId, AuthUI.getDefaultTheme());
+        assertEquals(2, flowParameters.providerInfo.size());
+        assertEquals(mFirebaseApp.getName(), flowParameters.appName);
+        assertEquals(TestConstants.TOS_URL, flowParameters.termsOfServiceUrl);
+        assertEquals(AuthUI.getDefaultTheme(), flowParameters.themeId);
     }
 }

--- a/auth/src/test/java/com/firebase/ui/auth/test_helpers/AutoCompleteTask.java
+++ b/auth/src/test/java/com/firebase/ui/auth/test_helpers/AutoCompleteTask.java
@@ -25,7 +25,7 @@ import com.google.android.gms.tasks.Task;
 
 import java.util.concurrent.Executor;
 
-public class AutoCompleteTask<TResult> extends Task {
+public class AutoCompleteTask<TResult> extends Task<TResult> {
     TResult mResult;
     boolean mComplete;
     boolean mSuccess;
@@ -49,7 +49,7 @@ public class AutoCompleteTask<TResult> extends Task {
     }
 
     @Override
-    public Object getResult() {
+    public TResult getResult() {
         return mResult;
     }
 

--- a/auth/src/test/java/com/firebase/ui/auth/ui/email/RegisterEmailActivityTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/email/RegisterEmailActivityTest.java
@@ -32,6 +32,7 @@ import com.firebase.ui.auth.test_helpers.TestHelper;
 import com.firebase.ui.auth.ui.ExtraConstants;
 import com.firebase.ui.auth.ui.account_link.SaveCredentialsActivity;
 import com.firebase.ui.auth.util.PlayServicesHelper;
+import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.auth.UserProfileChangeRequest;
 
@@ -117,7 +118,7 @@ public class RegisterEmailActivityTest {
                         TestConstants.EMAIL,
                         TestConstants.PASSWORD))
                 .thenReturn(
-                        new AutoCompleteTask<>(
+                        new AutoCompleteTask<AuthResult>(
                                 new FakeAuthResult(mockFirebaseUser),
                                 true,
                                 null));

--- a/auth/src/test/java/com/firebase/ui/auth/ui/email/RegisterEmailActivityTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/email/RegisterEmailActivityTest.java
@@ -98,7 +98,7 @@ public class RegisterEmailActivityTest {
 
     @Test
     @Config(shadows = {ActivityHelperShadow.class, FirebaseAuthWrapperImplShadow.class})
-    public void testSignupButton_successfulRegisterationShouldContinueToSaveCredentials() {
+    public void testSignUpButton_successfulRegistrationShouldContinueToSaveCredentials() {
         TestHelper.initializeApp(RuntimeEnvironment.application);
         RegisterEmailActivity registerEmailActivity = createActivity(TestConstants.EMAIL);
 

--- a/auth/src/test/java/com/firebase/ui/auth/ui/email/RegisterEmailActivityTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/email/RegisterEmailActivityTest.java
@@ -85,13 +85,14 @@ public class RegisterEmailActivityTest {
                 .findViewById(R.id.password_layout);
 
         assertEquals(
-                nameLayout.getError().toString(),
-                registerEmailActivity.getString(R.string.required_field));
+                registerEmailActivity.getString(R.string.required_field),
+                nameLayout.getError().toString());
         assertEquals(
-                passwordLayout.getError().toString(),
-                String.format(registerEmailActivity.getString(R.string.password_length),
-                        registerEmailActivity.getResources().getInteger(
-                                R.integer.min_password_length)));
+                String.format(
+                        registerEmailActivity.getString(R.string.password_length),
+                        registerEmailActivity.getResources().getInteger(R.integer.min_password_length)
+                ),
+                passwordLayout.getError().toString());
     }
 
     @Test
@@ -132,8 +133,8 @@ public class RegisterEmailActivityTest {
 
         assertNotNull(nextIntent);
         assertEquals(
-                nextIntent.intent.getComponent().getClassName(),
-                SaveCredentialsActivity.class.getName());
+                SaveCredentialsActivity.class.getName(),
+                nextIntent.intent.getComponent().getClassName());
         assertEquals(
                 TestConstants.EMAIL,
                 nextIntent.intent.getExtras().getString(ExtraConstants.EXTRA_EMAIL));

--- a/auth/src/test/java/com/firebase/ui/auth/ui/email/SignInActivityTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/email/SignInActivityTest.java
@@ -31,6 +31,7 @@ import com.firebase.ui.auth.test_helpers.TestHelper;
 import com.firebase.ui.auth.ui.ExtraConstants;
 import com.firebase.ui.auth.ui.account_link.SaveCredentialsActivity;
 import com.firebase.ui.auth.util.PlayServicesHelper;
+import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.FirebaseUser;
 
 import org.junit.Before;
@@ -108,7 +109,7 @@ public class SignInActivityTest {
         when(ActivityHelperShadow.firebaseAuth.signInWithEmailAndPassword(
                 TestConstants.EMAIL,
                 TestConstants.PASSWORD)).thenReturn(
-                    new AutoCompleteTask<>(new FakeAuthResult(mockFirebaseUser), true, null));
+                    new AutoCompleteTask<AuthResult>(new FakeAuthResult(mockFirebaseUser), true, null));
         when(mockFirebaseUser.getDisplayName()).thenReturn(TestConstants.NAME);
         when(mockFirebaseUser.getEmail()).thenReturn(TestConstants.EMAIL);
 

--- a/auth/src/test/java/com/firebase/ui/auth/ui/email/SignInNoPasswordActivityTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/email/SignInNoPasswordActivityTest.java
@@ -76,8 +76,8 @@ public class SignInNoPasswordActivityTest {
                 .findViewById(R.id.input_layout_email);
 
         assertEquals(
-                emailLayout.getError().toString(),
-                noPasswordActivity.getString(R.string.invalid_email_address));
+                noPasswordActivity.getString(R.string.invalid_email_address),
+                emailLayout.getError().toString());
     }
 
     private SignInNoPasswordActivity createActivity(String email) {
@@ -136,8 +136,8 @@ public class SignInNoPasswordActivityTest {
         ShadowActivity.IntentForResult nextIntent =
                 shadowActivity.getNextStartedActivityForResult();
         assertEquals(
-                nextIntent.intent.getComponent().getClassName(),
-                SignInActivity.class.getName());
+                SignInActivity.class.getName(),
+                nextIntent.intent.getComponent().getClassName());
         assertEquals(
                 TestConstants.EMAIL,
                 nextIntent.intent.getExtras().getString(ExtraConstants.EXTRA_EMAIL));

--- a/auth/src/test/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivityTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivityTest.java
@@ -214,23 +214,23 @@ public class AuthMethodPickerActivityTest {
                 SaveCredentialsActivity.class.getName(),
                 nextIntent.intent.getComponent().getClassName());
         assertEquals(
-                nextIntent.intent.getExtras().getString(ExtraConstants.EXTRA_EMAIL),
-                TestConstants.EMAIL);
+                TestConstants.EMAIL,
+                nextIntent.intent.getExtras().getString(ExtraConstants.EXTRA_EMAIL));
         assertEquals(
-                nextIntent.intent.getExtras().getString(ExtraConstants.EXTRA_NAME),
-                TestConstants.NAME);
+                TestConstants.NAME,
+                nextIntent.intent.getExtras().getString(ExtraConstants.EXTRA_NAME));
         assertEquals(
-                nextIntent.intent.getExtras().getString(ExtraConstants.EXTRA_PROFILE_PICTURE_URI),
-                TestConstants.PHOTO_URL);
+                TestConstants.PHOTO_URL,
+                nextIntent.intent.getExtras().getString(ExtraConstants.EXTRA_PROFILE_PICTURE_URI));
         assertEquals(
+                provider,
                 ((IdpResponse) nextIntent
                         .intent
                         .getExtras()
-                        .getParcelable(ExtraConstants.EXTRA_IDP_RESPONSE)).getProviderType(),
-                provider);
+                        .getParcelable(ExtraConstants.EXTRA_IDP_RESPONSE)).getProviderType());
         assertEquals(
-                nextIntent.intent.getExtras().getString(ExtraConstants.EXTRA_PASSWORD),
-                null);
+                null,
+                nextIntent.intent.getExtras().getString(ExtraConstants.EXTRA_PASSWORD));
     }
 
     private AuthMethodPickerActivity createActivity(List<String> providers) {


### PR DESCRIPTION
This has been on my mind for awhile. `assertEquals(expected, actual)` is the correct way to do it and some of the tests have that flipped so I went through and unflipped them.