### PR TITLE
Fix incorrect link in README to auth state changes

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -263,9 +263,9 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 ```
 
 Alternatively, you can register a listener for authentication state changes;
-see the
-[Firebase Auth documentation](https://firebase.google.com/docs/reference/android/com/google/firebase/auth/FirebaseAuth.html#addAuthStateListener(com.google.firebase.auth.FirebaseAuth.AuthStateListener))
-for more information.
+see the Firebase Auth documentation
+[get the currently signed-in user](https://firebase.google.com/docs/auth/android/manage-users#get_the_currently_signed-in_user)
+and [register an AuthStateListener](https://firebase.google.com/docs/reference/android/com/google/firebase/auth/FirebaseAuth.html#addAuthStateListener(com.google.firebase.auth.FirebaseAuth.AuthStateListener)).
 
 ##### ID Tokens
 To retrieve the ID token that the IDP returned, you can extract an `IdpResponse` from the result

--- a/auth/README.md
+++ b/auth/README.md
@@ -263,7 +263,7 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 ```
 
 Alternatively, you can register a listener for authentication state changes;
-see the Firebase Auth documentation
+see the Firebase Auth documentation to
 [get the currently signed-in user](https://firebase.google.com/docs/auth/android/manage-users#get_the_currently_signed-in_user)
 and [register an AuthStateListener](https://firebase.google.com/docs/reference/android/com/google/firebase/auth/FirebaseAuth.html#addAuthStateListener(com.google.firebase.auth.FirebaseAuth.AuthStateListener)).
 

--- a/auth/README.md
+++ b/auth/README.md
@@ -264,7 +264,7 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 
 Alternatively, you can register a listener for authentication state changes;
 see the
-[Firebase Auth documentation](https://firebase.google.com/docs/auth/android/manage-users#get_the_currently_signed-in_user)
+[Firebase Auth documentation](https://firebase.google.com/docs/reference/android/com/google/firebase/auth/FirebaseAuth.html#addAuthStateListener(com.google.firebase.auth.FirebaseAuth.AuthStateListener))
 for more information.
 
 ##### ID Tokens


### PR DESCRIPTION
@samtstern While working on https://github.com/firebase/FirebaseUI-Android/issues/671#issuecomment-298699037, I noticed that the links to the Firebase documentation weren't very clear so this PR fixes that.