### PR TITLE
add fabric maven url under allprojects

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -53,9 +53,11 @@ dependencies {
 and add the Fabric repository
 
 ```groovy
-repositories {
-    // ...
-    maven { url 'https://maven.fabric.io/public' }
+allprojects {
+    repositories {
+        // ...
+        maven { url 'https://maven.fabric.io/public' }
+    }
 }
 ```
 


### PR DESCRIPTION
Previously just writing repositories makes it confusing whether to add the url under `buildscript` or `allprojects`.

I was facing issue #392 because of this.