### PR TITLE
Fix phone verification progress dialog bugs on pre-L devices

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/CompletableProgressDialog.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/CompletableProgressDialog.java
@@ -17,6 +17,7 @@ package com.firebase.ui.auth.ui.phone;
 import android.app.Dialog;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AlertDialog;
@@ -31,7 +32,7 @@ public final class CompletableProgressDialog extends DialogFragment {
     private static final String TAG = "ComProgressDialog";
 
     private ProgressBar mProgress;
-    private TextView mMessageView;
+    @VisibleForTesting TextView mMessageView;
     private CharSequence mMessage;
     private ImageView mSuccessImage;
 

--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/CompletableProgressDialog.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/CompletableProgressDialog.java
@@ -14,9 +14,12 @@
 
 package com.firebase.ui.auth.ui.phone;
 
-import android.app.ProgressDialog;
-import android.content.Context;
+import android.app.Dialog;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v7.app.AlertDialog;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
@@ -24,41 +27,42 @@ import android.widget.TextView;
 
 import com.firebase.ui.auth.R;
 
-public final class CompletableProgressDialog extends ProgressDialog {
+public final class CompletableProgressDialog extends DialogFragment {
+    private static final String TAG = "ComProgressDialog";
+
     private ProgressBar mProgress;
     private TextView mMessageView;
     private CharSequence mMessage;
     private ImageView mSuccessImage;
 
-    public CompletableProgressDialog(Context context) {
-        super(context);
+    public static CompletableProgressDialog show(FragmentManager manager) {
+        CompletableProgressDialog dialog = new CompletableProgressDialog();
+        dialog.show(manager, TAG);
+        return dialog;
     }
 
-    public CompletableProgressDialog(Context context, int theme) {
-        super(context, theme);
-    }
-
+    @NonNull
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.fui_phone_progress_dialog);
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        View rootView = View.inflate(getContext(), R.layout.fui_phone_progress_dialog, null);
 
-        mProgress = (ProgressBar) findViewById(R.id.progress_bar);
-        mMessageView = (TextView) findViewById(R.id.progress_msg);
-        mSuccessImage = (ImageView) findViewById(R.id.progress_success_imaage);
+        mProgress = (ProgressBar) rootView.findViewById(R.id.progress_bar);
+        mMessageView = (TextView) rootView.findViewById(R.id.progress_msg);
+        mSuccessImage = (ImageView) rootView.findViewById(R.id.progress_success_imaage);
 
         if (mMessage != null) {
             setMessage(mMessage);
         }
+
+        return new AlertDialog.Builder(getContext()).setView(rootView).create();
     }
 
-    public void complete(String msg) {
+    public void onComplete(String msg) {
         setMessage(msg);
         mProgress.setVisibility(View.GONE);
         mSuccessImage.setVisibility(View.VISIBLE);
     }
 
-    @Override
     public void setMessage(CharSequence message) {
         if (mProgress != null) {
             mMessageView.setText(message);

--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneVerificationActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneVerificationActivity.java
@@ -67,7 +67,7 @@ public class PhoneVerificationActivity extends AppCompatBase {
     private static final String KEY_STATE = "KEY_STATE";
 
     private AlertDialog mAlertDialog;
-    private CompletableProgressDialog mProgressDialog;
+    @VisibleForTesting CompletableProgressDialog mProgressDialog;
     private Handler mHandler;
     private String mPhoneNumber;
     private String mVerificationId;

--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneVerificationActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneVerificationActivity.java
@@ -371,7 +371,7 @@ public class PhoneVerificationActivity extends AppCompatBase {
 
     private void completeLoadingDialog(String content) {
         if (mProgressDialog != null) {
-            mProgressDialog.complete(content);
+            mProgressDialog.onComplete(content);
         }
     }
 
@@ -379,13 +379,10 @@ public class PhoneVerificationActivity extends AppCompatBase {
         dismissLoadingDialog();
 
         if (mProgressDialog == null) {
-            mProgressDialog = new CompletableProgressDialog(this);
-            mProgressDialog.setIndeterminate(true);
-            mProgressDialog.setTitle("");
+            mProgressDialog = CompletableProgressDialog.show(getSupportFragmentManager());
         }
 
         mProgressDialog.setMessage(message);
-        mProgressDialog.show();
     }
 
     private void dismissLoadingDialog() {

--- a/auth/src/main/res/layout/fui_phone_progress_dialog.xml
+++ b/auth/src/main/res/layout/fui_phone_progress_dialog.xml
@@ -1,47 +1,41 @@
-<merge
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/dgts_body"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="match_parent"
+    android:paddingStart="8dp"
+    android:paddingEnd="8dp"
+    android:paddingTop="10dp"
+    android:paddingBottom="10dp"
+    android:baselineAligned="false"
+    android:orientation="horizontal"
+    tools:ignore="UnusedIds">
 
-    <LinearLayout
-        android:id="@+id/dgts_body"
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        style="@style/Base.Widget.AppCompat.ProgressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="12dp"
+        android:max="10000" />
+
+    <ImageView
+        android:id="@+id/progress_success_imaage"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="12dp"
+        android:contentDescription="@string/fui_done"
+        android:max="10000"
+        android:src="@drawable/fui_done_check_mark"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/progress_msg"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:paddingStart="8dip"
-        android:paddingEnd="8dip"
-        android:paddingTop="10dip"
-        android:paddingBottom="10dip"
-        android:baselineAligned="false"
-        android:orientation="horizontal"
-        tools:ignore="UnusedIds">
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        tools:ignore="SelectableText" />
 
-        <ProgressBar
-            android:id="@+id/progress_bar"
-            style="?android:attr/progressBarStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="12dip"
-            android:max="10000" />
-
-        <ImageView
-            android:id="@+id/progress_success_imaage"
-            style="?android:attr/progressBarStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="12dip"
-            android:contentDescription="@string/fui_done"
-            android:max="10000"
-            android:src="@drawable/fui_done_check_mark"
-            android:visibility="gone" />
-
-        <TextView
-            android:id="@+id/progress_msg"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            tools:ignore="SelectableText" />
-
-    </LinearLayout>
-
-</merge>
+</LinearLayout>

--- a/auth/src/main/res/layout/fui_phone_progress_dialog.xml
+++ b/auth/src/main/res/layout/fui_phone_progress_dialog.xml
@@ -1,16 +1,9 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/dgts_body"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingStart="8dp"
-    android:paddingEnd="8dp"
-    android:paddingTop="10dp"
-    android:paddingBottom="10dp"
-    android:baselineAligned="false"
+    android:layout_height="wrap_content"
     android:orientation="horizontal"
-    tools:ignore="UnusedIds">
+    android:padding="8dp">
 
     <ProgressBar
         android:id="@+id/progress_bar"
@@ -22,7 +15,6 @@
 
     <ImageView
         android:id="@+id/progress_success_imaage"
-        style="?android:attr/progressBarStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="12dp"
@@ -36,6 +28,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        tools:ignore="SelectableText" />
+        android:textIsSelectable="false" />
 
 </LinearLayout>

--- a/auth/src/test/java/com/firebase/ui/auth/ui/phone/PhoneVerificationActivityTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/phone/PhoneVerificationActivityTest.java
@@ -14,7 +14,6 @@
 
 package com.firebase.ui.auth.ui.phone;
 
-import android.app.AlertDialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
@@ -48,7 +47,6 @@ import org.mockito.Mock;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.ShadowAlertDialog;
 import org.robolectric.shadows.ShadowLooper;
 
 import java.util.Collections;
@@ -70,7 +68,6 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
-import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(CustomRobolectricGradleTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 25)
@@ -155,10 +152,10 @@ public class PhoneVerificationActivityTest {
         reset(AuthHelperShadow.sPhoneAuthProvider);
 
         mActivity.verifyPhoneNumber(PHONE, false);
-        AlertDialog alert = ShadowAlertDialog.getLatestAlertDialog();
-        ShadowAlertDialog sAlert = shadowOf(alert);
         //was dialog displayed
-        assertEquals(mActivity.getString(R.string.fui_verifying), sAlert.getMessage());
+        assertEquals(
+                mActivity.getString(R.string.fui_verifying),
+                mActivity.mProgressDialog.mMessageView.getText());
 
         //was upstream method invoked
         verify(AuthHelperShadow.sPhoneAuthProvider).verifyPhoneNumber(


### PR DESCRIPTION
@samtstern The dialog looks like this pre-L:
![image](https://user-images.githubusercontent.com/9490724/28485805-f24384ea-6e30-11e7-8e0f-a40815904448.png)

Pretty gross, right? 😆 

Anyway, since `ProgressDialog` is deprecated in Android O and we have a layout that basically just recreates it, I've updated `CompletableProgressDialog` to be a plain old `DialogFragment` and it now looks like this pre-L:
![image](https://user-images.githubusercontent.com/9490724/28485821-26c8074a-6e31-11e7-887a-8584d2ef1e96.png)