### PR TITLE
Changed order of parameters in constructor of "Chat" class

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -27,7 +27,7 @@ public static class Chat {
         // Needed for Firebase
     }
 
-    public Chat(String name, String message, String uid) {
+    public Chat(String name, String uid, String message) {
         mName = name;
         mMessage = message;
         mUid = uid;


### PR DESCRIPTION
All examples of the `new Chat(...)` constructor being used in the code assume the message is the 3rd parameter passed to the constructor and not the 2nd.