### PR TITLE
Fixing race between user code submission and verification callback

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneVerificationActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneVerificationActivity.java
@@ -63,8 +63,6 @@ public class PhoneVerificationActivity extends AppCompatBase {
     @VisibleForTesting static final long AUTO_RETRIEVAL_TIMEOUT_MILLIS = 120000;
 
     private static final String KEY_VERIFICATION_PHONE = "KEY_VERIFICATION_PHONE";
-    private static final String KEY_VERIFICATION_FORCE_RESEND_TOKEN = "KEY_FORCE_RESEND_TOKEN";
-    private static final String KEY_VERIFICATION_ID = "KEY_VERIFICATION_ID";
     private static final String KEY_STATE = "KEY_STATE";
 
     private AlertDialog mAlertDialog;
@@ -90,11 +88,6 @@ public class PhoneVerificationActivity extends AppCompatBase {
         mVerificationState = VerificationState.VERIFICATION_NOT_STARTED;
         if (savedInstance != null && !savedInstance.isEmpty()) {
             mPhoneNumber = savedInstance.getString(KEY_VERIFICATION_PHONE);
-
-            // We recover any persisted verification state up until the callback is invoked.
-            // See: https://github.com/firebase/FirebaseUI-Android/issues/922
-            mVerificationId = savedInstance.getString(KEY_VERIFICATION_ID);
-            mForceResendingToken = savedInstance.getParcelable(KEY_VERIFICATION_FORCE_RESEND_TOKEN);
 
             if (savedInstance.getSerializable(KEY_STATE) != null) {
                 mVerificationState = (VerificationState) savedInstance.getSerializable(KEY_STATE);
@@ -144,8 +137,6 @@ public class PhoneVerificationActivity extends AppCompatBase {
     protected void onSaveInstanceState(Bundle outState) {
         outState.putSerializable(KEY_STATE, mVerificationState);
         outState.putString(KEY_VERIFICATION_PHONE, mPhoneNumber);
-        outState.putString(KEY_VERIFICATION_ID, mVerificationId);
-        outState.putParcelable(KEY_VERIFICATION_FORCE_RESEND_TOKEN, mForceResendingToken);
         super.onSaveInstanceState(outState);
     }
 
@@ -170,8 +161,11 @@ public class PhoneVerificationActivity extends AppCompatBase {
         if (TextUtils.isEmpty(mVerificationId) || TextUtils.isEmpty(confirmationCode)) {
             // This situation should never happen except in the case of an extreme race
             // condition, so we will just ignore the submission.
+            // See: https://github.com/firebase/FirebaseUI-Android/issues/922
             Log.w(PHONE_VERIFICATION_LOG_TAG,
-                    "submitConfirmationCode: mVerificationId is null or empty");
+                    String.format("submitConfirmationCode: mVerificationId is %s ; " +
+                            "confirmationCode is %s", mVerificationId == null ? "null" : "not null",
+                            TextUtils.isEmpty(confirmationCode) ? "empty" : "not empty"));
             return;
         }
 

--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneVerificationActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneVerificationActivity.java
@@ -164,7 +164,7 @@ public class PhoneVerificationActivity extends AppCompatBase {
             // See: https://github.com/firebase/FirebaseUI-Android/issues/922
             Log.w(PHONE_VERIFICATION_LOG_TAG,
                     String.format("submitConfirmationCode: mVerificationId is %s ; " +
-                            "confirmationCode is %s", mVerificationId == null ? "null" : "not null",
+                            "confirmationCode is %s", TextUtils.isEmpty(mVerificationId) ? "empty" : "not empty",
                             TextUtils.isEmpty(confirmationCode) ? "empty" : "not empty"));
             return;
         }


### PR DESCRIPTION
Problems:
We run into a potential race when the device is rotated and the confirmation code is submitted before
the phone verification callbacks reinstate the verification id and related params.

Solution:
We preserve the verification id and related state and reinstate it before the callbacks overwrite it.
In addition, we add speculative checks to make sure that verification id and confirmation code are not null.

Reimplementing [fix in progress](https://github.com/firebase/FirebaseUI-Android/issues/922)
Testing and tests pending. 