### PR TITLE
Add option in AuthUI.SignInIntentBuilder to disable account creation

### DIFF
--- a/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
@@ -102,6 +102,9 @@ public class AuthUiActivity extends AppCompatActivity {
     @BindView(R.id.smartlock_enabled)
     CheckBox mEnableSmartLock;
 
+    @BindView(R.id.allow_new_email_accounts)
+    CheckBox mAllowNewEmailAccounts;
+
     @BindView(R.id.facebook_scopes_label)
     TextView mFacebookScopesLabel;
 
@@ -119,9 +122,6 @@ public class AuthUiActivity extends AppCompatActivity {
 
     @BindView(R.id.google_scope_games)
     CheckBox mGoogleScopeGames;
-
-    @BindView(R.id.allow_new_email_accounts)
-    CheckBox mAllowNewEmailAccounts;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
@@ -120,6 +120,9 @@ public class AuthUiActivity extends AppCompatActivity {
     @BindView(R.id.google_scope_games)
     CheckBox mGoogleScopeGames;
 
+    @BindView(R.id.create_account_enabled)
+    CheckBox mCreateAccountEnabled;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -183,6 +186,7 @@ public class AuthUiActivity extends AppCompatActivity {
                         .setProviders(getSelectedProviders())
                         .setTosUrl(getSelectedTosUrl())
                         .setIsSmartLockEnabled(mEnableSmartLock.isChecked())
+                        .setCreateAccountIfEmailNotExists(mCreateAccountEnabled.isChecked())
                         .build(),
                 RC_SIGN_IN);
     }
@@ -206,6 +210,9 @@ public class AuthUiActivity extends AppCompatActivity {
         if (resultCode == ResultCodes.OK) {
             startActivity(SignedInActivity.createIntent(this, response));
             finish();
+            return;
+        } else if(resultCode == ResultCodes.NO_EMAIL_ACCOUNT) {
+            showSnackbar(R.string.error_email_does_not_exist);
             return;
         } else {
             // Sign in failed

--- a/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
@@ -211,9 +211,6 @@ public class AuthUiActivity extends AppCompatActivity {
             startActivity(SignedInActivity.createIntent(this, response));
             finish();
             return;
-        } else if (resultCode == ResultCodes.NO_EMAIL_ACCOUNT) {
-            showSnackbar(R.string.error_email_does_not_exist);
-            return;
         } else {
             // Sign in failed
             if (response == null) {

--- a/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
@@ -120,8 +120,8 @@ public class AuthUiActivity extends AppCompatActivity {
     @BindView(R.id.google_scope_games)
     CheckBox mGoogleScopeGames;
 
-    @BindView(R.id.create_account_enabled)
-    CheckBox mCreateAccountEnabled;
+    @BindView(R.id.allow_new_email_accounts)
+    CheckBox mAllowNewEmailAccounts;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -186,7 +186,7 @@ public class AuthUiActivity extends AppCompatActivity {
                         .setProviders(getSelectedProviders())
                         .setTosUrl(getSelectedTosUrl())
                         .setIsSmartLockEnabled(mEnableSmartLock.isChecked())
-                        .setCreateAccountIfEmailNotExists(mCreateAccountEnabled.isChecked())
+                        .setAllowNewEmailAccounts(mAllowNewEmailAccounts.isChecked())
                         .build(),
                 RC_SIGN_IN);
     }

--- a/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
@@ -211,7 +211,7 @@ public class AuthUiActivity extends AppCompatActivity {
             startActivity(SignedInActivity.createIntent(this, response));
             finish();
             return;
-        } else if(resultCode == ResultCodes.NO_EMAIL_ACCOUNT) {
+        } else if (resultCode == ResultCodes.NO_EMAIL_ACCOUNT) {
             showSnackbar(R.string.error_email_does_not_exist);
             return;
         } else {

--- a/app/src/main/java/com/firebase/uidemo/database/ChatActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/database/ChatActivity.java
@@ -162,7 +162,8 @@ public class ChatActivity extends AppCompatActivity implements FirebaseAuth.Auth
             @Override
             protected void onDataChanged() {
                 // if there are no chat messages, show a view that invites the user to add a message
-                mEmptyListView.setVisibility(mRecyclerViewAdapter.getItemCount() == 0 ? View.VISIBLE : View.INVISIBLE);
+                mEmptyListView.setVisibility(mRecyclerViewAdapter.getItemCount() == 0 ?
+                        View.VISIBLE : View.INVISIBLE);
             }
         };
 

--- a/app/src/main/res/layout/auth_ui_layout.xml
+++ b/app/src/main/res/layout/auth_ui_layout.xml
@@ -235,6 +235,13 @@
                 android:checked="true"
                 android:text="@string/enable_smartlock"/>
 
+            <CheckBox
+                android:id="@+id/create_account_enabled"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:text="@string/create_email_account_if_not_exists"/>
+
         </LinearLayout>
 
     </ScrollView>

--- a/app/src/main/res/layout/auth_ui_layout.xml
+++ b/app/src/main/res/layout/auth_ui_layout.xml
@@ -236,11 +236,11 @@
                 android:text="@string/enable_smartlock"/>
 
             <CheckBox
-                android:id="@+id/create_account_enabled"
+                android:id="@+id/allow_new_email_accounts"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:checked="true"
-                android:text="@string/create_email_account_if_not_exists"/>
+                android:text="@string/allow_new_email_acccount"/>
 
         </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,4 +67,5 @@
 
     <!-- strings for Auth UI demo activities -->
     <string name="start_chatting">No messages. Start chatting at the bottom!</string>
+    <string name="create_email_account_if_not_exists">Allow account creation if email does not exist.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,5 +67,5 @@
 
     <!-- strings for Auth UI demo activities -->
     <string name="start_chatting">No messages. Start chatting at the bottom!</string>
-    <string name="create_email_account_if_not_exists">Allow account creation if email does not exist.</string>
+    <string name="allow_new_email_acccount">Allow account creation if email does not exist.</string>
 </resources>

--- a/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
@@ -517,6 +517,7 @@ public class AuthUI {
         private LinkedHashSet<IdpConfig> mProviders = new LinkedHashSet<>();
         private String mTosUrl;
         private boolean mIsSmartLockEnabled = true;
+        private boolean mCreateAccountIfEmailNotExists = true;
 
         private SignInIntentBuilder() {
             mProviders.add(new IdpConfig.Builder(EMAIL_PROVIDER).build());
@@ -632,7 +633,15 @@ public class AuthUI {
                                       mTheme,
                                       mLogo,
                                       mTosUrl,
-                                      mIsSmartLockEnabled);
+                                      mIsSmartLockEnabled,
+                                      mCreateAccountIfEmailNotExists);
         }
+
+        public SignInIntentBuilder setCreateAccountIfEmailNotExists(boolean enabled) {
+            mCreateAccountIfEmailNotExists = enabled;
+            return this;
+        }
+
+
     }
 }

--- a/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
@@ -637,7 +637,7 @@ public class AuthUI {
                                       mCreateAccountIfEmailNotExists);
         }
 
-        public SignInIntentBuilder setCreateAccountIfEmailNotExists(boolean enabled) {
+        public SignInIntentBuilder setAllowNewEmailAccounts(boolean enabled) {
             mCreateAccountIfEmailNotExists = enabled;
             return this;
         }

--- a/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
@@ -517,7 +517,7 @@ public class AuthUI {
         private LinkedHashSet<IdpConfig> mProviders = new LinkedHashSet<>();
         private String mTosUrl;
         private boolean mIsSmartLockEnabled = true;
-        private boolean mCreateAccountIfEmailNotExists = true;
+        private boolean mAllowNewEmailAccounts = true;
 
         private SignInIntentBuilder() {
             mProviders.add(new IdpConfig.Builder(EMAIL_PROVIDER).build());
@@ -634,11 +634,11 @@ public class AuthUI {
                                       mLogo,
                                       mTosUrl,
                                       mIsSmartLockEnabled,
-                                      mCreateAccountIfEmailNotExists);
+                                      mAllowNewEmailAccounts);
         }
 
         public SignInIntentBuilder setAllowNewEmailAccounts(boolean enabled) {
-            mCreateAccountIfEmailNotExists = enabled;
+            mAllowNewEmailAccounts = enabled;
             return this;
         }
 

--- a/auth/src/main/java/com/firebase/ui/auth/ResultCodes.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ResultCodes.java
@@ -17,11 +17,6 @@ public final class ResultCodes {
      **/
     public static final int CANCELED = Activity.RESULT_CANCELED;
 
-    /**
-     * Email does not exist in auth database
-     */
-    public static final int NO_EMAIL_ACCOUNT = 2;
-
     private ResultCodes() {
         // no instance
     }

--- a/auth/src/main/java/com/firebase/ui/auth/ResultCodes.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ResultCodes.java
@@ -17,6 +17,11 @@ public final class ResultCodes {
      **/
     public static final int CANCELED = Activity.RESULT_CANCELED;
 
+    /**
+     * Email does not exist in auth database
+     */
+    public static final int NO_EMAIL_ACCOUNT = 2;
+
     private ResultCodes() {
         // no instance
     }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/FlowParameters.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/FlowParameters.java
@@ -49,7 +49,7 @@ public class FlowParameters implements Parcelable {
 
     public final boolean smartLockEnabled;
 
-    public final boolean createAccountIfEmailNotExists;
+    public final boolean allowNewEmailAccounts;
 
     public FlowParameters(
             @NonNull String appName,
@@ -58,14 +58,14 @@ public class FlowParameters implements Parcelable {
             @DrawableRes int logoId,
             @Nullable String termsOfServiceUrl,
             boolean smartLockEnabled,
-            boolean createAccountIfEmailNotExists) {
+            boolean allowNewEmailAccounts) {
         this.appName = Preconditions.checkNotNull(appName, "appName cannot be null");
         this.providerInfo = Preconditions.checkNotNull(providerInfo, "providerInfo cannot be null");
         this.themeId = themeId;
         this.logoId = logoId;
         this.termsOfServiceUrl = termsOfServiceUrl;
         this.smartLockEnabled = smartLockEnabled;
-        this.createAccountIfEmailNotExists = createAccountIfEmailNotExists;
+        this.allowNewEmailAccounts = allowNewEmailAccounts;
     }
 
     @Override
@@ -76,7 +76,7 @@ public class FlowParameters implements Parcelable {
         dest.writeInt(logoId);
         dest.writeString(termsOfServiceUrl);
         dest.writeInt(smartLockEnabled ? 1 : 0);
-        dest.writeInt(createAccountIfEmailNotExists ? 1 : 0);
+        dest.writeInt(allowNewEmailAccounts ? 1 : 0);
     }
 
     @Override
@@ -93,10 +93,10 @@ public class FlowParameters implements Parcelable {
             int logoId = in.readInt();
             String termsOfServiceUrl = in.readString();
             int smartLockEnabledInt = in.readInt();
-            int createAccountIfNotEmailExistsInt = in.readInt();
+            int allowNewEmailAccountsInt = in.readInt();
 
             boolean smartLockEnabled = smartLockEnabledInt != 0;
-            boolean createAccountIfEmailNotExists = createAccountIfNotEmailExistsInt != 0;
+            boolean allowNewEmailAccounts = allowNewEmailAccountsInt != 0;
 
             return new FlowParameters(
                     appName,
@@ -105,7 +105,7 @@ public class FlowParameters implements Parcelable {
                     logoId,
                     termsOfServiceUrl,
                     smartLockEnabled,
-                    createAccountIfEmailNotExists);
+                    allowNewEmailAccounts);
         }
 
         @Override

--- a/auth/src/main/java/com/firebase/ui/auth/ui/FlowParameters.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/FlowParameters.java
@@ -49,19 +49,23 @@ public class FlowParameters implements Parcelable {
 
     public final boolean smartLockEnabled;
 
+    public final boolean createAccountIfEmailNotExists;
+
     public FlowParameters(
             @NonNull String appName,
             @NonNull List<IdpConfig> providerInfo,
             @StyleRes int themeId,
             @DrawableRes int logoId,
             @Nullable String termsOfServiceUrl,
-            boolean smartLockEnabled) {
+            boolean smartLockEnabled,
+            boolean createAccountIfEmailNotExists) {
         this.appName = Preconditions.checkNotNull(appName, "appName cannot be null");
         this.providerInfo = Preconditions.checkNotNull(providerInfo, "providerInfo cannot be null");
         this.themeId = themeId;
         this.logoId = logoId;
         this.termsOfServiceUrl = termsOfServiceUrl;
         this.smartLockEnabled = smartLockEnabled;
+        this.createAccountIfEmailNotExists = createAccountIfEmailNotExists;
     }
 
     @Override
@@ -72,6 +76,7 @@ public class FlowParameters implements Parcelable {
         dest.writeInt(logoId);
         dest.writeString(termsOfServiceUrl);
         dest.writeInt(smartLockEnabled ? 1 : 0);
+        dest.writeInt(createAccountIfEmailNotExists ? 1 : 0);
     }
 
     @Override
@@ -88,7 +93,10 @@ public class FlowParameters implements Parcelable {
             int logoId = in.readInt();
             String termsOfServiceUrl = in.readString();
             int smartLockEnabledInt = in.readInt();
+            int createAccountIfNotEmailExistsInt = in.readInt();
+
             boolean smartLockEnabled = smartLockEnabledInt != 0;
+            boolean createAccountIfEmailNotExists = createAccountIfNotEmailExistsInt != 0;
 
             return new FlowParameters(
                     appName,
@@ -96,7 +104,8 @@ public class FlowParameters implements Parcelable {
                     themeId,
                     logoId,
                     termsOfServiceUrl,
-                    smartLockEnabled);
+                    smartLockEnabled,
+                    createAccountIfEmailNotExists);
         }
 
         @Override

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/CheckEmailFragment.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/CheckEmailFragment.java
@@ -75,6 +75,7 @@ public class CheckEmailFragment extends FragmentBase implements View.OnClickList
     private static final int RC_SIGN_IN = 16;
 
     private EditText mEmailEditText;
+    private TextInputLayout mEmailLayout;
 
     private EmailFieldValidator mEmailFieldValidator;
     private CheckEmailListener mListener;
@@ -100,9 +101,11 @@ public class CheckEmailFragment extends FragmentBase implements View.OnClickList
         View v = inflater.inflate(R.layout.check_email_layout, container, false);
 
         // Email field and validator
+        mEmailLayout = (TextInputLayout) v.findViewById(R.id.email_layout);
         mEmailEditText = (EditText) v.findViewById(R.id.email);
-        mEmailFieldValidator = new EmailFieldValidator(
-                (TextInputLayout) v.findViewById(R.id.email_layout));
+        mEmailFieldValidator = new EmailFieldValidator(mEmailLayout);
+        mEmailLayout.setOnClickListener(this);
+        mEmailEditText.setOnClickListener(this);
 
         // "Next" button
         v.findViewById(R.id.button_next).setOnClickListener(this);
@@ -257,6 +260,8 @@ public class CheckEmailFragment extends FragmentBase implements View.OnClickList
 
         if (id == R.id.button_next) {
             validateAndProceed();
+        } else if (id == R.id.email_layout || id == R.id.email) {
+            mEmailLayout.setError(null);
         }
     }
 }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/RegisterEmailActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/RegisterEmailActivity.java
@@ -18,13 +18,12 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.RestrictTo;
+import android.support.design.widget.TextInputLayout;
 import android.support.v4.app.FragmentTransaction;
 import android.view.View;
 
-import com.firebase.ui.auth.ErrorCodes;
 import com.firebase.ui.auth.IdpResponse;
 import com.firebase.ui.auth.R;
-import com.firebase.ui.auth.ResultCodes;
 import com.firebase.ui.auth.ui.AppCompatBase;
 import com.firebase.ui.auth.ui.BaseHelper;
 import com.firebase.ui.auth.ui.ExtraConstants;
@@ -123,21 +122,22 @@ public class RegisterEmailActivity extends AppCompatBase implements
         // New user, direct them to create an account with email/password
         // if account creation is enabled in SignInIntentBuilder
 
-        boolean createAccount = mActivityHelper.getFlowParams().createAccountIfEmailNotExists;
-        if (createAccount) {
+        boolean createAccount = mActivityHelper.getFlowParams().allowNewEmailAccounts;
 
+        TextInputLayout mEmailLayout = (TextInputLayout) findViewById(R.id.email_layout);
+
+        if (createAccount) {
             RegisterEmailFragment fragment = RegisterEmailFragment.getInstance(
                     mActivityHelper.getFlowParams(),
                     user);
             FragmentTransaction ft = getSupportFragmentManager().beginTransaction()
                     .replace(R.id.fragment_register_email, fragment, RegisterEmailFragment.TAG);
 
-            View v = findViewById(R.id.email_layout);
-            if (v != null) ft.addSharedElement(v, "email_field");
+            if (mEmailLayout != null) ft.addSharedElement(mEmailLayout, "email_field");
 
             ft.disallowAddToBackStack().commit();
         } else {
-            finish(ResultCodes.NO_EMAIL_ACCOUNT, IdpResponse.getErrorCodeIntent(ErrorCodes.UNKNOWN_ERROR));
+            mEmailLayout.setError(getString(R.string.error_email_does_not_exist));
         }
     }
 

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/RegisterEmailActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/RegisterEmailActivity.java
@@ -21,8 +21,10 @@ import android.support.annotation.RestrictTo;
 import android.support.v4.app.FragmentTransaction;
 import android.view.View;
 
+import com.firebase.ui.auth.ErrorCodes;
 import com.firebase.ui.auth.IdpResponse;
 import com.firebase.ui.auth.R;
+import com.firebase.ui.auth.ResultCodes;
 import com.firebase.ui.auth.ui.AppCompatBase;
 import com.firebase.ui.auth.ui.BaseHelper;
 import com.firebase.ui.auth.ui.ExtraConstants;
@@ -118,17 +120,25 @@ public class RegisterEmailActivity extends AppCompatBase implements
 
     @Override
     public void onNewUser(User user) {
-        // New user, direct them to create an account with email/password.
-        RegisterEmailFragment fragment = RegisterEmailFragment.getInstance(
-                mActivityHelper.getFlowParams(),
-                user);
-        FragmentTransaction ft = getSupportFragmentManager().beginTransaction()
-                .replace(R.id.fragment_register_email, fragment, RegisterEmailFragment.TAG);
+        // New user, direct them to create an account with email/password
+        // if account creation is enabled in SignInIntentBuilder
 
-        View v = findViewById(R.id.email_layout);
-        if (v != null) ft.addSharedElement(v, "email_field");
+        boolean createAccount = mActivityHelper.getFlowParams().createAccountIfEmailNotExists;
+        if(createAccount) {
 
-        ft.disallowAddToBackStack().commit();
+            RegisterEmailFragment fragment = RegisterEmailFragment.getInstance(
+                    mActivityHelper.getFlowParams(),
+                    user);
+            FragmentTransaction ft = getSupportFragmentManager().beginTransaction()
+                    .replace(R.id.fragment_register_email, fragment, RegisterEmailFragment.TAG);
+
+            View v = findViewById(R.id.email_layout);
+            if (v != null) ft.addSharedElement(v, "email_field");
+
+            ft.disallowAddToBackStack().commit();
+        } else {
+            finish(ResultCodes.NO_EMAIL_ACCOUNT, IdpResponse.getErrorCodeIntent(ErrorCodes.UNKNOWN_ERROR));
+        }
     }
 
     private void setSlideAnimation() {

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/RegisterEmailActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/RegisterEmailActivity.java
@@ -124,7 +124,7 @@ public class RegisterEmailActivity extends AppCompatBase implements
         // if account creation is enabled in SignInIntentBuilder
 
         boolean createAccount = mActivityHelper.getFlowParams().createAccountIfEmailNotExists;
-        if(createAccount) {
+        if (createAccount) {
 
             RegisterEmailFragment fragment = RegisterEmailFragment.getInstance(
                     mActivityHelper.getFlowParams(),

--- a/auth/src/test/java/com/firebase/ui/auth/testhelpers/TestHelper.java
+++ b/auth/src/test/java/com/firebase/ui/auth/testhelpers/TestHelper.java
@@ -65,6 +65,7 @@ public class TestHelper {
                 AuthUI.getDefaultTheme(),
                 AuthUI.NO_LOGO,
                 null,
+                true,
                 true);
     }
 


### PR DESCRIPTION
As requested in #530 and #385, add option in AuthUI.SignInIntentBuilder to disable account creation if email does not pre-exist.
`gradlew check` passes.


