### PR TITLE
Fix NPE if status message is null in SignInDelegate

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/util/signincontainer/SignInDelegate.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/signincontainer/SignInDelegate.java
@@ -158,7 +158,7 @@ public class SignInDelegate extends SmartLockBase<CredentialRequestResult> {
                     Log.e(TAG, "Failed to send Credentials intent.", e);
                 }
             } else {
-                Log.e(TAG, status.getStatusMessage());
+                Log.e(TAG, "Status message:\n" + status.getStatusMessage());
             }
         }
         startAuthMethodChoice();


### PR DESCRIPTION
The easy solution is to add a descriptive string in front of the `getStatusMessage` call and just let Java concat the two strings for us, thus guaranteeing that the end result won't be `null`. The other solution would be to add a null check and log a different message, though I'm not sure what we would say.

The crash:
```
Exception java.lang.NullPointerException: println needs a message

android.util.Log.println_native_inner (Log.java)
android.util.Log.println_native (Log.java:290)
android.util.Log.e (Log.java:416)
com.firebase.ui.auth.util.signincontainer.SignInDelegate.onResult (SignInDelegate.java:161)
com.firebase.ui.auth.util.signincontainer.SignInDelegate.onResult (SignInDelegate.java:59)
com.google.android.gms.internal.zzaaf$zza.handleMessage (zzaaf.java)
android.os.Handler.dispatchMessage (Handler.java:102)
android.os.Looper.loop (Looper.java:136)
android.app.ActivityThread.main (ActivityThread.java:5102)
java.lang.reflect.Method.invokeNative (Method.java)
java.lang.reflect.Method.invoke (Method.java:515)
com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run (ZygoteInit.java:785)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:601)
dalvik.system.NativeStart.main (NativeStart.java)
```