### PR TITLE
Make protected fields final in adapters

### DIFF
--- a/database/src/main/java/com/firebase/ui/database/FirebaseListAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseListAdapter.java
@@ -27,9 +27,9 @@ import com.google.firebase.database.Query;
 public abstract class FirebaseListAdapter<T> extends BaseAdapter implements FirebaseAdapter<T> {
     private static final String TAG = "FirebaseListAdapter";
 
-    protected Activity mActivity;
-    protected ObservableSnapshotArray<T> mSnapshots;
-    protected int mLayout;
+    protected final Activity mActivity;
+    protected final ObservableSnapshotArray<T> mSnapshots;
+    protected final int mLayout;
 
     /**
      * @param activity    The {@link Activity} containing the {@link ListView}

--- a/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
@@ -31,9 +31,9 @@ public abstract class FirebaseRecyclerAdapter<T, VH extends RecyclerView.ViewHol
         extends RecyclerView.Adapter<VH> implements FirebaseAdapter<T> {
     private static final String TAG = "FirebaseRecyclerAdapter";
 
-    protected ObservableSnapshotArray<T> mSnapshots;
-    protected Class<VH> mViewHolderClass;
-    protected int mModelLayout;
+    protected final ObservableSnapshotArray<T> mSnapshots;
+    protected final Class<VH> mViewHolderClass;
+    protected final int mModelLayout;
 
     /**
      * @param snapshots       The data used to populate the adapter


### PR DESCRIPTION
@puf @samtstern Without this PR, devs could do stuff like this which would be nonsensical:
```java
new FirebaseRecyclerAdapter(...) {
    @Override
    protected void populateViewHolder(RecyclerView.ViewHolder holder, Object model, int position) {
        mSnapshots = new FirebaseArray<Team>(...);
        mViewHolderClass = null;
        mModelLayout = R.layout.new_layout;
    }
};