### PR TITLE
Fix adapter inconsistency crashes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
     - $HOME/.android/build-cache
+before_install:
+  - mkdir "$ANDROID_HOME/licenses" || true
+  - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
+  - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
 android:
   components:
     # https://github.com/travis-ci/travis-ci/issues/6040#issuecomment-219367943

--- a/firestore/src/main/java/com/firebase/ui/firestore/FirestoreRecyclerAdapter.java
+++ b/firestore/src/main/java/com/firebase/ui/firestore/FirestoreRecyclerAdapter.java
@@ -66,7 +66,7 @@ public abstract class FirestoreRecyclerAdapter<T, VH extends RecyclerView.ViewHo
 
     @Override
     public int getItemCount() {
-        return mSnapshots.size();
+        return mSnapshots.isListening(this) ? mSnapshots.size() : 0;
     }
 
     @Override


### PR DESCRIPTION
@samtstern Fixes the same issue we had with the RTDB adapter: if a `FirestoreArray` has multiple listeners and the adapter stops listening, it isn't cleared properly so trying to add items again in `startListening` causes `IndexOutOfBoundsException: Inconsistency detected` errors.