### PR TITLE
[2.0] Restrict unnecessary immutable stuff to library so we can change it later

### DIFF
--- a/database/src/main/java/com/firebase/ui/database/ImmutableList.java
+++ b/database/src/main/java/com/firebase/ui/database/ImmutableList.java
@@ -7,6 +7,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public abstract class ImmutableList<E> implements List<E> {
     /**
      * Guaranteed to throw an exception and leave the collection unmodified.
@@ -129,6 +130,7 @@ public abstract class ImmutableList<E> implements List<E> {
         throw new UnsupportedOperationException();
     }
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     protected final class ImmutableIterator implements Iterator<E> {
         protected Iterator<E> mIterator;
 
@@ -147,6 +149,7 @@ public abstract class ImmutableList<E> implements List<E> {
         }
     }
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     protected final class ImmutableListIterator implements ListIterator<E> {
         protected ListIterator<E> mListIterator;
 


### PR DESCRIPTION
@samtstern Sorry for being late about all this, I thought I had submitted a PR and it turns out I didn't. 😄

Basically, all I want to do is not have to support our custom iterator implementations because they aren't needed so I'm making them private for now. **_This has to be done before 2.0 is released to ensure backwards compatibility!_** Another PR is coming up for which 2.0 or not doesn't matter.