### PR TITLE
Merge improvements from anonymous auth PR (#309)

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
@@ -192,7 +192,7 @@ public class AuthUI {
 
         // Twitter sign out
         try {
-            TwitterProvider.signout(activity);
+            TwitterProvider.signOut(activity);
         } catch (NoClassDefFoundError e) {
             // do nothing
         }

--- a/auth/src/main/java/com/firebase/ui/auth/IdpResponse.java
+++ b/auth/src/main/java/com/firebase/ui/auth/IdpResponse.java
@@ -24,7 +24,6 @@ import android.text.TextUtils;
 
 import com.firebase.ui.auth.ui.ExtraConstants;
 import com.google.firebase.auth.FacebookAuthProvider;
-import com.google.firebase.auth.GithubAuthProvider;
 import com.google.firebase.auth.GoogleAuthProvider;
 import com.google.firebase.auth.TwitterAuthProvider;
 
@@ -33,23 +32,20 @@ import com.google.firebase.auth.TwitterAuthProvider;
  */
 public class IdpResponse implements Parcelable {
     private final User mUser;
-    private final String mPhoneNumber;
     private final String mToken;
     private final String mSecret;
     private final int mErrorCode;
 
     private IdpResponse(int errorCode) {
-        this(null, null, null, null, errorCode);
+        this(null, null, null, errorCode);
     }
 
     private IdpResponse(
             User user,
-            String phoneNumber,
             String token,
             String secret,
             int errorCode) {
         mUser = user;
-        mPhoneNumber = phoneNumber;
         mToken = token;
         mSecret = secret;
         mErrorCode = errorCode;
@@ -102,7 +98,7 @@ public class IdpResponse implements Parcelable {
      */
     @Nullable
     public String getPhoneNumber() {
-        return mPhoneNumber;
+        return mUser.getPhoneNumber();
     }
 
     /**
@@ -136,7 +132,6 @@ public class IdpResponse implements Parcelable {
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeParcelable(mUser, flags);
-        dest.writeString(mPhoneNumber);
         dest.writeString(mToken);
         dest.writeString(mSecret);
         dest.writeInt(mErrorCode);
@@ -147,7 +142,6 @@ public class IdpResponse implements Parcelable {
         public IdpResponse createFromParcel(Parcel in) {
             return new IdpResponse(
                     in.<User>readParcelable(User.class.getClassLoader()),
-                    in.readString(),
                     in.readString(),
                     in.readString(),
                     in.readInt()
@@ -163,17 +157,11 @@ public class IdpResponse implements Parcelable {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     public static class Builder {
         private User mUser;
-        private String mPhoneNumber;
         private String mToken;
         private String mSecret;
 
         public Builder(@NonNull User user) {
             mUser = user;
-        }
-
-        public Builder setPhoneNumber(String phoneNumber) {
-            mPhoneNumber = phoneNumber;
-            return this;
         }
 
         public Builder setToken(String token) {
@@ -190,8 +178,7 @@ public class IdpResponse implements Parcelable {
             String providerId = mUser.getProviderId();
             if ((providerId.equalsIgnoreCase(GoogleAuthProvider.PROVIDER_ID)
                     || providerId.equalsIgnoreCase(FacebookAuthProvider.PROVIDER_ID)
-                    || providerId.equalsIgnoreCase(TwitterAuthProvider.PROVIDER_ID)
-                    || providerId.equalsIgnoreCase(GithubAuthProvider.PROVIDER_ID))
+                    || providerId.equalsIgnoreCase(TwitterAuthProvider.PROVIDER_ID))
                     && TextUtils.isEmpty(mToken)) {
                 throw new IllegalStateException(
                         "Token cannot be null when using a non-email provider.");
@@ -202,7 +189,7 @@ public class IdpResponse implements Parcelable {
                         "Secret cannot be null when using the Twitter provider.");
             }
 
-            return new IdpResponse(mUser, mPhoneNumber, mToken, mSecret, ResultCodes.OK);
+            return new IdpResponse(mUser, mToken, mSecret, ResultCodes.OK);
         }
     }
 }

--- a/auth/src/main/java/com/firebase/ui/auth/User.java
+++ b/auth/src/main/java/com/firebase/ui/auth/User.java
@@ -1,4 +1,4 @@
-package com.firebase.ui.auth.ui;
+package com.firebase.ui.auth;
 
 import android.content.Intent;
 import android.net.Uri;
@@ -9,7 +9,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.RestrictTo;
 
-import com.firebase.ui.auth.AuthUI;
+import com.firebase.ui.auth.ui.ExtraConstants;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class User implements Parcelable {
@@ -29,15 +29,15 @@ public class User implements Parcelable {
         }
     };
 
+    private String mProviderId;
     private String mEmail;
     private String mName;
-    private String mProvider;
     private Uri mPhotoUri;
 
-    private User(String email, String name, String provider, Uri photoUri) {
+    private User(String providerId, String email, String name, Uri photoUri) {
+        mProviderId = providerId;
         mEmail = email;
         mName = name;
-        mProvider = provider;
         mPhotoUri = photoUri;
     }
 
@@ -50,6 +50,12 @@ public class User implements Parcelable {
     }
 
     @NonNull
+    @AuthUI.SupportedProvider
+    public String getProviderId() {
+        return mProviderId;
+    }
+
+    @Nullable
     public String getEmail() {
         return mEmail;
     }
@@ -60,14 +66,40 @@ public class User implements Parcelable {
     }
 
     @Nullable
-    @AuthUI.SupportedProvider
-    public String getProvider() {
-        return mProvider;
-    }
-
-    @Nullable
     public Uri getPhotoUri() {
         return mPhotoUri;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        User user = (User) o;
+
+        return mProviderId.equals(user.mProviderId)
+                && (mEmail == null ? user.mEmail == null : mEmail.equals(user.mEmail))
+                && (mName == null ? user.mName == null : mName.equals(user.mName))
+                && (mPhotoUri == null ? user.mPhotoUri == null : mPhotoUri.equals(user.mPhotoUri));
+    }
+
+    @Override
+    public int hashCode() {
+        int result = mProviderId.hashCode();
+        result = 31 * result + (mEmail == null ? 0 : mEmail.hashCode());
+        result = 31 * result + (mName == null ? 0 : mName.hashCode());
+        result = 31 * result + (mPhotoUri == null ? 0 : mPhotoUri.hashCode());
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "mProviderId='" + mProviderId + '\'' +
+                ", mEmail='" + mEmail + '\'' +
+                ", mName='" + mName + '\'' +
+                ", mPhotoUri=" + mPhotoUri +
+                '}';
     }
 
     @Override
@@ -77,29 +109,25 @@ public class User implements Parcelable {
 
     @Override
     public void writeToParcel(@NonNull Parcel dest, int flags) {
+        dest.writeString(mProviderId);
         dest.writeString(mEmail);
         dest.writeString(mName);
-        dest.writeString(mProvider);
         dest.writeParcelable(mPhotoUri, flags);
     }
 
     public static class Builder {
+        private String mProviderId;
         private String mEmail;
         private String mName;
-        private String mProvider;
         private Uri mPhotoUri;
 
-        public Builder(@NonNull String email) {
+        public Builder(@AuthUI.SupportedProvider @NonNull String providerId, @Nullable String email) {
+            mProviderId = providerId;
             mEmail = email;
         }
 
         public Builder setName(String name) {
             mName = name;
-            return this;
-        }
-
-        public Builder setProvider(@AuthUI.SupportedProvider String provider) {
-            mProvider = provider;
             return this;
         }
 
@@ -109,7 +137,7 @@ public class User implements Parcelable {
         }
 
         public User build() {
-            return new User(mEmail, mName, mProvider, mPhotoUri);
+            return new User(mProviderId, mEmail, mName, mPhotoUri);
         }
     }
 }

--- a/auth/src/main/java/com/firebase/ui/auth/User.java
+++ b/auth/src/main/java/com/firebase/ui/auth/User.java
@@ -20,6 +20,7 @@ public class User implements Parcelable {
                     in.readString(),
                     in.readString(),
                     in.readString(),
+                    in.readString(),
                     in.<Uri>readParcelable(Uri.class.getClassLoader()));
         }
 
@@ -29,14 +30,16 @@ public class User implements Parcelable {
         }
     };
 
-    private String mProviderId;
-    private String mEmail;
-    private String mName;
-    private Uri mPhotoUri;
+    private final String mProviderId;
+    private final String mEmail;
+    private final String mPhoneNumber;
+    private final String mName;
+    private final Uri mPhotoUri;
 
-    private User(String providerId, String email, String name, Uri photoUri) {
+    private User(String providerId, String email, String phoneNumber, String name, Uri photoUri) {
         mProviderId = providerId;
         mEmail = email;
+        mPhoneNumber = phoneNumber;
         mName = name;
         mPhotoUri = photoUri;
     }
@@ -58,6 +61,11 @@ public class User implements Parcelable {
     @Nullable
     public String getEmail() {
         return mEmail;
+    }
+
+    @Nullable
+    public String getPhoneNumber() {
+        return mPhoneNumber;
     }
 
     @Nullable
@@ -111,6 +119,7 @@ public class User implements Parcelable {
     public void writeToParcel(@NonNull Parcel dest, int flags) {
         dest.writeString(mProviderId);
         dest.writeString(mEmail);
+        dest.writeString(mPhoneNumber);
         dest.writeString(mName);
         dest.writeParcelable(mPhotoUri, flags);
     }
@@ -118,12 +127,19 @@ public class User implements Parcelable {
     public static class Builder {
         private String mProviderId;
         private String mEmail;
+        private String mPhoneNumber;
         private String mName;
         private Uri mPhotoUri;
 
-        public Builder(@AuthUI.SupportedProvider @NonNull String providerId, @Nullable String email) {
+        public Builder(@AuthUI.SupportedProvider @NonNull String providerId,
+                       @Nullable String email) {
             mProviderId = providerId;
             mEmail = email;
+        }
+
+        public Builder setPhoneNumber(String phoneNumber) {
+            mPhoneNumber = phoneNumber;
+            return this;
         }
 
         public Builder setName(String name) {
@@ -137,7 +153,7 @@ public class User implements Parcelable {
         }
 
         public User build() {
-            return new User(mProviderId, mEmail, mName, mPhotoUri);
+            return new User(mProviderId, mEmail, mPhoneNumber, mName, mPhotoUri);
         }
     }
 }

--- a/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
@@ -141,15 +141,17 @@ public class FacebookProvider implements IdpProvider, FacebookCallback<LoginResu
 
                             try {
                                 email = object.getString("email");
-                            } catch (JSONException ignored) { }
+                            } catch (JSONException e) {
+                                Log.e(TAG, "Failure retrieving Facebook email", e);
+                            }
                             try {
                                 name = object.getString("name");
-                            } catch (JSONException ignored) { }
+                            } catch (JSONException ignored) {}
                             try {
                                 photoUri = Uri.parse(object.getJSONObject("picture")
                                         .getJSONObject("data")
                                         .getString("url"));
-                            } catch (JSONException ignored) { }
+                            } catch (JSONException ignored) {}
 
                             onSuccess(loginResult, email, name, photoUri);
                         }

--- a/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
@@ -17,6 +17,7 @@ package com.firebase.ui.auth.provider;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.Nullable;
@@ -35,6 +36,7 @@ import com.facebook.login.LoginResult;
 import com.firebase.ui.auth.AuthUI;
 import com.firebase.ui.auth.IdpResponse;
 import com.firebase.ui.auth.R;
+import com.firebase.ui.auth.User;
 import com.google.firebase.auth.AuthCredential;
 import com.google.firebase.auth.FacebookAuthProvider;
 
@@ -133,19 +135,29 @@ public class FacebookProvider implements IdpProvider, FacebookCallback<LoginResu
                             Log.w(TAG, "Received null response from Facebook GraphRequest");
                             onFailure();
                         } else {
+                            String email = null;
+                            String name = null;
+                            Uri photoUri = null;
+
                             try {
-                                String email = object.getString("email");
-                                onSuccess(email, loginResult);
-                            } catch (JSONException e) {
-                                Log.e(TAG, "Failure retrieving Facebook email", e);
-                                onSuccess(null, loginResult);
-                            }
+                                email = object.getString("email");
+                            } catch (JSONException ignored) { }
+                            try {
+                                name = object.getString("name");
+                            } catch (JSONException ignored) { }
+                            try {
+                                photoUri = Uri.parse(object.getJSONObject("picture")
+                                        .getJSONObject("data")
+                                        .getString("url"));
+                            } catch (JSONException ignored) { }
+
+                            onSuccess(loginResult, email, name, photoUri);
                         }
                     }
                 });
 
         Bundle parameters = new Bundle();
-        parameters.putString("fields", "id,name,email");
+        parameters.putString("fields", "id,name,email,picture");
         request.setParameters(parameters);
         request.executeAsync();
     }
@@ -161,15 +173,18 @@ public class FacebookProvider implements IdpProvider, FacebookCallback<LoginResu
         onFailure();
     }
 
-    private void onSuccess(@Nullable String email, LoginResult loginResult) {
+    private void onSuccess(LoginResult loginResult,
+                           @Nullable String email,
+                           String name,
+                           Uri photoUri) {
         gcCallbackManager();
-        mCallbackObject.onSuccess(createIdpResponse(email, loginResult));
-    }
-
-    private IdpResponse createIdpResponse(@Nullable String email, LoginResult loginResult) {
-        return new IdpResponse.Builder(FacebookAuthProvider.PROVIDER_ID, email)
+        mCallbackObject.onSuccess(new IdpResponse.Builder(
+                new User.Builder(FacebookAuthProvider.PROVIDER_ID, email)
+                        .setName(name)
+                        .setPhotoUri(photoUri)
+                        .build())
                 .setToken(loginResult.getAccessToken().getToken())
-                .build();
+                .build());
     }
 
     private void onFailure() {

--- a/auth/src/main/java/com/firebase/ui/auth/provider/GoogleProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/GoogleProvider.java
@@ -28,6 +28,7 @@ import android.widget.Toast;
 import com.firebase.ui.auth.AuthUI.IdpConfig;
 import com.firebase.ui.auth.IdpResponse;
 import com.firebase.ui.auth.R;
+import com.firebase.ui.auth.User;
 import com.firebase.ui.auth.util.GoogleApiHelper;
 import com.google.android.gms.auth.api.Auth;
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
@@ -113,7 +114,11 @@ public class GoogleProvider implements IdpProvider, GoogleApiClient.OnConnection
     }
 
     private IdpResponse createIdpResponse(GoogleSignInAccount account) {
-        return new IdpResponse.Builder(GoogleAuthProvider.PROVIDER_ID, account.getEmail())
+        return new IdpResponse.Builder(
+                new User.Builder(GoogleAuthProvider.PROVIDER_ID, account.getEmail())
+                        .setName(account.getDisplayName())
+                        .setPhotoUri(account.getPhotoUrl())
+                        .build())
                 .setToken(account.getIdToken())
                 .build();
     }

--- a/auth/src/main/java/com/firebase/ui/auth/provider/TwitterProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/TwitterProvider.java
@@ -3,6 +3,7 @@ package com.firebase.ui.auth.provider;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 import android.support.annotation.LayoutRes;
 import android.util.Log;
 
@@ -19,8 +20,7 @@ import com.twitter.sdk.android.core.TwitterCore;
 import com.twitter.sdk.android.core.TwitterException;
 import com.twitter.sdk.android.core.TwitterSession;
 import com.twitter.sdk.android.core.identity.TwitterAuthClient;
-
-import java.lang.ref.WeakReference;
+import com.twitter.sdk.android.core.models.User;
 
 
 public class TwitterProvider extends Callback<TwitterSession> implements IdpProvider {
@@ -51,7 +51,7 @@ public class TwitterProvider extends Callback<TwitterSession> implements IdpProv
         Twitter.initialize(config);
     }
 
-    public static void signout(Context context) {
+    public static void signOut(Context context) {
         try {
             Twitter.getInstance();
         } catch (IllegalStateException e) {
@@ -92,9 +92,27 @@ public class TwitterProvider extends Callback<TwitterSession> implements IdpProv
     }
 
     @Override
-    public void success(Result<TwitterSession> result) {
-        mTwitterAuthClient.requestEmail(result.data,
-                new EmailCallback(result.data, mCallbackObject));
+    public void success(final Result<TwitterSession> sessionResult) {
+        TwitterCore.getInstance()
+                .getApiClient()
+                .getAccountService()
+                .verifyCredentials(false, false, true)
+                .enqueue(new Callback<User>() {
+                    @Override
+                    public void success(Result<User> result) {
+                        User user = result.data;
+                        mCallbackObject.onSuccess(createIdpResponse(
+                                sessionResult.data,
+                                user.email,
+                                user.name,
+                                Uri.parse(user.profileImageUrlHttps)));
+                    }
+
+                    @Override
+                    public void failure(TwitterException exception) {
+                        mCallbackObject.onFailure();
+                    }
+                });
     }
 
     @Override
@@ -103,39 +121,17 @@ public class TwitterProvider extends Callback<TwitterSession> implements IdpProv
         mCallbackObject.onFailure();
     }
 
-    private static class EmailCallback extends Callback<String> {
-        private TwitterSession mTwitterSession;
-        private WeakReference<IdpCallback> mCallbackObject;
-
-        public EmailCallback(TwitterSession session, IdpCallback callbackObject) {
-            mTwitterSession = session;
-            mCallbackObject = new WeakReference<>(callbackObject);
-        }
-
-        @Override
-        public void success(Result<String> emailResult) {
-            onSuccess(createIdpResponse(emailResult.data));
-        }
-
-        @Override
-        public void failure(TwitterException exception) {
-            Log.e(TAG, "Failure retrieving Twitter email. " + exception.getMessage());
-            // If retrieving the email fails, we should still be able to sign in, but Smart Lock
-            // and account linking won't work.
-            onSuccess(createIdpResponse(null));
-        }
-
-        private void onSuccess(IdpResponse response) {
-            if (mCallbackObject != null) {
-                mCallbackObject.get().onSuccess(response);
-            }
-        }
-
-        private IdpResponse createIdpResponse(String email) {
-            return new IdpResponse.Builder(TwitterAuthProvider.PROVIDER_ID, email)
-                    .setToken(mTwitterSession.getAuthToken().token)
-                    .setSecret(mTwitterSession.getAuthToken().secret)
-                    .build();
-        }
+    private IdpResponse createIdpResponse(TwitterSession session,
+                                          String email,
+                                          String name,
+                                          Uri photoUri) {
+        return new IdpResponse.Builder(
+                new com.firebase.ui.auth.User.Builder(TwitterAuthProvider.PROVIDER_ID, email)
+                        .setName(name)
+                        .setPhotoUri(photoUri)
+                        .build())
+                .setToken(session.getAuthToken().token)
+                .setSecret(session.getAuthToken().secret)
+                .build();
     }
 }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/accountlink/WelcomeBackIdpPrompt.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/accountlink/WelcomeBackIdpPrompt.java
@@ -41,7 +41,7 @@ import com.firebase.ui.auth.ui.ExtraConstants;
 import com.firebase.ui.auth.ui.FlowParameters;
 import com.firebase.ui.auth.ui.HelperActivityBase;
 import com.firebase.ui.auth.ui.TaskFailureLogger;
-import com.firebase.ui.auth.ui.User;
+import com.firebase.ui.auth.User;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
@@ -80,7 +80,7 @@ public class WelcomeBackIdpPrompt extends AppCompatBase implements IdpCallback {
 
         User oldUser = User.getUser(getIntent());
 
-        String providerId = oldUser.getProvider();
+        String providerId = oldUser.getProviderId();
         for (IdpConfig idpConfig : getFlowParams().providerInfo) {
             if (providerId.equals(idpConfig.getProviderId())) {
                 switch (providerId) {

--- a/auth/src/main/java/com/firebase/ui/auth/ui/accountlink/WelcomeBackPasswordPrompt.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/accountlink/WelcomeBackPasswordPrompt.java
@@ -42,6 +42,7 @@ import com.firebase.ui.auth.ui.FlowParameters;
 import com.firebase.ui.auth.ui.HelperActivityBase;
 import com.firebase.ui.auth.ui.ImeHelper;
 import com.firebase.ui.auth.ui.TaskFailureLogger;
+import com.firebase.ui.auth.User;
 import com.firebase.ui.auth.ui.email.RecoverPasswordActivity;
 import com.firebase.ui.auth.util.signincontainer.SaveSmartLock;
 import com.google.android.gms.tasks.OnFailureListener;
@@ -162,7 +163,9 @@ public class WelcomeBackPasswordPrompt extends AppCompatBase
                                     mSaveSmartLock,
                                     authResult.getUser(),
                                     password,
-                                    new IdpResponse.Builder(EmailAuthProvider.PROVIDER_ID, email)
+                                    new IdpResponse.Builder(
+                                            new User.Builder(EmailAuthProvider.PROVIDER_ID, email)
+                                                    .build())
                                             .build());
                         } else {
                             authResult.getUser()

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/CheckEmailFragment.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/CheckEmailFragment.java
@@ -17,12 +17,12 @@ import android.view.ViewGroup;
 import android.widget.EditText;
 
 import com.firebase.ui.auth.R;
+import com.firebase.ui.auth.User;
 import com.firebase.ui.auth.provider.ProviderUtils;
 import com.firebase.ui.auth.ui.ExtraConstants;
 import com.firebase.ui.auth.ui.FlowParameters;
 import com.firebase.ui.auth.ui.FragmentBase;
 import com.firebase.ui.auth.ui.ImeHelper;
-import com.firebase.ui.auth.ui.User;
 import com.firebase.ui.auth.ui.email.fieldvalidators.EmailFieldValidator;
 import com.firebase.ui.auth.util.GoogleApiHelper;
 import com.google.android.gms.auth.api.Auth;
@@ -198,15 +198,16 @@ public class CheckEmailFragment extends FragmentBase implements
                     @Override
                     public void onSuccess(String provider) {
                         if (provider == null) {
-                            mListener.onNewUser(new User.Builder(email)
+                            mListener.onNewUser(new User.Builder(EmailAuthProvider.PROVIDER_ID, email)
                                     .setName(finalName)
                                     .setPhotoUri(finalPhotoUri)
                                     .build());
                         } else if (EmailAuthProvider.PROVIDER_ID.equalsIgnoreCase(provider)) {
-                            mListener.onExistingEmailUser(new User.Builder(email).build());
+                            mListener.onExistingEmailUser(
+                                    new User.Builder(EmailAuthProvider.PROVIDER_ID, email).build());
                         } else {
                             mListener.onExistingIdpUser(
-                                    new User.Builder(email).setProvider(provider).build());
+                                    new User.Builder(EmailAuthProvider.PROVIDER_ID, email).build());
                         }
                     }
                 })

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/RegisterEmailActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/RegisterEmailActivity.java
@@ -27,10 +27,9 @@ import com.firebase.ui.auth.ui.AppCompatBase;
 import com.firebase.ui.auth.ui.ExtraConstants;
 import com.firebase.ui.auth.ui.FlowParameters;
 import com.firebase.ui.auth.ui.HelperActivityBase;
-import com.firebase.ui.auth.ui.User;
+import com.firebase.ui.auth.User;
 import com.firebase.ui.auth.ui.accountlink.WelcomeBackIdpPrompt;
 import com.firebase.ui.auth.ui.accountlink.WelcomeBackPasswordPrompt;
-import com.google.firebase.auth.EmailAuthProvider;
 
 /**
  * Activity to control the entire email sign up flow. Plays host to {@link CheckEmailFragment} and
@@ -96,8 +95,7 @@ public class RegisterEmailActivity extends AppCompatBase implements
                 WelcomeBackPasswordPrompt.createIntent(
                         this,
                         getFlowParams(),
-                        new IdpResponse.Builder(
-                                EmailAuthProvider.PROVIDER_ID, user.getEmail()).build()),
+                        new IdpResponse.Builder(user).build()),
                 RC_SIGN_IN);
 
         setSlideAnimation();
@@ -110,7 +108,7 @@ public class RegisterEmailActivity extends AppCompatBase implements
                 this,
                 getFlowParams(),
                 user,
-                new IdpResponse.Builder(EmailAuthProvider.PROVIDER_ID, user.getEmail()).build());
+                new IdpResponse.Builder(user).build());
 
         startActivityForResult(intent, RC_WELCOME_BACK_IDP);
         setSlideAnimation();

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/RegisterEmailFragment.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/RegisterEmailFragment.java
@@ -15,6 +15,7 @@ import android.widget.Toast;
 
 import com.firebase.ui.auth.IdpResponse;
 import com.firebase.ui.auth.R;
+import com.firebase.ui.auth.User;
 import com.firebase.ui.auth.provider.ProviderUtils;
 import com.firebase.ui.auth.ui.ExtraConstants;
 import com.firebase.ui.auth.ui.FlowParameters;
@@ -22,7 +23,6 @@ import com.firebase.ui.auth.ui.FragmentBase;
 import com.firebase.ui.auth.ui.HelperActivityBase;
 import com.firebase.ui.auth.ui.ImeHelper;
 import com.firebase.ui.auth.ui.TaskFailureLogger;
-import com.firebase.ui.auth.ui.User;
 import com.firebase.ui.auth.ui.accountlink.WelcomeBackIdpPrompt;
 import com.firebase.ui.auth.ui.accountlink.WelcomeBackPasswordPrompt;
 import com.firebase.ui.auth.ui.email.fieldvalidators.EmailFieldValidator;
@@ -173,7 +173,7 @@ public class RegisterEmailFragment extends FragmentBase implements
     @Override
     public void onSaveInstanceState(Bundle outState) {
         outState.putParcelable(ExtraConstants.EXTRA_USER,
-                new User.Builder(mEmailEditText.getText().toString())
+                new User.Builder(EmailAuthProvider.PROVIDER_ID, mEmailEditText.getText().toString())
                         .setName(mNameEditText.getText().toString())
                         .setPhotoUri(mUser.getPhotoUri())
                         .build());
@@ -246,8 +246,11 @@ public class RegisterEmailFragment extends FragmentBase implements
                                         // the credential to SmartLock (if enabled).
                                         mActivity.saveCredentialsOrFinish(
                                                 mSaveSmartLock, user, password,
-                                                new IdpResponse.Builder(EmailAuthProvider.PROVIDER_ID,
-                                                        email).build());
+                                                new IdpResponse.Builder(new User.Builder(
+                                                        EmailAuthProvider.PROVIDER_ID, email)
+                                                        .setName(name)
+                                                        .setPhotoUri(mUser.getPhotoUri())
+                                                        .build()).build());
                                     }
                                 });
                     }
@@ -288,21 +291,20 @@ public class RegisterEmailFragment extends FragmentBase implements
                                                         WelcomeBackPasswordPrompt.createIntent(
                                                                 getContext(),
                                                                 getFlowParams(),
-                                                                new IdpResponse.Builder(
+                                                                new IdpResponse.Builder(new User.Builder(
                                                                         EmailAuthProvider.PROVIDER_ID,
-                                                                        email).build()),
+                                                                        email).build()).build()),
                                                         RegisterEmailActivity.RC_WELCOME_BACK_IDP);
                                             } else {
                                                 getActivity().startActivityForResult(
                                                         WelcomeBackIdpPrompt.createIntent(
                                                                 getContext(),
                                                                 getFlowParams(),
-                                                                new User.Builder(email)
-                                                                        .setProvider(provider)
+                                                                new User.Builder(provider, email)
                                                                         .build(),
-                                                                new IdpResponse.Builder(
+                                                                new IdpResponse.Builder(new User.Builder(
                                                                         EmailAuthProvider.PROVIDER_ID,
-                                                                        email).build()),
+                                                                        email).build()).build()),
                                                         RegisterEmailActivity.RC_WELCOME_BACK_IDP);
                                             }
                                         }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/idp/CredentialSignInHandler.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/idp/CredentialSignInHandler.java
@@ -25,7 +25,7 @@ import com.firebase.ui.auth.IdpResponse;
 import com.firebase.ui.auth.ResultCodes;
 import com.firebase.ui.auth.provider.ProviderUtils;
 import com.firebase.ui.auth.ui.HelperActivityBase;
-import com.firebase.ui.auth.ui.User;
+import com.firebase.ui.auth.User;
 import com.firebase.ui.auth.ui.accountlink.WelcomeBackIdpPrompt;
 import com.firebase.ui.auth.ui.accountlink.WelcomeBackPasswordPrompt;
 import com.firebase.ui.auth.util.signincontainer.SaveSmartLock;
@@ -115,9 +115,7 @@ public class CredentialSignInHandler implements OnCompleteListener<AuthResult> {
                         WelcomeBackIdpPrompt.createIntent(
                                 mActivity,
                                 mActivity.getFlowParams(),
-                                new User.Builder(mResponse.getEmail())
-                                        .setProvider(provider)
-                                        .build(),
+                                new User.Builder(provider, mResponse.getEmail()).build(),
                                 mResponse),
                         mAccountLinkRequestCode);
             }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneVerificationActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneVerificationActivity.java
@@ -289,8 +289,9 @@ public class PhoneVerificationActivity extends AppCompatBase {
 
     private void finish(FirebaseUser user) {
         IdpResponse response = new IdpResponse.Builder(
-                new User.Builder(PhoneAuthProvider.PROVIDER_ID, null).build())
-                .setPhoneNumber(user.getPhoneNumber())
+                new User.Builder(PhoneAuthProvider.PROVIDER_ID, null)
+                        .setPhoneNumber(user.getPhoneNumber())
+                        .build())
                 .build();
         setResult(ResultCodes.OK, response.toIntent());
         finish();

--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneVerificationActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneVerificationActivity.java
@@ -31,6 +31,7 @@ import com.firebase.ui.auth.FirebaseAuthError;
 import com.firebase.ui.auth.IdpResponse;
 import com.firebase.ui.auth.R;
 import com.firebase.ui.auth.ResultCodes;
+import com.firebase.ui.auth.User;
 import com.firebase.ui.auth.ui.AppCompatBase;
 import com.firebase.ui.auth.ui.ExtraConstants;
 import com.firebase.ui.auth.ui.FlowParameters;
@@ -287,7 +288,8 @@ public class PhoneVerificationActivity extends AppCompatBase {
     }
 
     private void finish(FirebaseUser user) {
-        IdpResponse response = new IdpResponse.Builder(PhoneAuthProvider.PROVIDER_ID, null)
+        IdpResponse response = new IdpResponse.Builder(
+                new User.Builder(PhoneAuthProvider.PROVIDER_ID, null).build())
                 .setPhoneNumber(user.getPhoneNumber())
                 .build();
         setResult(ResultCodes.OK, response.toIntent());

--- a/auth/src/main/java/com/firebase/ui/auth/util/signincontainer/IdpSignInContainer.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/signincontainer/IdpSignInContainer.java
@@ -38,7 +38,7 @@ import com.firebase.ui.auth.ui.FlowParameters;
 import com.firebase.ui.auth.ui.FragmentBase;
 import com.firebase.ui.auth.ui.HelperActivityBase;
 import com.firebase.ui.auth.ui.TaskFailureLogger;
-import com.firebase.ui.auth.ui.User;
+import com.firebase.ui.auth.User;
 import com.firebase.ui.auth.ui.idp.CredentialSignInHandler;
 import com.google.firebase.auth.AuthCredential;
 import com.google.firebase.auth.FacebookAuthProvider;
@@ -88,7 +88,7 @@ public class IdpSignInContainer extends FragmentBase implements IdpCallback {
         mSaveSmartLock = getAuthHelper().getSaveSmartLockInstance(mActivity);
 
         User user = User.getUser(getArguments());
-        String provider = user.getProvider();
+        String provider = user.getProviderId();
 
         AuthUI.IdpConfig providerConfig = null;
         for (AuthUI.IdpConfig config : getFlowParams().providerInfo) {

--- a/auth/src/main/java/com/firebase/ui/auth/util/signincontainer/SignInDelegate.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/signincontainer/SignInDelegate.java
@@ -19,7 +19,7 @@ import com.firebase.ui.auth.ResultCodes;
 import com.firebase.ui.auth.ui.ExtraConstants;
 import com.firebase.ui.auth.ui.FlowParameters;
 import com.firebase.ui.auth.ui.TaskFailureLogger;
-import com.firebase.ui.auth.ui.User;
+import com.firebase.ui.auth.User;
 import com.firebase.ui.auth.ui.email.RegisterEmailActivity;
 import com.firebase.ui.auth.ui.idp.AuthMethodPickerActivity;
 import com.firebase.ui.auth.ui.phone.PhoneVerificationActivity;
@@ -273,7 +273,8 @@ public class SignInDelegate extends SmartLockBase<CredentialRequestResult> {
      */
     private void signInWithEmailAndPassword(String email, String password) {
         final IdpResponse response =
-                new IdpResponse.Builder(EmailAuthProvider.PROVIDER_ID, email).build();
+                new IdpResponse.Builder(new User.Builder(EmailAuthProvider.PROVIDER_ID, email).build())
+                        .build();
 
         getAuthHelper().getFirebaseAuth()
                 .signInWithEmailAndPassword(email, password)
@@ -341,8 +342,7 @@ public class SignInDelegate extends SmartLockBase<CredentialRequestResult> {
             IdpSignInContainer.signIn(
                     getActivity(),
                     getFlowParams(),
-                    new User.Builder(email)
-                            .setProvider(accountTypeToProviderId(accountType))
+                    new User.Builder(SmartLockBase.accountTypeToProviderId(accountType), email)
                             .build());
         } else {
             Log.w(TAG, "Unknown provider: " + accountType);

--- a/auth/src/test/java/com/firebase/ui/auth/ui/email/RegisterEmailActivityTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/email/RegisterEmailActivityTest.java
@@ -23,13 +23,13 @@ import android.widget.EditText;
 import com.firebase.ui.auth.AuthUI;
 import com.firebase.ui.auth.BuildConfig;
 import com.firebase.ui.auth.R;
+import com.firebase.ui.auth.User;
 import com.firebase.ui.auth.testhelpers.AuthHelperShadow;
 import com.firebase.ui.auth.testhelpers.AutoCompleteTask;
 import com.firebase.ui.auth.testhelpers.CustomRobolectricGradleTestRunner;
 import com.firebase.ui.auth.testhelpers.FakeAuthResult;
 import com.firebase.ui.auth.testhelpers.TestConstants;
 import com.firebase.ui.auth.testhelpers.TestHelper;
-import com.firebase.ui.auth.ui.User;
 import com.google.firebase.auth.EmailAuthProvider;
 import com.google.firebase.auth.UserProfileChangeRequest;
 
@@ -74,7 +74,8 @@ public class RegisterEmailActivityTest {
         RegisterEmailActivity registerEmailActivity = createActivity();
 
         // Trigger RegisterEmailFragment (bypass check email)
-        registerEmailActivity.onNewUser(new User.Builder(TestConstants.EMAIL).build());
+        registerEmailActivity.onNewUser(
+                new User.Builder(EmailAuthProvider.PROVIDER_ID, TestConstants.EMAIL).build());
 
         Button button = (Button) registerEmailActivity.findViewById(R.id.button_create);
         button.performClick();
@@ -108,10 +109,11 @@ public class RegisterEmailActivityTest {
         RegisterEmailActivity registerEmailActivity = createActivity();
 
         // Trigger new user UI (bypassing check email)
-        registerEmailActivity.onNewUser(new User.Builder(TestConstants.EMAIL)
-                                                .setName(TestConstants.NAME)
-                                                .setPhotoUri(TestConstants.PHOTO_URI)
-                                                .build());
+        registerEmailActivity.onNewUser(
+                new User.Builder(EmailAuthProvider.PROVIDER_ID, TestConstants.EMAIL)
+                        .setName(TestConstants.NAME)
+                        .setPhotoUri(TestConstants.PHOTO_URI)
+                        .build());
 
         EditText name = (EditText) registerEmailActivity.findViewById(R.id.name);
         EditText password = (EditText) registerEmailActivity.findViewById(R.id.password);

--- a/auth/src/test/java/com/firebase/ui/auth/ui/email/WelcomeBackPasswordPromptTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/email/WelcomeBackPasswordPromptTest.java
@@ -22,6 +22,7 @@ import android.widget.EditText;
 import com.firebase.ui.auth.BuildConfig;
 import com.firebase.ui.auth.IdpResponse;
 import com.firebase.ui.auth.R;
+import com.firebase.ui.auth.User;
 import com.firebase.ui.auth.testhelpers.AuthHelperShadow;
 import com.firebase.ui.auth.testhelpers.AutoCompleteTask;
 import com.firebase.ui.auth.testhelpers.CustomRobolectricGradleTestRunner;
@@ -61,8 +62,10 @@ public class WelcomeBackPasswordPromptTest {
         Intent startIntent = WelcomeBackPasswordPrompt.createIntent(
                 RuntimeEnvironment.application,
                 TestHelper.getFlowParameters(Collections.<String>emptyList()),
-                new IdpResponse.Builder(EmailAuthProvider.PROVIDER_ID,
-                                        TestConstants.EMAIL).build());
+                new IdpResponse.Builder(
+                        new User.Builder(EmailAuthProvider.PROVIDER_ID, TestConstants.EMAIL)
+                                .build())
+                        .build());
         return Robolectric
                 .buildActivity(WelcomeBackPasswordPrompt.class)
                 .withIntent(startIntent)

--- a/auth/src/test/java/com/firebase/ui/auth/ui/idp/CredentialSignInHandlerTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/idp/CredentialSignInHandlerTest.java
@@ -18,6 +18,7 @@ import android.content.Intent;
 
 import com.firebase.ui.auth.BuildConfig;
 import com.firebase.ui.auth.IdpResponse;
+import com.firebase.ui.auth.User;
 import com.firebase.ui.auth.testhelpers.AuthHelperShadow;
 import com.firebase.ui.auth.testhelpers.AutoCompleteTask;
 import com.firebase.ui.auth.testhelpers.CustomRobolectricGradleTestRunner;
@@ -28,7 +29,6 @@ import com.firebase.ui.auth.testhelpers.TestHelper;
 import com.firebase.ui.auth.ui.AppCompatBase;
 import com.firebase.ui.auth.ui.FlowParameters;
 import com.firebase.ui.auth.ui.ProgressDialogHolder;
-import com.firebase.ui.auth.ui.User;
 import com.firebase.ui.auth.ui.accountlink.WelcomeBackIdpPrompt;
 import com.firebase.ui.auth.ui.accountlink.WelcomeBackPasswordPrompt;
 import com.firebase.ui.auth.util.AuthHelper;
@@ -78,7 +78,9 @@ public class CredentialSignInHandlerTest {
     public void testSignInSucceeded() {
         AppCompatBase mockActivity = mock(AppCompatBase.class);
         IdpResponse idpResponse =
-                new IdpResponse.Builder(GoogleAuthProvider.PROVIDER_ID, TestConstants.EMAIL)
+                new IdpResponse.Builder(
+                        new User.Builder(GoogleAuthProvider.PROVIDER_ID, TestConstants.EMAIL)
+                                .build())
                         .setToken(TestConstants.TOKEN)
                         .build();
         SaveSmartLock smartLock = mock(SaveSmartLock.class);
@@ -116,7 +118,9 @@ public class CredentialSignInHandlerTest {
     public void testSignInFailed_withFacebookAlreadyLinked() {
         AppCompatBase mockActivity = mock(AppCompatBase.class);
         IdpResponse idpResponse =
-                new IdpResponse.Builder(GoogleAuthProvider.PROVIDER_ID, TestConstants.EMAIL)
+                new IdpResponse.Builder(
+                        new User.Builder(GoogleAuthProvider.PROVIDER_ID, TestConstants.EMAIL)
+                                .build())
                         .setToken(TestConstants.TOKEN)
                         .build();
         CredentialSignInHandler credentialSignInHandler = new CredentialSignInHandler(
@@ -161,7 +165,7 @@ public class CredentialSignInHandlerTest {
                 capturedUser.getEmail());
         assertEquals(
                 FacebookAuthProvider.PROVIDER_ID,
-                capturedUser.getProvider());
+                capturedUser.getProviderId());
 
     }
 
@@ -170,7 +174,9 @@ public class CredentialSignInHandlerTest {
     public void testSignInFailed_withPasswordAccountAlreadyLinked() {
         AppCompatBase mockActivity = mock(AppCompatBase.class);
         IdpResponse idpResponse =
-                new IdpResponse.Builder(GoogleAuthProvider.PROVIDER_ID, TestConstants.EMAIL)
+                new IdpResponse.Builder(
+                        new User.Builder(GoogleAuthProvider.PROVIDER_ID, TestConstants.EMAIL)
+                                .build())
                         .setToken(TestConstants.TOKEN)
                         .build();
         CredentialSignInHandler credentialSignInHandler = new CredentialSignInHandler(


### PR DESCRIPTION
@samtstern While working on automatically merging user profiles for #309, I made several improvements worth merging back into master:
- We no longer show that annoying Twitter request email screen!!! 😄🚀 I always knew we were doing it wrong somehow since the Firebase apis could get the Twitter email without showing that screen and that's correct--you can get profile info from the current Twitter session.
- The `IdpResponse` user data is unified and uses our `User` object under the hood now
- We collect all possible user info from all providers (we aren't using this yet, but it's used in #309 and could be useful for other things in the future.)