### PR TITLE
Update Android Gradle plugin to 2.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-rc1'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         classpath 'com.google.gms:google-services:3.0.0'
         classpath 'io.fabric.tools:gradle:1.+'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'


### PR DESCRIPTION
The stable version of Android Studio 2.3.0 and the matching Android Gradle plugin `2.3.0` were released today.

https://android-developers.googleblog.com/2017/03/android-studio-2-3.html