### PR TITLE
Add android build cache to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+    - $HOME/.android/build-cache
 android:
   components:
     - tools


### PR DESCRIPTION
The 2.3 android gradle plugin comes with a new build cache: http://tools.android.com/tech-docs/build-cache.