### PR TITLE
Fix displayed provider order being the inverse of the order in which they were supplied

### DIFF
--- a/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
@@ -182,7 +182,7 @@ public class AuthUiActivity extends AppCompatActivity {
                 AuthUI.getInstance().createSignInIntentBuilder()
                         .setTheme(getSelectedTheme())
                         .setLogo(getSelectedLogo())
-                        .setProviders(getSelectedProviders())
+                        .setAvailableProviders(getSelectedProviders())
                         .setTosUrl(getSelectedTosUrl())
                         .setIsSmartLockEnabled(mEnableSmartLock.isChecked())
                         .setAllowNewEmailAccounts(mAllowNewEmailAccounts.isChecked())
@@ -292,12 +292,11 @@ public class AuthUiActivity extends AppCompatActivity {
     private List<IdpConfig> getSelectedProviders() {
         List<IdpConfig> selectedProviders = new ArrayList<>();
 
-        if (mUseEmailProvider.isChecked()) {
-            selectedProviders.add(new IdpConfig.Builder(AuthUI.EMAIL_PROVIDER).build());
-        }
-
-        if (mUseTwitterProvider.isChecked()) {
-            selectedProviders.add(new IdpConfig.Builder(AuthUI.TWITTER_PROVIDER).build());
+        if (mUseGoogleProvider.isChecked()) {
+            selectedProviders.add(
+                    new IdpConfig.Builder(AuthUI.GOOGLE_PROVIDER)
+                            .setPermissions(getGooglePermissions())
+                            .build());
         }
 
         if (mUseFacebookProvider.isChecked()) {
@@ -307,11 +306,12 @@ public class AuthUiActivity extends AppCompatActivity {
                             .build());
         }
 
-        if (mUseGoogleProvider.isChecked()) {
-            selectedProviders.add(
-                    new IdpConfig.Builder(AuthUI.GOOGLE_PROVIDER)
-                            .setPermissions(getGooglePermissions())
-                            .build());
+        if (mUseTwitterProvider.isChecked()) {
+            selectedProviders.add(new IdpConfig.Builder(AuthUI.TWITTER_PROVIDER).build());
+        }
+
+        if (mUseEmailProvider.isChecked()) {
+            selectedProviders.add(new IdpConfig.Builder(AuthUI.EMAIL_PROVIDER).build());
         }
 
         return selectedProviders;

--- a/app/src/main/java/com/firebase/uidemo/auth/SignedInActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/auth/SignedInActivity.java
@@ -117,7 +117,7 @@ public class SignedInActivity extends AppCompatActivity {
     public void reauthenticate() {
         Intent reauthIntent = AuthUI.getInstance()
                 .createReauthIntentBuilder()
-                .setProviders(mSignedInConfig.providerInfo)
+                .setAvailableProviders(mSignedInConfig.providerInfo)
                 .setIsSmartLockEnabled(mSignedInConfig.isSmartLockEnabled)
                 .setLogo(mSignedInConfig.logo)
                 .setTheme(mSignedInConfig.theme)

--- a/auth/README.md
+++ b/auth/README.md
@@ -428,8 +428,8 @@ startActivityForResult(
     AuthUI.getInstance()
         .createSignInIntentBuilder()
         .setAvailableProviders(Arrays.asList(new IdpConfig.Builder(AuthUI.EMAIL_PROVIDER).build(),
-                               googleIdp,
-                               new IdpConfig.Builder(AuthUI.FACEBOOK_PROVIDER).build()))
+                                             googleIdp,
+                                             new IdpConfig.Builder(AuthUI.FACEBOOK_PROVIDER).build()))
         .build(),
     RC_SIGN_IN);
 ```
@@ -454,7 +454,7 @@ startActivityForResult(
     AuthUI.getInstance()
         .createSignInIntentBuilder()
         .setAvailableProviders(Arrays.asList(new AuthUI.IdpConfig.Builder(AuthUI.EMAIL_PROVIDER).build(),
-                               facebookIdp))
+                                             facebookIdp))
         .build(),
     RC_SIGN_IN);
 ```

--- a/auth/README.md
+++ b/auth/README.md
@@ -161,16 +161,17 @@ is returned to your app in onActivityResult(...). See the [response codes](#resp
 details on receiving the results of the sign in flow.
 
 You can enable sign-in providers like Google Sign-In or Facebook Log In by calling the
-`setProviders` method:
+`setAvailableProviders` method:
 
 ```java
 startActivityForResult(
     AuthUI.getInstance()
         .createSignInIntentBuilder()
-        .setProviders(Arrays.asList(new AuthUI.IdpConfig.Builder(AuthUI.EMAIL_PROVIDER).build(),
-                                    new AuthUI.IdpConfig.Builder(AuthUI.GOOGLE_PROVIDER).build(),
-                                    new AuthUI.IdpConfig.Builder(AuthUI.FACEBOOK_PROVIDER).build(),
-                                    new AuthUI.IdpConfig.Builder(AuthUI.TWITTER_PROVIDER).build()))
+        .setAvailableProviders(
+                Arrays.asList(new AuthUI.IdpConfig.Builder(AuthUI.EMAIL_PROVIDER).build(),
+                              new AuthUI.IdpConfig.Builder(AuthUI.GOOGLE_PROVIDER).build(),
+                              new AuthUI.IdpConfig.Builder(AuthUI.FACEBOOK_PROVIDER).build(),
+                              new AuthUI.IdpConfig.Builder(AuthUI.TWITTER_PROVIDER).build()))
         .build(),
     RC_SIGN_IN);
 ```
@@ -181,7 +182,7 @@ If a terms of service URL and a custom theme are required:
 startActivityForResult(
     AuthUI.getInstance()
         .createSignInIntentBuilder()
-        .setProviders(...)
+        .setAvailableProviders(...)
         .setTosUrl("https://superapp.example.com/terms-of-service.html")
         .setTheme(R.style.SuperAppTheme)
         .build(),
@@ -426,9 +427,9 @@ AuthUI.IdpConfig googleIdp = new AuthUI.IdpConfig.Builder(AuthUI.GOOGLE_PROVIDER
 startActivityForResult(
     AuthUI.getInstance()
         .createSignInIntentBuilder()
-        .setProviders(Arrays.asList(new IdpConfig.Builder(AuthUI.EMAIL_PROVIDER).build(),
-                                    googleIdp,
-                                    new IdpConfig.Builder(AuthUI.FACEBOOK_PROVIDER).build()))
+        .setAvailableProviders(Arrays.asList(new IdpConfig.Builder(AuthUI.EMAIL_PROVIDER).build(),
+                               googleIdp,
+                               new IdpConfig.Builder(AuthUI.FACEBOOK_PROVIDER).build()))
         .build(),
     RC_SIGN_IN);
 ```
@@ -452,8 +453,8 @@ AuthUI.IdpConfig facebookIdp = new AuthUI.IdpConfig.Builder(AuthUI.FACEBOOK_PROV
 startActivityForResult(
     AuthUI.getInstance()
         .createSignInIntentBuilder()
-        .setProviders(Arrays.asList(new AuthUI.IdpConfig.Builder(AuthUI.EMAIL_PROVIDER).build(),
-                                    facebookIdp))
+        .setAvailableProviders(Arrays.asList(new AuthUI.IdpConfig.Builder(AuthUI.EMAIL_PROVIDER).build(),
+                               facebookIdp))
         .build(),
     RC_SIGN_IN);
 ```

--- a/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
@@ -527,7 +527,14 @@ public class AuthUI {
         @Deprecated
         public T setProviders(@NonNull List<IdpConfig> idpConfigs) {
             setAvailableProviders(idpConfigs);
+
+            // Ensure email provider is at the bottom to keep backwards compatibility
+            int emailProviderIndex = mProviders.indexOf(new IdpConfig.Builder(EMAIL_PROVIDER).build());
+            if (emailProviderIndex != -1) {
+                mProviders.add(0, mProviders.remove(emailProviderIndex));
+            }
             Collections.reverse(mProviders);
+
             return (T) this;
         }
 

--- a/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
@@ -76,22 +76,22 @@ public class AuthUI {
 
     /**
      * Provider identifier for email and password credentials, for use with
-     * {@link SignInIntentBuilder#setProviders}.
+     * {@link SignInIntentBuilder#setAvailableProviders(List)}.
      */
     public static final String EMAIL_PROVIDER = EmailAuthProvider.PROVIDER_ID;
 
     /**
-     * Provider identifier for Google, for use with {@link SignInIntentBuilder#setProviders}.
+     * Provider identifier for Google, for use with {@link SignInIntentBuilder#setAvailableProviders(List)}.
      */
     public static final String GOOGLE_PROVIDER = GoogleAuthProvider.PROVIDER_ID;
 
     /**
-     * Provider identifier for Facebook, for use with {@link SignInIntentBuilder#setProviders}.
+     * Provider identifier for Facebook, for use with {@link SignInIntentBuilder#setAvailableProviders(List)}.
      */
     public static final String FACEBOOK_PROVIDER = FacebookAuthProvider.PROVIDER_ID;
 
     /**
-     * Provider identifier for Twitter, for use with {@link SignInIntentBuilder#setProviders}.
+     * Provider identifier for Twitter, for use with {@link SignInIntentBuilder#setAvailableProviders(List)}.
      */
     public static final String TWITTER_PROVIDER = TwitterAuthProvider.PROVIDER_ID;
 
@@ -493,9 +493,31 @@ public class AuthUI {
          * @param idpConfigs a list of {@link IdpConfig}s, where each {@link IdpConfig} contains the
          *                   configuration parameters for the IDP.
          * @see IdpConfig
+         * @deprecated because the order in which providers were displayed was the inverse of the
+         * order in which they were supplied. Use {@link #setAvailableProviders(List)} to display
+         * the providers in the order in which they were supplied.
          */
+        @Deprecated
         public T setProviders(@NonNull List<IdpConfig> idpConfigs) {
+            setAvailableProviders(idpConfigs);
+            Collections.reverse(mProviders);
+            return (T) this;
+        }
+
+        /**
+         * Specified the set of supported authentication providers. At least one provider must
+         * be specified. There may only be one instance of each provider.
+         * <p>
+         * <p>If no providers are explicitly specified by calling this method, then the email
+         * provider is the default supported provider.
+         *
+         * @param idpConfigs a list of {@link IdpConfig}s, where each {@link IdpConfig} contains the
+         *                   configuration parameters for the IDP.
+         * @see IdpConfig
+         */
+        public T setAvailableProviders(@NonNull List<IdpConfig> idpConfigs) {
             mProviders.clear();
+
             for (IdpConfig config : idpConfigs) {
                 if (mProviders.contains(config)) {
                     throw new IllegalArgumentException("Each provider can only be set once. "
@@ -505,6 +527,7 @@ public class AuthUI {
                     mProviders.add(config);
                 }
             }
+
             return (T) this;
         }
 

--- a/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
@@ -493,27 +493,6 @@ public class AuthUI {
          * @param idpConfigs a list of {@link IdpConfig}s, where each {@link IdpConfig} contains the
          *                   configuration parameters for the IDP.
          * @see IdpConfig
-         * @deprecated because the order in which providers were displayed was the inverse of the
-         * order in which they were supplied. Use {@link #setAvailableProviders(List)} to display
-         * the providers in the order in which they were supplied.
-         */
-        @Deprecated
-        public T setProviders(@NonNull List<IdpConfig> idpConfigs) {
-            setAvailableProviders(idpConfigs);
-            Collections.reverse(mProviders);
-            return (T) this;
-        }
-
-        /**
-         * Specified the set of supported authentication providers. At least one provider must
-         * be specified. There may only be one instance of each provider.
-         * <p>
-         * <p>If no providers are explicitly specified by calling this method, then the email
-         * provider is the default supported provider.
-         *
-         * @param idpConfigs a list of {@link IdpConfig}s, where each {@link IdpConfig} contains the
-         *                   configuration parameters for the IDP.
-         * @see IdpConfig
          */
         public T setAvailableProviders(@NonNull List<IdpConfig> idpConfigs) {
             mProviders.clear();
@@ -528,6 +507,27 @@ public class AuthUI {
                 }
             }
 
+            return (T) this;
+        }
+
+        /**
+         * Specified the set of supported authentication providers. At least one provider must
+         * be specified. There may only be one instance of each provider.
+         * <p>
+         * <p>If no providers are explicitly specified by calling this method, then the email
+         * provider is the default supported provider.
+         *
+         * @param idpConfigs a list of {@link IdpConfig}s, where each {@link IdpConfig} contains the
+         *                   configuration parameters for the IDP.
+         * @see IdpConfig
+         * @deprecated because the order in which providers were displayed was the inverse of the
+         * order in which they were supplied. Use {@link #setAvailableProviders(List)} to display
+         * the providers in the order in which they were supplied.
+         */
+        @Deprecated
+        public T setProviders(@NonNull List<IdpConfig> idpConfigs) {
+            setAvailableProviders(idpConfigs);
+            Collections.reverse(mProviders);
             return (T) this;
         }
 

--- a/auth/src/main/java/com/firebase/ui/auth/provider/EmailProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/EmailProvider.java
@@ -3,6 +3,7 @@ package com.firebase.ui.auth.provider;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.LayoutRes;
 
 import com.firebase.ui.auth.R;
 import com.firebase.ui.auth.ResultCodes;
@@ -29,6 +30,12 @@ public class EmailProvider implements Provider {
     @Override
     public String getProviderId() {
         return EmailAuthProvider.PROVIDER_ID;
+    }
+
+    @Override
+    @LayoutRes
+    public int getButtonLayout() {
+        return R.layout.provider_button_email;
     }
 
     @Override

--- a/auth/src/main/java/com/firebase/ui/auth/provider/EmailProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/EmailProvider.java
@@ -1,0 +1,47 @@
+package com.firebase.ui.auth.provider;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+
+import com.firebase.ui.auth.R;
+import com.firebase.ui.auth.ResultCodes;
+import com.firebase.ui.auth.ui.BaseHelper;
+import com.firebase.ui.auth.ui.email.RegisterEmailActivity;
+import com.google.firebase.auth.EmailAuthProvider;
+
+public class EmailProvider implements Provider {
+    private static final int RC_EMAIL_FLOW = 2;
+
+    private Activity mActivity;
+    private BaseHelper mHelper;
+
+    public EmailProvider(Activity activity, BaseHelper helper) {
+        mActivity = activity;
+        mHelper = helper;
+    }
+
+    @Override
+    public String getName(Context context) {
+        return context.getString(R.string.provider_name_email);
+    }
+
+    @Override
+    public String getProviderId() {
+        return EmailAuthProvider.PROVIDER_ID;
+    }
+
+    @Override
+    public void startLogin(Activity activity) {
+        activity.startActivityForResult(
+                RegisterEmailActivity.createIntent(activity, mHelper.getFlowParams()),
+                RC_EMAIL_FLOW);
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (resultCode == ResultCodes.OK) {
+            mHelper.finishActivity(mActivity, ResultCodes.OK, data);
+        }
+    }
+}

--- a/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
@@ -83,7 +83,7 @@ public class FacebookProvider implements IdpProvider, FacebookCallback<LoginResu
 
     @Override
     public String getName(Context context) {
-        return context.getResources().getString(R.string.idp_name_facebook);
+        return context.getString(R.string.idp_name_facebook);
     }
 
     @Override

--- a/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
@@ -18,6 +18,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.LayoutRes;
 import android.support.annotation.StyleRes;
 import android.util.Log;
 
@@ -89,6 +90,12 @@ public class FacebookProvider implements IdpProvider, FacebookCallback<LoginResu
     @Override
     public String getProviderId() {
         return FacebookAuthProvider.PROVIDER_ID;
+    }
+
+    @Override
+    @LayoutRes
+    public int getButtonLayout() {
+        return R.layout.idp_button_facebook;
     }
 
     @Override

--- a/auth/src/main/java/com/firebase/ui/auth/provider/GoogleProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/GoogleProvider.java
@@ -18,6 +18,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentActivity;
@@ -105,6 +106,12 @@ public class GoogleProvider implements IdpProvider, GoogleApiClient.OnConnection
     @Override
     public String getProviderId() {
         return GoogleAuthProvider.PROVIDER_ID;
+    }
+
+    @Override
+    @LayoutRes
+    public int getButtonLayout() {
+        return R.layout.idp_button_google;
     }
 
     @Override

--- a/auth/src/main/java/com/firebase/ui/auth/provider/GoogleProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/GoogleProvider.java
@@ -97,8 +97,9 @@ public class GoogleProvider implements IdpProvider, GoogleApiClient.OnConnection
         return builder.build();
     }
 
+    @Override
     public String getName(Context context) {
-        return context.getResources().getString(R.string.idp_name_google);
+        return context.getString(R.string.idp_name_google);
     }
 
     @Override

--- a/auth/src/main/java/com/firebase/ui/auth/provider/IdpProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/IdpProvider.java
@@ -14,27 +14,12 @@
 
 package com.firebase.ui.auth.provider;
 
-import android.app.Activity;
-import android.content.Context;
-import android.content.Intent;
 import android.os.Bundle;
 
 import com.firebase.ui.auth.IdpResponse;
 
-public interface IdpProvider {
-
-    /**
-     * Retrieves the name of the IDP, for display on-screen.
-     */
-    String getName(Context context);
-
-    String getProviderId();
-
+public interface IdpProvider extends Provider {
     void setAuthenticationCallback(IdpCallback callback);
-
-    void onActivityResult(int requestCode, int resultCode, Intent data);
-
-    void startLogin(Activity activity);
 
     interface IdpCallback {
         void onSuccess(IdpResponse idpResponse);

--- a/auth/src/main/java/com/firebase/ui/auth/provider/Provider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/Provider.java
@@ -5,9 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 
 public interface Provider {
-    /**
-     * Retrieves the name of the IDP, for display on-screen.
-     */
+    /** Retrieves the name of the IDP, for display on-screen. */
     String getName(Context context);
 
     String getProviderId();

--- a/auth/src/main/java/com/firebase/ui/auth/provider/Provider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/Provider.java
@@ -1,0 +1,18 @@
+package com.firebase.ui.auth.provider;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+
+public interface Provider {
+    /**
+     * Retrieves the name of the IDP, for display on-screen.
+     */
+    String getName(Context context);
+
+    String getProviderId();
+
+    void startLogin(Activity activity);
+
+    void onActivityResult(int requestCode, int resultCode, Intent data);
+}

--- a/auth/src/main/java/com/firebase/ui/auth/provider/Provider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/Provider.java
@@ -3,6 +3,7 @@ package com.firebase.ui.auth.provider;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.LayoutRes;
 
 import com.google.firebase.auth.GoogleAuthProvider;
 
@@ -12,6 +13,10 @@ public interface Provider {
 
     /** Retrieves the id of the IDP, e.g. {@link GoogleAuthProvider#PROVIDER_ID}. */
     String getProviderId();
+
+    /** Retrieves the layout id of the button to inflate and/or set a click listener. */
+    @LayoutRes
+    int getButtonLayout();
 
     /** Start the login process for the IDP, e.g. show the Google sign-in activity. */
     void startLogin(Activity activity);

--- a/auth/src/main/java/com/firebase/ui/auth/provider/Provider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/Provider.java
@@ -4,13 +4,21 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 
+import com.google.firebase.auth.GoogleAuthProvider;
+
 public interface Provider {
     /** Retrieves the name of the IDP, for display on-screen. */
     String getName(Context context);
 
+    /** Retrieves the id of the IDP, e.g. {@link GoogleAuthProvider#PROVIDER_ID}. */
     String getProviderId();
 
+    /** Start the login process for the IDP, e.g. show the Google sign-in activity. */
     void startLogin(Activity activity);
 
+    /**
+     * Handle the sign result by either finishing the calling activity or sending an {@link
+     * IdpProvider.IdpCallback} response.
+     */
     void onActivityResult(int requestCode, int resultCode, Intent data);
 }

--- a/auth/src/main/java/com/firebase/ui/auth/provider/TwitterProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/TwitterProvider.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.LayoutRes;
 import android.util.Log;
 
 import com.firebase.ui.auth.IdpResponse;
@@ -55,6 +56,12 @@ public class TwitterProvider extends Callback<TwitterSession> implements IdpProv
     @Override
     public String getProviderId() {
         return TwitterAuthProvider.PROVIDER_ID;
+    }
+
+    @Override
+    @LayoutRes
+    public int getButtonLayout() {
+        return R.layout.idp_button_twitter;
     }
 
     @Override

--- a/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
@@ -140,6 +140,7 @@ public class AuthMethodPickerActivity extends AppCompatBase
                     }
                 });
                 provider.setAuthenticationCallback(this);
+                // Account for the email provider which should always be at the bottom
                 btnHolder.addView(loginButton, btnHolder.getChildCount() - 1);
             }
         }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
@@ -140,7 +140,7 @@ public class AuthMethodPickerActivity extends AppCompatBase
                     }
                 });
                 provider.setAuthenticationCallback(this);
-                btnHolder.addView(loginButton, 0);
+                btnHolder.addView(loginButton, btnHolder.getChildCount() - 1);
             }
         }
     }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
@@ -43,10 +43,6 @@ import com.firebase.ui.auth.ui.TaskFailureLogger;
 import com.firebase.ui.auth.ui.email.RegisterEmailActivity;
 import com.firebase.ui.auth.util.signincontainer.SaveSmartLock;
 import com.google.firebase.auth.AuthCredential;
-import com.google.firebase.auth.EmailAuthProvider;
-import com.google.firebase.auth.FacebookAuthProvider;
-import com.google.firebase.auth.GoogleAuthProvider;
-import com.google.firebase.auth.TwitterAuthProvider;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -112,41 +108,20 @@ public class AuthMethodPickerActivity extends AppCompatBase implements IdpCallba
 
         ViewGroup btnHolder = (ViewGroup) findViewById(R.id.btn_holder);
         for (final Provider provider : mProviders) {
-            View loginButton = null;
-            switch (provider.getProviderId()) {
-                case GoogleAuthProvider.PROVIDER_ID:
-                    loginButton = getLayoutInflater()
-                            .inflate(R.layout.idp_button_google, btnHolder, false);
-                    break;
-                case FacebookAuthProvider.PROVIDER_ID:
-                    loginButton = getLayoutInflater()
-                            .inflate(R.layout.idp_button_facebook, btnHolder, false);
-                    break;
-                case TwitterAuthProvider.PROVIDER_ID:
-                    loginButton = getLayoutInflater()
-                            .inflate(R.layout.idp_button_twitter, btnHolder, false);
-                    break;
-                case EmailAuthProvider.PROVIDER_ID:
-                    loginButton = getLayoutInflater()
-                            .inflate(R.layout.provider_button_email, btnHolder, false);
-                    break;
-                default:
-                    Log.e(TAG, "No button for provider " + provider.getProviderId());
-            }
+            View loginButton = getLayoutInflater()
+                    .inflate(provider.getButtonLayout(), btnHolder, false);
 
-            if (loginButton != null) {
-                loginButton.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View view) {
-                        mActivityHelper.showLoadingDialog(R.string.progress_dialog_loading);
-                        provider.startLogin(AuthMethodPickerActivity.this);
-                    }
-                });
-                if (provider instanceof IdpProvider) {
-                    ((IdpProvider) provider).setAuthenticationCallback(this);
+            loginButton.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    mActivityHelper.showLoadingDialog(R.string.progress_dialog_loading);
+                    provider.startLogin(AuthMethodPickerActivity.this);
                 }
-                btnHolder.addView(loginButton);
+            });
+            if (provider instanceof IdpProvider) {
+                ((IdpProvider) provider).setAuthenticationCallback(this);
             }
+            btnHolder.addView(loginButton);
         }
     }
 

--- a/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
@@ -114,7 +114,9 @@ public class AuthMethodPickerActivity extends AppCompatBase implements IdpCallba
             loginButton.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {
-                    mActivityHelper.showLoadingDialog(R.string.progress_dialog_loading);
+                    if (provider instanceof IdpProvider) {
+                        mActivityHelper.showLoadingDialog(R.string.progress_dialog_loading);
+                    }
                     provider.startLogin(AuthMethodPickerActivity.this);
                 }
             });

--- a/auth/src/main/res/layout-land/auth_method_picker_layout.xml
+++ b/auth/src/main/res/layout-land/auth_method_picker_layout.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:baselineAligned="false"
@@ -13,7 +13,7 @@
         layout="@layout/include_auth_method_picker_logo"
         android:layout_width="0dp"
         android:layout_height="match_parent"
-        android:layout_weight="1.0" />
+        android:layout_weight="1.0"/>
 
     <FrameLayout
         android:layout_width="0dp"
@@ -26,16 +26,7 @@
             style="@style/FirebaseUI.AuthMethodPicker.ButtonHolder"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:paddingTop="@dimen/auth_method_button_marginBottom">
-
-            <Button
-                android:id="@+id/email_provider"
-                style="@style/FirebaseUI.Button.AccountChooser.EmailButton"
-                android:text="@string/sign_in_with_email"
-                android:visibility="gone"
-                tools:visibility="visible" />
-
-        </LinearLayout>
+            android:paddingTop="@dimen/auth_method_button_marginBottom"/>
 
     </FrameLayout>
 

--- a/auth/src/main/res/layout/auth_method_picker_layout.xml
+++ b/auth/src/main/res/layout/auth_method_picker_layout.xml
@@ -1,27 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:tools="http://schemas.android.com/tools"
     android:clipChildren="false"
     android:clipToPadding="false"
     android:gravity="center|bottom"
     android:orientation="vertical">
 
-    <include layout="@layout/include_auth_method_picker_logo" />
+    <include layout="@layout/include_auth_method_picker_logo"/>
 
     <LinearLayout
         android:id="@+id/btn_holder"
         style="@style/FirebaseUI.AuthMethodPicker.ButtonHolder.Portrait"
-        android:layout_height="wrap_content">
-
-        <Button
-            android:id="@+id/email_provider"
-            style="@style/FirebaseUI.Button.AccountChooser.EmailButton"
-            android:text="@string/sign_in_with_email"
-            android:visibility="gone"
-            tools:visibility="visible"/>
-
-    </LinearLayout>
+        android:layout_height="wrap_content"/>
 
 </LinearLayout>

--- a/auth/src/main/res/layout/idp_button_facebook.xml
+++ b/auth/src/main/res/layout/idp_button_facebook.xml
@@ -1,5 +1,7 @@
 <Button
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/facebook_button"
     style="@style/FirebaseUI.Button.AccountChooser.FacebookButton"
     android:text="@string/sign_in_with_facebook"
-    android:id="@+id/facebook_button"/>
+    tools:ignore="UnusedIds"/> <!-- Used in tests -->

--- a/auth/src/main/res/layout/idp_button_google.xml
+++ b/auth/src/main/res/layout/idp_button_google.xml
@@ -1,5 +1,7 @@
 <Button
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/google_button"
     style="@style/FirebaseUI.Button.AccountChooser.GoogleButton"
     android:text="@string/sign_in_with_google"
-    android:id="@+id/google_button"/>
+    tools:ignore="UnusedIds"/> <!-- Used in tests -->

--- a/auth/src/main/res/layout/idp_button_twitter.xml
+++ b/auth/src/main/res/layout/idp_button_twitter.xml
@@ -1,5 +1,7 @@
 <Button
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/twitter_button"
     style="@style/FirebaseUI.Button.AccountChooser.TwitterButton"
     android:text="@string/sign_in_with_twitter"
-    android:id="@+id/twitter_button"/>
+    tools:ignore="UnusedIds"/> <!-- Used in tests -->

--- a/auth/src/main/res/layout/provider_button_email.xml
+++ b/auth/src/main/res/layout/provider_button_email.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Button
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/email_button"
+    style="@style/FirebaseUI.Button.AccountChooser.EmailButton"
+    android:text="@string/sign_in_with_email"
+    tools:ignore="UnusedIds"/> <!-- Used in tests -->

--- a/auth/src/main/res/values/strings.xml
+++ b/auth/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="idp_name_google">Google</string>
     <string name="idp_name_facebook">Facebook</string>
     <string name="idp_name_twitter">Twitter</string>
+    <string name="provider_name_email">Email</string>
 
     <!-- Auth method picker -->
     <string name="sign_in_with_google">Sign in with Google</string>

--- a/auth/src/test/java/com/firebase/ui/auth/AuthUITest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/AuthUITest.java
@@ -70,7 +70,7 @@ public class AuthUITest {
     public void testCreateStartIntent_shouldOnlyAllowOneInstanceOfAnIdp() {
         SignInIntentBuilder startIntent =
                 AuthUI.getInstance(mFirebaseApp).createSignInIntentBuilder();
-        startIntent.setProviders(
+        startIntent.setAvailableProviders(
                 Arrays.asList(new IdpConfig.Builder(AuthUI.EMAIL_PROVIDER).build(),
                               new IdpConfig.Builder(AuthUI.EMAIL_PROVIDER).build()));
     }
@@ -78,9 +78,10 @@ public class AuthUITest {
     @Test
     public void testCreatingStartIntent() {
         FlowParameters flowParameters = AuthUI.getInstance(mFirebaseApp).createSignInIntentBuilder()
-                .setProviders(Arrays.asList(new IdpConfig.Builder(AuthUI.EMAIL_PROVIDER).build(),
-                                            new IdpConfig.Builder(AuthUI.GOOGLE_PROVIDER).build(),
-                                            new IdpConfig.Builder(AuthUI.FACEBOOK_PROVIDER).build()))
+                .setAvailableProviders(
+                        Arrays.asList(new IdpConfig.Builder(AuthUI.EMAIL_PROVIDER).build(),
+                                      new IdpConfig.Builder(AuthUI.GOOGLE_PROVIDER).build(),
+                                      new IdpConfig.Builder(AuthUI.FACEBOOK_PROVIDER).build()))
                 .setTosUrl(TestConstants.TOS_URL)
                 .build()
                 .getParcelableExtra(ExtraConstants.EXTRA_FLOW_PARAMS);

--- a/auth/src/test/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivityTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivityTest.java
@@ -97,8 +97,6 @@ public class AuthMethodPickerActivityTest {
         assertEquals(providers.size(),
                      ((LinearLayout) authMethodPickerActivity.findViewById(R.id.btn_holder))
                              .getChildCount());
-        Button emailButton = (Button) authMethodPickerActivity.findViewById(R.id.email_button);
-        assertEquals(View.GONE, emailButton.getVisibility());
     }
 
     @Test

--- a/auth/src/test/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivityTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivityTest.java
@@ -81,7 +81,7 @@ public class AuthMethodPickerActivityTest {
         assertEquals(providers.size(),
                      ((LinearLayout) authMethodPickerActivity.findViewById(R.id.btn_holder))
                              .getChildCount());
-        Button emailButton = (Button) authMethodPickerActivity.findViewById(R.id.email_provider);
+        Button emailButton = (Button) authMethodPickerActivity.findViewById(R.id.email_button);
         assertEquals(View.VISIBLE, emailButton.getVisibility());
     }
 
@@ -94,10 +94,10 @@ public class AuthMethodPickerActivityTest {
 
         AuthMethodPickerActivity authMethodPickerActivity = createActivity(providers);
 
-        assertEquals(providers.size() + 1, // plus one due to the invisible email button
+        assertEquals(providers.size(),
                      ((LinearLayout) authMethodPickerActivity.findViewById(R.id.btn_holder))
                              .getChildCount());
-        Button emailButton = (Button) authMethodPickerActivity.findViewById(R.id.email_provider);
+        Button emailButton = (Button) authMethodPickerActivity.findViewById(R.id.email_button);
         assertEquals(View.GONE, emailButton.getVisibility());
     }
 
@@ -107,7 +107,7 @@ public class AuthMethodPickerActivityTest {
 
         AuthMethodPickerActivity authMethodPickerActivity = createActivity(providers);
 
-        Button emailButton = (Button) authMethodPickerActivity.findViewById(R.id.email_provider);
+        Button emailButton = (Button) authMethodPickerActivity.findViewById(R.id.email_button);
         emailButton.performClick();
         ShadowActivity.IntentForResult nextIntent =
                 Shadows.shadowOf(authMethodPickerActivity).getNextStartedActivityForResult();

--- a/library/quality/lint-baseline.xml
+++ b/library/quality/lint-baseline.xml
@@ -13,42 +13,6 @@
     </issue>
 
     <issue
-        id="UnusedIds"
-        message="The resource `R.id.facebook_button` appears to be unused"
-        errorLine1="    android:id=&quot;@+id/facebook_button&quot;/>
-"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout/idp_button_facebook.xml"
-            line="5"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="UnusedIds"
-        message="The resource `R.id.google_button` appears to be unused"
-        errorLine1="    android:id=&quot;@+id/google_button&quot;/>
-"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout/idp_button_google.xml"
-            line="5"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="UnusedIds"
-        message="The resource `R.id.twitter_button` appears to be unused"
-        errorLine1="    android:id=&quot;@+id/twitter_button&quot;/>
-"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout/idp_button_twitter.xml"
-            line="5"
-            column="5"/>
-    </issue>
-
-    <issue
         id="SelectableText"
         message="Consider making the text value selectable by specifying `android:textIsSelectable=&quot;true&quot;`"
         errorLine1="        &lt;TextView


### PR DESCRIPTION
@samtstern In both #309 and a PR I'm working on to fix \#554, I've wanted to get providers in an orderly fashion with the most important provider being on top and the least at the bottom. In #309, I simply made the assumption that the order should be `Google` -> `Facebook` -> `Twitter` -> `Email`. However, I think it would be better to use the dev's supplied provider order, but unfortunately, the order in which providers are displayed and passed in is wonky so this PR fixes that.

Addresses https://github.com/firebase/FirebaseUI-Android/issues/586#issuecomment-279246587

PS: I made this change in a backwards compatible way because I think people might be surprised if they just update FirebaseUI and suddenly their provider order is all messed up.