### PR TITLE
Add documentation for `GoogleApiHelper#getSafeAutoManageId()` and do a teeny bit of cleanup in the auth README

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -217,7 +217,8 @@ startActivityForResult(
 
 #### Handling the sign-in response
 
-#####Response codes
+##### Response codes
+
 The authentication flow provides several response codes of which the most common are as follows:
 `ResultCodes.OK` if a user is signed in, `ResultCodes.CANCELLED` if the user manually canceled the sign in,
 `ResultCodes.NO_NETWORK` if sign in failed due to a lack of network connectivity,
@@ -344,6 +345,23 @@ AuthUI.getInstance()
         });
 ```
 
+### Using the `GoogleApiClient` in your own app
+
+FirebaseUI Auth heavily relies on the `GoogleApiClient` and its `enableAutoManage` method to
+help prevent memory leaks. However, using `enableAutoManage` can be risky because the method will throw
+an `IllegalStateException` if another `GoogleApiClient` is being managed with the same id.
+To help solve this problem, FirebaseUI provides a helper method to get a safe id that is
+not being used: `GoogleApiHelper#getSafeAutoManageId()`
+
+#### Example usage:
+
+```java
+new GoogleApiClient.Builder(mActivity)
+        .enableAutoManage(mActivity, GoogleApiHelper.getSafeAutoManageId(), null /* listener */)
+        .addApi(...)
+        .build()
+```
+
 ### Authentication flow chart
 
 The authentication flow implemented on Android is more complex than on other
@@ -352,7 +370,7 @@ represented in the following diagram:
 
 ![FirebaseUI authentication flow on Android](flow.png)
 
-### UI customization
+## UI customization
 
 To provide customization of the visual style of the activities that implement
 the flow, a new theme can be declared. Standard material design color
@@ -459,4 +477,4 @@ startActivityForResult(
 
 #### Twitter
 
-Twitter permissions can only be configured through Twitter's developer console.
+Twitter permissions can only be configured through [Twitter's developer console](https://apps.twitter.com/).

--- a/auth/README.md
+++ b/auth/README.md
@@ -345,13 +345,13 @@ AuthUI.getInstance()
         });
 ```
 
-### Using the `GoogleApiClient` in your own app
+### Using the `GoogleApiClient` in your own app with `enableAutoManage` 
 
 FirebaseUI Auth heavily relies on the `GoogleApiClient` and its `enableAutoManage` method to
 help prevent memory leaks. However, using `enableAutoManage` can be risky because the method will throw
 an `IllegalStateException` if another `GoogleApiClient` is being managed with the same id.
 To help solve this problem, FirebaseUI provides a helper method to get a safe id that is
-not being used: `GoogleApiHelper#getSafeAutoManageId()`
+not being used: `GoogleApiHelper#getSafeAutoManageId()`.
 
 #### Example usage:
 

--- a/auth/src/main/java/com/firebase/ui/auth/util/GoogleApiHelper.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/GoogleApiHelper.java
@@ -32,6 +32,10 @@ public abstract class GoogleApiHelper implements GoogleApiClient.ConnectionCallb
         mClient = builder.build();
     }
 
+    /**
+     * @return a safe id for {@link GoogleApiClient.Builder#enableAutoManage(FragmentActivity, int,
+     * GoogleApiClient.OnConnectionFailedListener)}
+     */
     public static int getSafeAutoManageId() {
         return SAFE_ID.getAndIncrement();
     }


### PR DESCRIPTION
@samtstern I recently added Firebase app indexing to my app and noticed that it was crashing if I tried to sign in or out. Turns out I was duplicating `enableAutoManage` ids with FirebaseUI so I think we should make `GoogleApiHelper#getSafeAutoManageId()` part of the public api so people can use it to get around this problem.