### PR TITLE
[DO NOT MERGE] Fix AuthMethodPickerLayout logo size

### DIFF
--- a/auth/src/main/res/layout-land/fui_auth_method_picker_layout.xml
+++ b/auth/src/main/res/layout-land/fui_auth_method_picker_layout.xml
@@ -5,9 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:clipChildren="false"
-    android:clipToPadding="false">
+    android:layout_height="match_parent">
 
     <ImageView
         android:id="@+id/logo"

--- a/auth/src/main/res/layout/fui_auth_method_picker_layout.xml
+++ b/auth/src/main/res/layout/fui_auth_method_picker_layout.xml
@@ -5,9 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:clipChildren="false"
-    android:clipToPadding="false">
+    android:layout_height="match_parent">
 
     <ImageView
         android:id="@+id/logo"
@@ -15,16 +13,25 @@
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/container"
+        app:layout_constraintBottom_toTopOf="@+id/barrier"
         tools:ignore="ContentDescription" /> <!-- TODO remove once the bug is fixed: https://issuetracker.google.com/issues/38281866-->
+
+    <android.support.constraint.Barrier
+        android:id="@+id/barrier"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="parent"
+        app:barrierDirection="bottom"
+        app:constraint_referenced_ids="logo, parent" />
 
     <ScrollView
         android:id="@+id/container"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/barrier"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintVertical_bias="0.9">
 

--- a/auth/src/main/res/values/styles.xml
+++ b/auth/src/main/res/values/styles.xml
@@ -167,7 +167,7 @@
 
     <style name="FirebaseUI.AuthMethodPicker.Logo">
         <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">0dp</item>
+        <item name="android:layout_height">wrap_content</item>
         <item name="android:contentDescription">@string/fui_accessibility_logo</item>
     </style>
 
@@ -176,6 +176,7 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:minWidth">@dimen/fui_auth_method_button_width</item>
         <item name="android:orientation">vertical</item>
+        <item name="android:clipChildren">false</item>
         <item name="android:clipToPadding">false</item>
         <item name="android:paddingLeft">4dp</item>
         <item name="android:paddingRight">4dp</item>


### PR DESCRIPTION
@samtstern This PR fixes [your comment](https://github.com/firebase/FirebaseUI-Android/pull/711#issuecomment-317768014) using `ConstraintLayout`'s new `Barrier`s! 😄

![image](https://user-images.githubusercontent.com/9490724/28588149-77b69fea-712e-11e7-8f0f-a6373b193cdb.png)

PS: could you create a `v2.1.2-dev` branch? Thanks!