### PR TITLE
Update Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,14 @@ cache:
     - $HOME/.android/build-cache
 before_install:
   - mkdir "$ANDROID_HOME/licenses" || true
-  - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
-  - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
+  - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55\nd56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
+  - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd\n504667f4c0de7af1a06de9f4b1727b84351f2910" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
 android:
   components:
     # https://github.com/travis-ci/travis-ci/issues/6040#issuecomment-219367943
     - tools
     - tools
-    - platform-tools
-    - android-26
-    - build-tools-26.0.1
-before_script:
-  - mv library/google-services.json app/google-services.json
-  - echo y | ${ANDROID_HOME}tools/bin/sdkmanager --channel=3 "tools" "platform-tools" "build-tools;26.0.2" "platforms;android-26"
+before_script: mv library/google-services.json app/google-services.json
 script: ./gradlew clean assembleDebug check
 after_failure:
   # tests

--- a/constants.gradle
+++ b/constants.gradle
@@ -9,6 +9,6 @@ project.ext {
     minSdk = 14
 
     firebaseVersion = '11.6.2'
-    supportLibraryVersion = '27.0.1'
+    supportLibraryVersion = '27.0.2'
     architectureVersion = '1.0.0'
 }


### PR DESCRIPTION
@samtstern the [previous Travis fix](https://github.com/firebase/FirebaseUI-Android/pull/1047) is pretty random and downloads API 26 which we aren't using anymore. This PR gets rid of all that and just lets the gradle plugin figure things out which is what we had in the dev branch.

_Who doesn't love a randomly broken Travis build, eh? 😆_