### PR TITLE
Fix NPE in FacebookProvider

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
@@ -113,7 +113,9 @@ public class FacebookProvider implements IdpProvider, FacebookCallback<LoginResu
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        sCallbackManager.onActivityResult(requestCode, resultCode, data);
+        if (sCallbackManager != null) {
+            sCallbackManager.onActivityResult(requestCode, resultCode, data);
+        }
     }
 
     @Override


### PR DESCRIPTION
My bad, I forgot to test how other providers reacted the Facebook change. Not well apparently since users would get a NPE every time they tried to log in with a provider besides Facebook. Thankfully, this wasn't released. 😌