### PR TITLE
Use to Stale to simplify GitHub issue cleanup

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,6 +4,7 @@ exemptLabels:
   - feature
   - enhancement
   - bug
+  - refactor
   - docs
   - fix-implemented
 staleLabel: stale

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,13 @@
+daysUntilStale: 7
+daysUntilClose: 7
+exemptLabels:
+  - feature
+  - bug
+  - docs
+  - fix-implemented
+staleLabel: stale
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,6 +2,7 @@ daysUntilStale: 7
 daysUntilClose: 7
 exemptLabels:
   - feature
+  - enhancement
   - bug
   - docs
   - fix-implemented


### PR DESCRIPTION
@samtstern As you've probably noticed, I usually try to occasionally go through rounds where I ping you about a bunch of issues that can be closed now, but after working on Glide, I've noticed that Sam J. (yes, another awesome Sam! 😄) uses [Stale](https://github.com/apps/stale). The idea is very cool: until an issue is tagged with special tags (whitelisted), it's up for removal and will be closed (becomes stale) if there isn't a comment within a customizable timeout.

I've always been amazed at how few issues an incredibly popular library like Glide has, and it's all thanks to Stale. It would basically be a huge help in upkeeping our own issues. What do you think? If I had write access to the repo, I would totally set this up! 😜

If you do want to go through with this PR and Stale, you'll need to do a few things:
1. Add it to the `firebase` organization through the link above
1. Add a `feature` and `stale` label
1. That's it! Then, just make sure to add `feature`, `bug`, or `docs` tags once you're sure we're going to follow through on an issue.