### PR TITLE
Add getSnapshots method to adapters

### DIFF
--- a/database/src/main/java/com/firebase/ui/database/FirebaseAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseAdapter.java
@@ -20,4 +20,6 @@ interface FirebaseAdapter<T> extends ChangeEventListener {
     T getItem(int position);
 
     DatabaseReference getRef(int position);
+
+    ObservableSnapshotArray<T> getSnapshots();
 }

--- a/database/src/main/java/com/firebase/ui/database/FirebaseListAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseListAdapter.java
@@ -113,6 +113,11 @@ public abstract class FirebaseListAdapter<T> extends BaseAdapter implements Fire
     }
 
     @Override
+    public ObservableSnapshotArray<T> getSnapshots() {
+        return mSnapshots;
+    }
+
+    @Override
     public int getCount() {
         return mSnapshots.size();
     }

--- a/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
@@ -133,6 +133,11 @@ public abstract class FirebaseRecyclerAdapter<T, VH extends RecyclerView.ViewHol
     }
 
     @Override
+    public ObservableSnapshotArray<T> getSnapshots() {
+        return mSnapshots;
+    }
+
+    @Override
     public int getItemCount() {
         return mSnapshots.size();
     }


### PR DESCRIPTION
@samtstern I think it would be really useful to have this available for when you are trying to get the `DataSnapshot`s outside of the adapter. For example, I have a method to add an item at the end of the list by priority. Since I don't update all refs when an item is deleted, I just get the highest priority + 1:
```java
public static int getHighestIntPriority(ObservableSnapshotArray snapshots) {
    int highest = 0;
    for (DataSnapshot snapshot : snapshots) {
        int priority = (int) snapshot.getPriority();
        if (priority > highest) highest = priority;
    }
    return highest;
}
```

This would be harder to do without an `Adapter#getSnapshots()` method easily available to retrieve the `FirebaseArray`.