### PR TITLE
Update docs stating the need to call cleanup

### DIFF
--- a/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
@@ -67,6 +67,9 @@ import java.lang.reflect.InvocationTargetException;
  *     };
  *     recycler.setAdapter(mAdapter);
  * </pre>
+ * <p>
+ * To avoid Context leaks, make sure you invoke {@link #cleanup() cleanup}
+ * <p>
  *
  * @param <T>  The Java class that maps to the type of objects stored in the Firebase location.
  * @param <VH> The ViewHolder class that contains the Views in the layout that is shown for each object.


### PR DESCRIPTION
See https://github.com/firebase/FirebaseUI-Android/issues/244

Not invoking cleanup causes a memory leak, and it isn't mentioned.