### PR TITLE
Fix Fragment getContext NPE

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/VerifyPhoneNumberFragment.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/VerifyPhoneNumberFragment.java
@@ -15,6 +15,7 @@
 package com.firebase.ui.auth.ui.phone;
 
 import android.app.PendingIntent;
+import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.os.Bundle;
@@ -52,6 +53,8 @@ import java.util.Locale;
 public class VerifyPhoneNumberFragment extends FragmentBase implements View.OnClickListener {
     public static final String TAG = "VerifyPhoneFragment";
 
+    private Context mAppContext;
+
     private CountryListSpinner countryListSpinner;
     private EditText mPhoneEditText;
     private TextView errorEditText;
@@ -71,6 +74,12 @@ public class VerifyPhoneNumberFragment extends FragmentBase implements View.OnCl
 
         fragment.setArguments(args);
         return fragment;
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        mAppContext = context.getApplicationContext();
     }
 
     @Nullable
@@ -142,7 +151,7 @@ public class VerifyPhoneNumberFragment extends FragmentBase implements View.OnCl
                     final String formattedPhone =
                             PhoneNumberUtils
                                     .formatPhoneNumberUsingCurrentCountry(unformattedPhone,
-                                                                          getContext());
+                                                                          mAppContext);
                     if (formattedPhone == null) {
                         Log.e(TAG, "Unable to normalize phone number from hint selector:"
                                 + unformattedPhone);


### PR DESCRIPTION
#780

@samtstern Sigh, classic Fragment `getContext()` NPE. We've [done this before](https://github.com/firebase/FirebaseUI-Android/blob/c449be1c316c321fcbb45e1f4d7d99bec1ea1ea5/auth/src/main/java/com/firebase/ui/auth/util/signincontainer/SaveSmartLock.java#L83-L87) so it should work just fine.