### PR TITLE
Add getItems method to adapters

### DIFF
--- a/auth/src/main/AndroidManifest.xml
+++ b/auth/src/main/AndroidManifest.xml
@@ -29,32 +29,27 @@
         <activity
             android:name=".ui.email.RecoverPasswordActivity"
             android:label="@string/title_recover_password_activity"
-            android:exported="false"
-            android:theme="@style/FirebaseUI"/>
+            android:exported="false"/>
 
         <activity
             android:name=".ui.email.RegisterEmailActivity"
             android:label="@string/sign_in_default"
-            android:exported="false"
-            android:theme="@style/FirebaseUI"/>
+            android:exported="false"/>
 
         <activity
             android:name=".ui.accountlink.WelcomeBackIdpPrompt"
             android:label="@string/title_welcome_back_idp_prompt"
-            android:exported="false"
-            android:theme="@style/FirebaseUI"/>
+            android:exported="false"/>
 
         <activity
             android:name=".ui.accountlink.WelcomeBackPasswordPrompt"
             android:label="@string/title_welcome_back_password_prompt"
-            android:exported="false"
-            android:theme="@style/FirebaseUI"/>
+            android:exported="false"/>
 
         <activity
             android:name=".ui.idp.AuthMethodPickerActivity"
             android:label="@string/default_toolbar_title"
-            android:exported="false"
-            android:theme="@style/FirebaseUI"/>
+            android:exported="false"/>
 
         <activity
             android:name="com.facebook.FacebookActivity"

--- a/database/src/main/java/com/firebase/ui/database/FirebaseListAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseListAdapter.java
@@ -114,10 +114,10 @@ public abstract class FirebaseListAdapter<T> extends BaseAdapter {
         return parseSnapshot(mSnapshots.getItem(position));
     }
 
-    public List<T> getItems() {
-        List<T> items = new ArrayList<>(getCount());
+    public List<DataSnapshot> getItems() {
+        List<DataSnapshot> items = new ArrayList<>(getCount());
         for (int i = 0; i < getCount(); i++) {
-            items.add(getItem(i));
+            items.add(mSnapshots.getItem(i));
         }
         return items;
     }

--- a/database/src/main/java/com/firebase/ui/database/FirebaseListAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseListAdapter.java
@@ -26,6 +26,9 @@ import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.Query;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * This class is a generic way of backing an Android ListView with a Firebase location.
  * It handles all of the child events at the given Firebase location. It marshals received data into the given
@@ -109,6 +112,14 @@ public abstract class FirebaseListAdapter<T> extends BaseAdapter {
     @Override
     public T getItem(int position) {
         return parseSnapshot(mSnapshots.getItem(position));
+    }
+
+    public List<T> getItems() {
+        List<T> items = new ArrayList<>(getCount());
+        for (int i = 0; i < getCount(); i++) {
+            items.add(getItem(i));
+        }
+        return items;
     }
 
     /**

--- a/database/src/main/java/com/firebase/ui/database/FirebaseListAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseListAdapter.java
@@ -131,10 +131,10 @@ public abstract class FirebaseListAdapter<T> extends BaseAdapter {
         return parseSnapshot(mSnapshots.getItem(position));
     }
 
-    public List<DataSnapshot> getItems() {
-        List<DataSnapshot> items = new ArrayList<>(getCount());
+    public List<T> getItems() {
+        List<T> items = new ArrayList<>(getCount());
         for (int i = 0; i < getCount(); i++) {
-            items.add(mSnapshots.getItem(i));
+            items.add(getItem(i));
         }
         return items;
     }
@@ -152,6 +152,14 @@ public abstract class FirebaseListAdapter<T> extends BaseAdapter {
 
     public DatabaseReference getRef(int position) {
         return mSnapshots.getItem(position).getRef();
+    }
+
+    public List<DataSnapshot> getSnapshots() {
+        List<DataSnapshot> items = new ArrayList<>(getCount());
+        for (int i = 0; i < getCount(); i++) {
+            items.add(mSnapshots.getItem(i));
+        }
+        return items;
     }
 
     @Override

--- a/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
@@ -149,10 +149,10 @@ public abstract class FirebaseRecyclerAdapter<T, VH extends RecyclerView.ViewHol
         return parseSnapshot(mSnapshots.getItem(position));
     }
 
-    public List<T> getItems() {
-        List<T> items = new ArrayList<>(getItemCount());
+    public List<DataSnapshot> getItems() {
+        List<DataSnapshot> items = new ArrayList<>(getItemCount());
         for (int i = 0; i < getItemCount(); i++) {
-            items.add(getItem(i));
+            items.add(mSnapshots.getItem(i));
         }
         return items;
     }

--- a/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
@@ -28,6 +28,8 @@ import com.google.firebase.database.Query;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This class is a generic way of backing an RecyclerView with a Firebase location.
@@ -145,6 +147,14 @@ public abstract class FirebaseRecyclerAdapter<T, VH extends RecyclerView.ViewHol
 
     public T getItem(int position) {
         return parseSnapshot(mSnapshots.getItem(position));
+    }
+
+    public List<T> getItems() {
+        List<T> items = new ArrayList<>(getItemCount());
+        for (int i = 0; i < getItemCount(); i++) {
+            items.add(getItem(i));
+        }
+        return items;
     }
 
     /**

--- a/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
@@ -165,10 +165,10 @@ public abstract class FirebaseRecyclerAdapter<T, VH extends RecyclerView.ViewHol
         return parseSnapshot(mSnapshots.getItem(position));
     }
 
-    public List<DataSnapshot> getItems() {
-        List<DataSnapshot> items = new ArrayList<>(getItemCount());
+    public List<T> getItems() {
+        List<T> items = new ArrayList<>(getItemCount());
         for (int i = 0; i < getItemCount(); i++) {
-            items.add(mSnapshots.getItem(i));
+            items.add(getItem(i));
         }
         return items;
     }
@@ -186,6 +186,14 @@ public abstract class FirebaseRecyclerAdapter<T, VH extends RecyclerView.ViewHol
 
     public DatabaseReference getRef(int position) {
         return mSnapshots.getItem(position).getRef();
+    }
+
+    public List<DataSnapshot> getSnapshots() {
+        List<DataSnapshot> items = new ArrayList<>(getItemCount());
+        for (int i = 0; i < getItemCount(); i++) {
+            items.add(mSnapshots.getItem(i));
+        }
+        return items;
     }
 
     @Override


### PR DESCRIPTION
@puf I've been needing to get all the items in my adapter recently and there is no way to do that without writing a for loop each time so I created a simple `getItems` method for each adapter. @puf PTAL and confirm that this is a reasonable change.