### PR TITLE
Finish the KickOffActivity on dialog tap outside

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/KickoffActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/KickoffActivity.java
@@ -108,6 +108,12 @@ public class KickoffActivity extends HelperActivityBase {
         final FlowParameters flowParams = mActivityHelper.getFlowParams();
         AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.FirebaseUI_Dialog)
                 .setTitle(R.string.reauth_dialog_title)
+                .setOnCancelListener(new DialogInterface.OnCancelListener() {
+                    @Override
+                    public void onCancel(DialogInterface dialog) {
+                        finish(ResultCodes.CANCELED, new Intent());
+                    }
+                })
                 .setPositiveButton(R.string.sign_in_default, new OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {


### PR DESCRIPTION
Fixes an issue where tapping outside the reauth dialog would result in an invisible activity hanging around blocking clicks.