### PR TITLE
Fix `onDataChanged` not being called in FirebaseIndexArray if empty

### DIFF
--- a/database/src/main/java/com/firebase/ui/database/FirebaseIndexArray.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseIndexArray.java
@@ -110,7 +110,7 @@ public class FirebaseIndexArray<T> extends CachingObservableSnapshotArray<T> imp
 
     @Override
     public void onDataChanged() {
-        if (mHasPendingMoveOrDelete) {
+        if (mHasPendingMoveOrDelete || mKeySnapshots.isEmpty()) {
             notifyListenersOnDataChanged();
             mHasPendingMoveOrDelete = false;
         }


### PR DESCRIPTION
@samtstern I think I've finally eradicated all the `onDataChanged` bugs! 😄

This PR fixes the edge case where if the key array calls `onDataChanged` but is empty, the index array won't notify its client because there were no `onChildChanged` events to switch the `mHasPendingMoveOrDelete` flag.