### PR TITLE
Add documentation for setAllowNewEmailAccounts and teeny cleanup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,8 +43,8 @@ dependencies {
     // They are used to make some aspects of the demo app implementation simpler for
     // demonstrative purposes, and you may find them useful in your own apps; YMMV.
     compile 'pub.devrel:easypermissions:0.2.1'
-    compile 'com.jakewharton:butterknife:8.4.0'
-    apt 'com.jakewharton:butterknife-compiler:8.4.0'
+    compile 'com.jakewharton:butterknife:8.5.1'
+    apt 'com.jakewharton:butterknife-compiler:8.5.1'
     debugCompile 'com.squareup.leakcanary:leakcanary-android:1.5'
     releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5'
     testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5'

--- a/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
@@ -616,7 +616,7 @@ public class AuthUI {
         /**
          * Enables or disables creating new accounts in the email sign in flow.
          * <p>
-         * <p>Account creation is enabled by default
+         * <p>Account creation is enabled by default.
          */
         public SignInIntentBuilder setAllowNewEmailAccounts(boolean enabled) {
             mAllowNewEmailAccounts = enabled;

--- a/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
@@ -636,7 +636,7 @@ public class AuthUI {
             return KickoffActivity.createIntent(mApp.getApplicationContext(), getFlowParams());
         }
 
-        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        @VisibleForTesting()
         public FlowParameters getFlowParams() {
             return new FlowParameters(mApp.getName(),
                                       new ArrayList<>(mProviders),

--- a/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
@@ -606,10 +606,20 @@ public class AuthUI {
         /**
          * Enables or disables the use of Smart Lock for Passwords in the sign in flow.
          * <p>
-         * <p>SmartLock is enabled by default
+         * <p>SmartLock is enabled by default.
          */
         public SignInIntentBuilder setIsSmartLockEnabled(boolean enabled) {
             mIsSmartLockEnabled = enabled;
+            return this;
+        }
+
+        /**
+         * Enables or disables creating new accounts in the email sign in flow.
+         * <p>
+         * <p>Account creation is enabled by default
+         */
+        public SignInIntentBuilder setAllowNewEmailAccounts(boolean enabled) {
+            mAllowNewEmailAccounts = enabled;
             return this;
         }
 
@@ -636,12 +646,5 @@ public class AuthUI {
                                       mIsSmartLockEnabled,
                                       mAllowNewEmailAccounts);
         }
-
-        public SignInIntentBuilder setAllowNewEmailAccounts(boolean enabled) {
-            mAllowNewEmailAccounts = enabled;
-            return this;
-        }
-
-
     }
 }


### PR DESCRIPTION
@samtstern Moved the `setAllowNewEmailAccounts` method to a nicer position and added documentation.

Updated butterknife: https://github.com/JakeWharton/butterknife/blob/master/CHANGELOG.md#version-851-2017-01-24.

Removed `otherwise = VisibleForTesting.PRIVATE` because I found out it was the default for `@VisibleForTesting()`.