### PR TITLE
Disable NewerVersionAvailable lint check

### DIFF
--- a/library/quality/quality.gradle
+++ b/library/quality/quality.gradle
@@ -72,7 +72,7 @@ android {
         // We have okio as a transitive dependency, which causes some lint errors due to
         // using Java 8 nio packages. Safely downgrading them to warning.
         // https://github.com/square/okio/issues/58
-        disable 'InvalidPackage'
+        disable 'InvalidPackage', 'NewerVersionAvailable'
 
         baseline file("$configDir/lint-baseline.xml")
         checkAllWarnings true


### PR DESCRIPTION
This check causes Travis to be flaky.  For example if a PR is submitted the tests may pass, but then in the time between submission and merge a dependency could get a new version and it could fail.

Also, I don't think it's a good thing to blindly update dependency versions to always be newest, that could sacrifice stability (for example, Robolectric 3.2.0 had a Windows fatal bug in it).

For these reasons, this lint check should be disabled.