### PR TITLE
[HIGH PRIORITY] Fix inflation errors

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/ActivityHelper.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/ActivityHelper.java
@@ -20,6 +20,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.RestrictTo;
 
 import com.firebase.ui.auth.IdpResponse;
+import com.firebase.ui.auth.R;
 import com.firebase.ui.auth.util.signincontainer.SaveSmartLock;
 import com.google.firebase.auth.FirebaseUser;
 
@@ -33,6 +34,7 @@ public class ActivityHelper extends BaseHelper {
     }
 
     public void configureTheme() {
+        mActivity.setTheme(R.style.FirebaseUI); // Provides default values
         mActivity.setTheme(getFlowParams().themeId);
     }
 


### PR DESCRIPTION
Hey @samtstern I started noticing inflation crashes in my app earlier today. It turns out there was a reason for the theme stuff in the manifest file: I didn't know this, but setting a theme doesn't actually overwrite the previous theme, it just adds on values (and overwrite identical ones). The theme I provide in my app doesn't extend the default FirebaseUI theme so some color stuff was nonexistent causing the crash.

Example error:
`Caused by android.view.InflateException: Binary XML file line #9: Binary XML file line #9: Error inflating class android.support.design.widget.TextInputLayout`