### PR TITLE
Add hint that a DatabaseReference is also a Query

### DIFF
--- a/database/src/main/java/com/firebase/ui/database/FirebaseIndexListAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseIndexListAdapter.java
@@ -14,7 +14,8 @@ public abstract class FirebaseIndexListAdapter<T> extends FirebaseListAdapter<T>
      *                 model class
      * @param keyQuery The Firebase location containing the list of keys to be found in {@code
      *                 dataRef}. Can also be a slice of a location, using some combination of {@code
-     *                 limit()}, {@code startAt()}, and {@code endAt()}.
+     *                 limit()}, {@code startAt()}, and {@code endAt()}. <b>Note, this can also be a
+     *                 {@link DatabaseReference}.</b>
      * @param dataRef  The Firebase location to watch for data changes. Each key key found at {@code
      *                 keyQuery}'s location represents a list item in the {@link ListView}.
      * @see FirebaseIndexListAdapter#FirebaseIndexListAdapter(Activity, SnapshotParser, int, Query,

--- a/database/src/main/java/com/firebase/ui/database/FirebaseIndexRecyclerAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseIndexRecyclerAdapter.java
@@ -14,7 +14,8 @@ public abstract class FirebaseIndexRecyclerAdapter<T, VH extends RecyclerView.Vi
      *                 model class
      * @param keyQuery The Firebase location containing the list of keys to be found in {@code
      *                 dataRef}. Can also be a slice of a location, using some combination of {@code
-     *                 limit()}, {@code startAt()}, and {@code endAt()}.
+     *                 limit()}, {@code startAt()}, and {@code endAt()}. <b>Note, this can also be a
+     *                 {@link DatabaseReference}.</b>
      * @param dataRef  The Firebase location to watch for data changes. Each key key found at {@code
      *                 keyQuery}'s location represents a list item in the {@link RecyclerView}.
      * @see FirebaseRecyclerAdapter#FirebaseRecyclerAdapter(ObservableSnapshotArray, int, Class)

--- a/database/src/main/java/com/firebase/ui/database/FirebaseListAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseListAdapter.java
@@ -53,7 +53,7 @@ public abstract class FirebaseListAdapter<T> extends BaseAdapter implements Fire
      *               class
      * @param query  The Firebase location to watch for data changes. Can also be a slice of a
      *               location, using some combination of {@code limit()}, {@code startAt()}, and
-     *               {@code endAt()}.
+     *               {@code endAt()}. <b>Note, this can also be a {@link DatabaseReference}.</b>
      * @see #FirebaseListAdapter(Activity, ObservableSnapshotArray, int)
      */
     public FirebaseListAdapter(Activity activity,

--- a/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
@@ -58,7 +58,7 @@ public abstract class FirebaseRecyclerAdapter<T, VH extends RecyclerView.ViewHol
      *               class
      * @param query  The Firebase location to watch for data changes. Can also be a slice of a
      *               location, using some combination of {@code limit()}, {@code startAt()}, and
-     *               {@code endAt()}.
+     *               {@code endAt()}. <b>Note, this can also be a {@link DatabaseReference}.</b>
      * @see #FirebaseRecyclerAdapter(ObservableSnapshotArray, int, Class)
      */
     public FirebaseRecyclerAdapter(SnapshotParser<T> parser,


### PR DESCRIPTION
@samtstern I would like to compromise on @puf's proposal (#642). Currently, we already have 3 constructors with 2 of them using queries. This would mean we'll have to add two more "useless" constructors which is 😢. Instead, I propose we add a bolded note in the javadoc for each constructor that has a `Query` explaining that you can also pass in a `DatabaseReference`. Here's what it looks like:

![image](https://cloud.githubusercontent.com/assets/9490724/25502772/e7b6afba-2b4c-11e7-8d4f-2da75eca7aa8.png)

The `README` has also be revamped and clearly shows that you can pass in a ref [here](https://github.com/firebase/FirebaseUI-Android/blob/version-2.0.0-dev/database/README.md#create-custom-firebaserecycleradapter-subclass):

![image](https://cloud.githubusercontent.com/assets/9490724/25503244/780bf024-2b4e-11e7-888e-f6dd691244cc.png)
