### PR TITLE
Lockdown firebase arrays and improve index add performance

### DIFF
--- a/database/src/main/java/com/firebase/ui/database/FirebaseArray.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseArray.java
@@ -26,7 +26,8 @@ import java.util.List;
 /**
  * This class implements a collection on top of a Firebase location.
  */
-public class FirebaseArray<T> extends CachingObservableSnapshotArray<T> implements ChildEventListener, ValueEventListener {
+public final class FirebaseArray<T> extends CachingObservableSnapshotArray<T>
+        implements ChildEventListener, ValueEventListener {
     private Query mQuery;
     private List<DataSnapshot> mSnapshots = new ArrayList<>();
 

--- a/database/src/main/java/com/firebase/ui/database/FirebaseArray.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseArray.java
@@ -26,7 +26,7 @@ import java.util.List;
 /**
  * This class implements a collection on top of a Firebase location.
  */
-public final class FirebaseArray<T> extends CachingObservableSnapshotArray<T>
+public class FirebaseArray<T> extends CachingObservableSnapshotArray<T>
         implements ChildEventListener, ValueEventListener {
     private Query mQuery;
     private List<DataSnapshot> mSnapshots = new ArrayList<>();

--- a/database/src/main/java/com/firebase/ui/database/FirebaseIndexArray.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseIndexArray.java
@@ -108,7 +108,7 @@ public final class FirebaseIndexArray<T> extends CachingObservableSnapshotArray<
     public void onChildChanged(EventType type, DataSnapshot snapshot, int index, int oldIndex) {
         switch (type) {
             case ADDED:
-                onKeyAdded(snapshot, newIndex);
+                onKeyAdded(snapshot, index);
                 break;
             case MOVED:
                 onKeyMoved(snapshot, index, oldIndex);

--- a/database/src/main/java/com/firebase/ui/database/FirebaseIndexArray.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseIndexArray.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public final class FirebaseIndexArray<T> extends CachingObservableSnapshotArray<T>
+public class FirebaseIndexArray<T> extends CachingObservableSnapshotArray<T>
         implements ChangeEventListener {
     private static final String TAG = "FirebaseIndexArray";
 


### PR DESCRIPTION
Here's my reasoning behind the change:
1. Our classes aren't extensible anyway.
I'm personally a culprit here, I've never really bothered thinking about how devs would extend our firebase arrays. Take the `FirebaseIndexArray` for example. Let's say a developer wants to override `onKeyAdded`:
https://github.com/firebase/FirebaseUI-Android/blob/d871c7acd39d88ee8aba58739248804d5d34a898/database/src/main/java/com/firebase/ui/database/FirebaseIndexArray.java#L178-L185
All of the fields referenced in there are private so the developer would also have to override `onKey[Changed/Removed/Moved]`. Since they had to reimplement those methods, they also have to reimplement `DataRefListener` since it accesses private fields. And then all the other methods are private so at this point the developer has just reimplemented the whole class and there's no point in extending it in the first place. As for getting the callbacks, they should just be using our `ChangeEventListener` api.
2. It hinders improvements.
As you can see in this PR, I was able to improve performance by breaking backwards compatibility.
3. Favor composition over inheritance.
Using inheritance (on lists especially) is poor practice and we should encourage developers to use inheritance.