### PR TITLE
Fix issues found by round of manual test

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     // See https://github.com/robolectric/robolectric/issues/1932#issuecomment-219796474
     testCompile 'org.khronos:opengl-api:gl1.1-android-2.1_r1'
     
-    compile 'com.facebook.android:facebook-android-sdk:4.14.1'
+    compile 'com.facebook.android:facebook-android-sdk:4.16.1'
     compile("com.twitter.sdk.android:twitter:2.0.0@aar") {
         transitive = true;
     }

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     // See https://github.com/robolectric/robolectric/issues/1932#issuecomment-219796474
     testCompile 'org.khronos:opengl-api:gl1.1-android-2.1_r1'
     
-    compile 'com.facebook.android:facebook-android-sdk:4.16.1'
+    compile 'com.facebook.android:facebook-android-sdk:4.14.1'
     compile("com.twitter.sdk.android:twitter:2.0.0@aar") {
         transitive = true;
     }

--- a/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
@@ -38,7 +38,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.w3c.dom.CDATASection;
 
 public class FacebookProvider implements IdpProvider, FacebookCallback<LoginResult> {
     protected static final String ERROR = "err";

--- a/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.w3c.dom.CDATASection;
 
 public class FacebookProvider implements IdpProvider, FacebookCallback<LoginResult> {
     protected static final String ERROR = "err";
@@ -46,14 +47,12 @@ public class FacebookProvider implements IdpProvider, FacebookCallback<LoginResu
     private static final String TAG = "FacebookProvider";
     private static final String EMAIL = "email";
     private static final String PUBLIC_PROFILE = "public_profile";
+    private static final CallbackManager mCallbackManager = CallbackManager.Factory.create();
 
     private final List<String> mScopes;
-    private CallbackManager mCallbackManager;
     private IdpCallback mCallbackObject;
 
     public FacebookProvider(Context appContext, IdpConfig idpConfig) {
-        mCallbackManager = CallbackManager.Factory.create();
-
         if (appContext.getResources().getIdentifier(
                 "facebook_permissions", "array", appContext.getPackageName()) != 0) {
             Log.w(TAG, "DEVELOPER WARNING: You have defined R.array.facebook_permissions but that"
@@ -84,7 +83,6 @@ public class FacebookProvider implements IdpProvider, FacebookCallback<LoginResu
 
     @Override
     public void startLogin(Activity activity) {
-        mCallbackManager = CallbackManager.Factory.create();
         LoginManager loginManager = LoginManager.getInstance();
         loginManager.registerCallback(mCallbackManager, this);
 

--- a/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
@@ -46,7 +46,7 @@ public class FacebookProvider implements IdpProvider, FacebookCallback<LoginResu
     private static final String TAG = "FacebookProvider";
     private static final String EMAIL = "email";
     private static final String PUBLIC_PROFILE = "public_profile";
-    private static final CallbackManager mCallbackManager = CallbackManager.Factory.create();
+    private static final CallbackManager sCallbackManager = CallbackManager.Factory.create();
 
     private final List<String> mScopes;
     private IdpCallback mCallbackObject;
@@ -83,7 +83,7 @@ public class FacebookProvider implements IdpProvider, FacebookCallback<LoginResu
     @Override
     public void startLogin(Activity activity) {
         LoginManager loginManager = LoginManager.getInstance();
-        loginManager.registerCallback(mCallbackManager, this);
+        loginManager.registerCallback(sCallbackManager, this);
 
         List<String> permissionsList = new ArrayList<>(mScopes);
 
@@ -107,7 +107,7 @@ public class FacebookProvider implements IdpProvider, FacebookCallback<LoginResu
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        mCallbackManager.onActivityResult(requestCode, resultCode, data);
+        sCallbackManager.onActivityResult(requestCode, resultCode, data);
     }
 
     @Override

--- a/auth/src/main/java/com/firebase/ui/auth/ui/FlowParameters.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/FlowParameters.java
@@ -89,10 +89,7 @@ public class FlowParameters implements Parcelable {
             String termsOfServiceUrl = in.readString();
             int smartLockEnabledInt = in.readInt();
             boolean smartLockEnabled = (smartLockEnabledInt != 0);
-            List<String> additionalFacebookPermissions = new ArrayList<>();
-            in.readStringList(additionalFacebookPermissions);
-            List<String> additionalGooglePermissions = new ArrayList<>();
-            in.readStringList(additionalGooglePermissions);
+
             return new FlowParameters(
                     appName,
                     providerInfo,

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/EmailHintContainerActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/EmailHintContainerActivity.java
@@ -20,6 +20,7 @@ import android.content.Intent;
 import android.content.IntentSender;
 import android.os.Bundle;
 
+import android.util.Log;
 import com.firebase.ui.auth.ui.AcquireEmailHelper;
 import com.firebase.ui.auth.ui.ActivityHelper;
 import com.firebase.ui.auth.ui.AppCompatBase;
@@ -29,6 +30,7 @@ import com.firebase.ui.auth.util.FirebaseAuthWrapperFactory;
 import com.google.android.gms.auth.api.credentials.Credential;
 
 public class EmailHintContainerActivity extends AppCompatBase {
+    private static final String TAG = "EmailHintContainer";
     private static final int RC_HINT = 13;
     private AcquireEmailHelper mAcquireEmailHelper;
 
@@ -45,7 +47,7 @@ public class EmailHintContainerActivity extends AppCompatBase {
                 startIntentSenderForResult(hintIntent.getIntentSender(), RC_HINT, null, 0, 0, 0);
                 return;
             } catch (IntentSender.SendIntentException e) {
-                e.printStackTrace();
+                Log.e(TAG, "Unable to start hint intent", e);
             }
         }
         finish(RESULT_CANCELED, new Intent());

--- a/auth/src/main/java/com/firebase/ui/auth/util/SmartLock.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/SmartLock.java
@@ -168,6 +168,7 @@ public class SmartLock extends Fragment
                     finish();
                 }
             } else {
+                Log.w(TAG, status.getStatusMessage());
                 finish();
             }
         }

--- a/common/constants.gradle
+++ b/common/constants.gradle
@@ -1,5 +1,5 @@
 project.ext.firebase_version = '9.6.1'
-project.ext.support_library_version = '25.0.0'
+project.ext.support_library_version = '24.2.1'
 
 project.ext.submodules = ['database', 'auth', 'storage']
 project.ext.group = 'com.firebaseui'

--- a/common/constants.gradle
+++ b/common/constants.gradle
@@ -1,4 +1,6 @@
 project.ext.firebase_version = '9.6.1'
+// use caution when updating support library version, v25.0.0 caused issues
+// with the Facebook SDK. (NoSuchMethodError startActivity)
 project.ext.support_library_version = '24.2.1'
 
 project.ext.submodules = ['database', 'auth', 'storage']


### PR DESCRIPTION
This solves the following problems:
- Tapping login with Facebook crashes with Chrome custom tab. I tracked this down to the Facebook SDK not playing nicely with the support library version 25.0.0.  To solve this I upgraded the Facebook SDK and down graded the support library.
- Starting the register email flow on older devices crashed the app. This was a problem with trying to unparcel things that weren't there.
- On low memory devices Facebook login with a chrome custom tab would occasionally do nothing. This was because the activity was being destroyed, taking the callback manager with it. 
