### PR TITLE
Fix bug where onDataChanged isn't called if no data is found at index key

### DIFF
--- a/database/src/main/java/com/firebase/ui/database/FirebaseIndexArray.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseIndexArray.java
@@ -253,6 +253,11 @@ public class FirebaseIndexArray<T> extends CachingObservableSnapshotArray<T> imp
                 }
             }
 
+            // In theory, we would only want to pop the queue if this listener was just added
+            // i.e. `snapshot.value != null && isKeyAtIndex(...)`. However, if the developer makes a
+            // mistake and `snapshot.value == null`, we will never pop the queue and
+            // `notifyListenersOnDataChanged()` will never be called. Thus, we pop the queue anytime
+            // an update is received.
             mKeysWithPendingUpdate.remove(key);
             if (mKeysWithPendingUpdate.isEmpty()) notifyListenersOnDataChanged();
         }

--- a/database/src/main/java/com/firebase/ui/database/FirebaseIndexArray.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseIndexArray.java
@@ -235,7 +235,6 @@ public class FirebaseIndexArray<T> extends CachingObservableSnapshotArray<T> imp
                     // We already know about this data, just update it
                     updateData(index, snapshot);
                     notifyChangeEventListeners(EventType.CHANGED, snapshot, index);
-                    notifyListenersOnDataChanged();
                 } else {
                     // We don't already know about this data, add it
                     mDataSnapshots.add(index, snapshot);
@@ -246,7 +245,6 @@ public class FirebaseIndexArray<T> extends CachingObservableSnapshotArray<T> imp
                     // This data has disappeared, remove it
                     removeData(index);
                     notifyChangeEventListeners(EventType.REMOVED, snapshot, index);
-                    notifyListenersOnDataChanged();
                 } else {
                     // Data does not exist
                     Log.w(TAG, "Key not found at ref: " + snapshot.getRef());

--- a/database/src/main/java/com/firebase/ui/database/FirebaseIndexArray.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseIndexArray.java
@@ -42,7 +42,7 @@ public class FirebaseIndexArray<T> extends CachingObservableSnapshotArray<T> imp
      * contains keys that exist in the backing {@link FirebaseArray}, but their data hasn't been
      * downloaded yet in this array.
      */
-    private List<String> mKeysWithPendingData = new ArrayList<>();
+    private List<String> mKeysWithPendingUpdate = new ArrayList<>();
     /**
      * Moves or deletions don't need to fetch new data so they can be performed instantly once the
      * backing {@link FirebaseArray} is done updating. This will be true if the backing {@link
@@ -165,7 +165,7 @@ public class FirebaseIndexArray<T> extends CachingObservableSnapshotArray<T> imp
         String key = data.getKey();
         DatabaseReference ref = mDataRef.child(key);
 
-        mKeysWithPendingData.add(key);
+        mKeysWithPendingUpdate.add(key);
         // Start listening
         mRefs.put(ref, ref.addValueEventListener(new DataRefListener()));
     }
@@ -240,9 +240,6 @@ public class FirebaseIndexArray<T> extends CachingObservableSnapshotArray<T> imp
                     // We don't already know about this data, add it
                     mDataSnapshots.add(index, snapshot);
                     notifyChangeEventListeners(EventType.ADDED, snapshot, index);
-
-                    mKeysWithPendingData.remove(key);
-                    if (mKeysWithPendingData.isEmpty()) notifyListenersOnDataChanged();
                 }
             } else {
                 if (isKeyAtIndex(key, index)) {
@@ -255,6 +252,9 @@ public class FirebaseIndexArray<T> extends CachingObservableSnapshotArray<T> imp
                     Log.w(TAG, "Key not found at ref: " + snapshot.getRef());
                 }
             }
+
+            mKeysWithPendingUpdate.remove(key);
+            if (mKeysWithPendingUpdate.isEmpty()) notifyListenersOnDataChanged();
         }
 
         @Override


### PR DESCRIPTION
I noticed this in my app when I incorrectly deleted some stuff in my database: if the key isn't found, `onDataChanged` won't fire for addition events in `FirebaseIndexArray`.