### PR TITLE
Set android:supportsRtl="true" in manifest

### DIFF
--- a/auth/src/main/AndroidManifest.xml
+++ b/auth/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
-        android:supportsRtl="false">
+        android:supportsRtl="true">
 
         <meta-data
             android:name="com.google.android.gms.version"


### PR DESCRIPTION
It conflicts with manifest of the application that uses this library which is defaulted to true. keeping it false is making error during gradle dependencies resolving which is not easy to be discovered by newbies.

Issue and solution discussed here:
https://github.com/firebase/FirebaseUI-Android/issues/392
