### PR TITLE
Remove boilerplate license headers

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.firebase.ui.auth;
 
 import android.app.Activity;

--- a/auth/src/main/java/com/firebase/ui/auth/IdpResponse.java
+++ b/auth/src/main/java/com/firebase/ui/auth/IdpResponse.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.firebase.ui.auth;
 
 import android.app.Activity;

--- a/auth/src/main/java/com/firebase/ui/auth/package-info.java
+++ b/auth/src/main/java/com/firebase/ui/auth/package-info.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * The Firebase AuthUI library. See the {@link com.firebase.ui.auth.AuthUI} entry class for
  * information on using the library to manage signed-in user state.

--- a/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/FacebookProvider.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.firebase.ui.auth.provider;
 
 import android.app.Activity;

--- a/auth/src/main/java/com/firebase/ui/auth/provider/GoogleProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/GoogleProvider.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.firebase.ui.auth.provider;
 
 import android.app.Activity;

--- a/auth/src/main/java/com/firebase/ui/auth/provider/IdpProvider.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/IdpProvider.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.firebase.ui.auth.provider;
 
 import com.firebase.ui.auth.IdpResponse;

--- a/auth/src/main/java/com/firebase/ui/auth/provider/ProviderUtils.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/ProviderUtils.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.firebase.ui.auth.provider;
 
 import android.support.annotation.NonNull;
@@ -63,7 +49,7 @@ public final class ProviderUtils {
                         new TaskFailureLogger(TAG, "Error fetching providers for email"))
                 .continueWith(new Continuation<ProviderQueryResult, String>() {
                     @Override
-                    public String then(@NonNull Task<ProviderQueryResult> task) throws Exception {
+                    public String then(@NonNull Task<ProviderQueryResult> task) {
                         if (!task.isSuccessful()) return null;
 
                         List<String> providers = task.getResult().getProviders();

--- a/auth/src/main/java/com/firebase/ui/auth/provider/package-info.java
+++ b/auth/src/main/java/com/firebase/ui/auth/provider/package-info.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * IDP-specific interactions for signing in users. The contents of this package should be considered
  * an implementation detail and not part of the main API.

--- a/auth/src/main/java/com/firebase/ui/auth/ui/AppCompatBase.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/AppCompatBase.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.firebase.ui.auth.ui;
 
 import android.os.Bundle;

--- a/auth/src/main/java/com/firebase/ui/auth/ui/ExtraConstants.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/ExtraConstants.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.firebase.ui.auth.ui;
 
 import android.support.annotation.RestrictTo;

--- a/auth/src/main/java/com/firebase/ui/auth/ui/FlowParameters.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/FlowParameters.java
@@ -1,16 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.firebase.ui.auth.ui;
 
 import android.content.Intent;

--- a/auth/src/main/java/com/firebase/ui/auth/ui/TaskFailureLogger.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/TaskFailureLogger.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.firebase.ui.auth.ui;
 
 import android.support.annotation.NonNull;

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/RecoverPasswordActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/RecoverPasswordActivity.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.firebase.ui.auth.ui.email;
 
 import android.content.Context;

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/RegisterEmailActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/RegisterEmailActivity.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.firebase.ui.auth.ui.email;
 
 import android.content.Context;

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/package-info.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/package-info.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Activities related to the email and password based authentication.
  */

--- a/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.firebase.ui.auth.ui.idp;
 
 import android.content.Context;

--- a/auth/src/main/java/com/firebase/ui/auth/ui/idp/CredentialSignInHandler.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/idp/CredentialSignInHandler.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.firebase.ui.auth.ui.idp;
 
 import android.app.Activity;

--- a/auth/src/main/java/com/firebase/ui/auth/ui/idp/package-info.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/idp/package-info.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
- * Activites related to identity provider authentication.
+ * Activities related to identity provider authentication.
  */
 package com.firebase.ui.auth.ui.idp;

--- a/auth/src/main/java/com/firebase/ui/auth/ui/package-info.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/package-info.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Activities which implement the AuthUI authentication flow.
  */

--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/CompletableProgressDialog.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/CompletableProgressDialog.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.firebase.ui.auth.ui.phone;
 
 import android.app.Dialog;

--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/CountryInfo.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/CountryInfo.java
@@ -16,6 +16,7 @@
  * Modifications copyright (C) 2017 Google Inc
  *
  */
+
 package com.firebase.ui.auth.ui.phone;
 
 import java.text.Collator;

--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/CountryListSpinner.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/CountryListSpinner.java
@@ -15,6 +15,7 @@
  *
  * Modifications copyright (C) 2017 Google Inc
  */
+
 package com.firebase.ui.auth.ui.phone;
 
 import android.app.AlertDialog;

--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/CustomCountDownTimer.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/CustomCountDownTimer.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.firebase.ui.auth.ui.phone;
 
 import android.os.CountDownTimer;

--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneNumber.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneNumber.java
@@ -15,6 +15,7 @@
  *
  * Modifications copyright (C) 2017 Google Inc
  */
+
 package com.firebase.ui.auth.ui.phone;
 
 import android.text.TextUtils;

--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneNumberUtils.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneNumberUtils.java
@@ -15,6 +15,7 @@
  *
  * Modifications copyright (C) 2017 Google Inc
  */
+
 package com.firebase.ui.auth.ui.phone;
 
 import android.content.Context;

--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneVerificationActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneVerificationActivity.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.firebase.ui.auth.ui.phone;
 
 import android.content.Context;

--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/SubmitConfirmationCodeFragment.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/SubmitConfirmationCodeFragment.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.firebase.ui.auth.ui.phone;
 
 import android.content.Context;

--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/VerifyPhoneNumberFragment.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/VerifyPhoneNumberFragment.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.firebase.ui.auth.ui.phone;
 
 import android.app.PendingIntent;

--- a/auth/src/main/java/com/firebase/ui/auth/util/Preconditions.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/Preconditions.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.firebase.ui.auth.util;
 
 import android.content.Context;

--- a/auth/src/main/java/com/firebase/ui/auth/util/package-info.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/package-info.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Utilities to simplify interactions with {@code GoogleApiClient} and the APIs it provides, such as
  * Google Sign-in and Smart Lock for Passwords. The contents of this package should be considered an


### PR DESCRIPTION
This is just an itty bitty nit I have, dunno if you want to go through with it. The Apache license doesn't require a header and we haven't been using one in new files for ages now, so I just wanted to make our code consistent and get rid of our current headers (except for the twitter code which has the special modifications license header). What do you think?