### PR TITLE
Fix broken publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,11 @@ allprojects { project ->
     def isSubmodule = submodules.contains(project.name)
 
     if (isLibrary || isSubmodule) {
+        tasks.whenTaskAdded { task ->
+            if (task.name.contains("publish") && task.name.contains("PublicationToMavenLocal")) {
+                task.dependsOn 'assemble'
+            }
+        }
 
         // So that we can resolve 'android' variable
         project.apply plugin: 'com.android.library'

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ allprojects { project ->
 
     if (isLibrary || isSubmodule) {
         tasks.whenTaskAdded { task ->
-            if (task.name.contains("publish") && task.name.contains("PublicationToMavenLocal")) {
+            if (task.name.contains("publish") && task.name.toLowerCase().contains("publication")) {
                 task.dependsOn 'assemble'
             }
         }


### PR DESCRIPTION
@samtstern I was trying to get my custom build from JitPack, but it kept failing. I'm not sure if this is just an issue on my side, but this PR basically ensures all publishing tasks first build the modules. (I think the 3.0 gradle plugin might have broken the order somewhere.)