### PR TITLE
Remove apply constants from module build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'com.neenbedankt.android-apt'
-apply from: "../constants.gradle"
 apply from: '../library/quality/quality.gradle'
 
 android {


### PR DESCRIPTION
This is a really small change, but I got burned by it while working on a different project. `apply from: "../constants.gradle"` doesn't work for some reason and is unused. Instead, the constants are applied in the [root `build.gradle`](https://github.com/firebase/FirebaseUI-Android/blob/master/build.gradle#L1).