### PR TITLE
Update AcquireEmailHelper.java

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/AcquireEmailHelper.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/AcquireEmailHelper.java
@@ -33,10 +33,10 @@ import java.util.List;
 
 public class AcquireEmailHelper {
     private static final String TAG = "AcquireEmailHelper";
-    private static final int RC_REGISTER_ACCOUNT = 14;
-    private static final int RC_WELCOME_BACK_IDP = 15;
-    static final int RC_SIGN_IN = 16;
-    private static final List<Integer> REQUEST_CODES = Arrays.asList(
+    public static final int RC_REGISTER_ACCOUNT = 14;
+    public static final int RC_WELCOME_BACK_IDP = 15;
+    public static final int RC_SIGN_IN = 16;
+    public static final List<Integer> REQUEST_CODES = Arrays.asList(
             RC_REGISTER_ACCOUNT,
             RC_WELCOME_BACK_IDP,
             RC_SIGN_IN


### PR DESCRIPTION
Changed request codes to public from private.

This is a sign-in example from the readme, which seems to require these request codes to be public.

```java
startActivityForResult(
    // Get an instance of AuthUI based on the default app
    AuthUI.getInstance().createSignInIntentBuilder().build(),
    RC_SIGN_IN);
```