### PR TITLE
Fix crash because `onConnected` is called multiple times

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/util/GoogleApiHelper.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/GoogleApiHelper.java
@@ -42,6 +42,9 @@ public abstract class GoogleApiHelper implements GoogleApiClient.ConnectionCallb
 
     @Override
     public void onConnected(@Nullable Bundle bundle) {
+        // onConnected might be called multiple times, but we don't want to unregister listeners
+        // because extenders might be relying on each onConnected call. Instead, we just ignore future
+        // calls to onConnected or onConnectionFailed by using a `trySomething` strategy.
         mGoogleApiConnectionTask.trySetResult(bundle);
     }
 

--- a/auth/src/main/java/com/firebase/ui/auth/util/GoogleApiHelper.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/GoogleApiHelper.java
@@ -42,7 +42,7 @@ public abstract class GoogleApiHelper implements GoogleApiClient.ConnectionCallb
 
     @Override
     public void onConnected(@Nullable Bundle bundle) {
-        mGoogleApiConnectionTask.setResult(bundle);
+        mGoogleApiConnectionTask.trySetResult(bundle);
     }
 
     @Override
@@ -52,7 +52,7 @@ public abstract class GoogleApiHelper implements GoogleApiClient.ConnectionCallb
 
     @Override
     public void onConnectionFailed(@NonNull ConnectionResult result) {
-        mGoogleApiConnectionTask.setException(new ConnectException(result.toString()));
+        mGoogleApiConnectionTask.trySetException(new ConnectException(result.toString()));
     }
 
     protected static final class TaskResultCaptor<R extends Result> implements ResultCallback<R> {


### PR DESCRIPTION
Refactor mistake: I didn't notice that the old helper [removed the listeners](https://github.com/firebase/FirebaseUI-Android/blob/version-1.2.0-dev/auth/src/main/java/com/firebase/ui/auth/util/GoogleApiClientTaskHelper.java#L105). I think that method is flawed though because if `onConnectionFailed` is called and later on `onConnected` also gets called, an `IllegalStateException` will still be thrown.