### PR TITLE
Robolectic now supports api 25!

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
     //noinspection NewerVersionAvailable, GradleDynamicVersion
     testCompile 'org.mockito:mockito-core:2.5.+'
-    testCompile 'org.robolectric:robolectric:3.1.4'
+    testCompile 'org.robolectric:robolectric:3.2'
     // See https://github.com/robolectric/robolectric/issues/1932#issuecomment-219796474
     testCompile 'org.khronos:opengl-api:gl1.1-android-2.1_r1'
 }

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
     //noinspection NewerVersionAvailable, GradleDynamicVersion
     testCompile 'org.mockito:mockito-core:2.5.+'
-    testCompile 'org.robolectric:robolectric:3.2'
+    testCompile 'org.robolectric:robolectric:3.2.1'
     // See https://github.com/robolectric/robolectric/issues/1932#issuecomment-219796474
     testCompile 'org.khronos:opengl-api:gl1.1-android-2.1_r1'
 }

--- a/auth/src/test/java/com/firebase/ui/auth/AuthUITest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/AuthUITest.java
@@ -33,7 +33,7 @@ import java.util.Arrays;
 import static junit.framework.Assert.assertEquals;
 
 @RunWith(CustomRobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 23)
+@Config(constants = BuildConfig.class, sdk = 25)
 public class AuthUITest {
     private FirebaseApp mFirebaseApp;
 

--- a/auth/src/test/java/com/firebase/ui/auth/ui/email/RecoverPasswordActivityTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/email/RecoverPasswordActivityTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(CustomRobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 23)
+@Config(constants = BuildConfig.class, sdk = 25)
 public class RecoverPasswordActivityTest {
 
     @Before

--- a/auth/src/test/java/com/firebase/ui/auth/ui/email/RegisterEmailActivityTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/email/RegisterEmailActivityTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.when;
 
 
 @RunWith(CustomRobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 23)
+@Config(constants = BuildConfig.class, sdk = 25)
 public class RegisterEmailActivityTest {
 
     private RegisterEmailActivity createActivity() {

--- a/auth/src/test/java/com/firebase/ui/auth/ui/email/WelcomeBackPasswordPromptTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/email/WelcomeBackPasswordPromptTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(CustomRobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 23)
+@Config(constants = BuildConfig.class, sdk = 25)
 public class WelcomeBackPasswordPromptTest {
     @Before
     public void setUp() {

--- a/auth/src/test/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivityTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivityTest.java
@@ -65,7 +65,7 @@ import static org.mockito.Mockito.when;
                 GoogleProviderShadow.class,
                 FacebookProviderShadow.class,
                 LoginManagerShadow.class
-        }, sdk = 23)
+        }, sdk = 25)
 public class AuthMethodPickerActivityTest {
     @Test
     public void testAllProvidersArePopulated() {

--- a/auth/src/test/java/com/firebase/ui/auth/ui/idp/CredentialSignInHandlerTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/idp/CredentialSignInHandlerTest.java
@@ -60,7 +60,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(CustomRobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 23, shadows = {ActivityHelperShadow.class})
+@Config(constants = BuildConfig.class, sdk = 25, shadows = {ActivityHelperShadow.class})
 public class CredentialSignInHandlerTest {
     private static final int RC_ACCOUNT_LINK = 3;
     private static final String LINKING_ERROR = "ERROR_TEST_LINKING";


### PR DESCRIPTION
Upgrade all our tests to target sdk 25.

Note: we're probably going to have to upgrade again soon because of a stopship (that wasn't stopped) on windows: https://github.com/robolectric/robolectric/issues/2814.