### PR TITLE
Remove io.fabric.ApiKey override

### DIFF
--- a/auth/src/main/AndroidManifest.xml
+++ b/auth/src/main/AndroidManifest.xml
@@ -13,10 +13,6 @@
             android:value="@integer/google_play_services_version" />
 
         <meta-data
-            android:name="io.fabric.ApiKey"
-            android:value="@string/twitter_consumer_secret" />
-
-        <meta-data
             android:name="com.facebook.sdk.ApplicationId"
             android:value="@string/facebook_application_id" />
 


### PR DESCRIPTION
Fixes https://github.com/firebase/FirebaseUI-Android/issues/904

Twitter auth is no longer part of Fabric (which is why this was added) and this override causes problems for Fabric users trying initialize without an ApiKey