### PR TITLE
Fix crash using email authentication on API 19. Fixes issue #1036

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/EmailActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/EmailActivity.java
@@ -125,8 +125,9 @@ public class EmailActivity extends AppCompatBase implements
                     .replace(R.id.fragment_register_email, fragment, RegisterEmailFragment.TAG);
 
             if (emailLayout != null) {
-                ViewCompat.setTransitionName(emailLayout, "email_field");
-                ft.addSharedElement(emailLayout, "email_field");
+                String emailFieldName = getString(R.string.email_field_name);
+                ViewCompat.setTransitionName(emailLayout, emailFieldName);
+                ft.addSharedElement(emailLayout, emailFieldName);
             }
 
             ft.disallowAddToBackStack().commit();

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/EmailActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/EmailActivity.java
@@ -125,7 +125,7 @@ public class EmailActivity extends AppCompatBase implements
                     .replace(R.id.fragment_register_email, fragment, RegisterEmailFragment.TAG);
 
             if (emailLayout != null) {
-                String emailFieldName = getString(R.string.email_field_name);
+                String emailFieldName = getString(R.string.fui_email_field_name);
                 ViewCompat.setTransitionName(emailLayout, emailFieldName);
                 ft.addSharedElement(emailLayout, emailFieldName);
             }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/EmailActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/EmailActivity.java
@@ -20,6 +20,7 @@ import android.os.Bundle;
 import android.support.annotation.RestrictTo;
 import android.support.design.widget.TextInputLayout;
 import android.support.v4.app.FragmentTransaction;
+import android.support.v4.view.ViewCompat;
 
 import com.firebase.ui.auth.IdpResponse;
 import com.firebase.ui.auth.R;
@@ -123,7 +124,10 @@ public class EmailActivity extends AppCompatBase implements
             FragmentTransaction ft = getSupportFragmentManager().beginTransaction()
                     .replace(R.id.fragment_register_email, fragment, RegisterEmailFragment.TAG);
 
-            if (emailLayout != null) ft.addSharedElement(emailLayout, "email_field");
+            if (emailLayout != null) {
+                ViewCompat.setTransitionName(emailLayout, "email_field");
+                ft.addSharedElement(emailLayout, "email_field");
+            }
 
             ft.disallowAddToBackStack().commit();
         } else {

--- a/auth/src/main/res/layout/fui_check_email_layout.xml
+++ b/auth/src/main/res/layout/fui_check_email_layout.xml
@@ -18,7 +18,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/fui_field_padding_vert"
             android:transitionGroup="true"
-            android:transitionName="@string/email_field_name"
+            android:transitionName="@string/fui_email_field_name"
             app:errorEnabled="true"
             tools:ignore="UnusedAttribute">
 

--- a/auth/src/main/res/layout/fui_check_email_layout.xml
+++ b/auth/src/main/res/layout/fui_check_email_layout.xml
@@ -18,7 +18,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/fui_field_padding_vert"
             android:transitionGroup="true"
-            android:transitionName="email_field"
+            android:transitionName="@string/email_field_name"
             app:errorEnabled="true"
             tools:ignore="UnusedAttribute">
 

--- a/auth/src/main/res/layout/fui_register_email_layout.xml
+++ b/auth/src/main/res/layout/fui_register_email_layout.xml
@@ -18,7 +18,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/fui_field_padding_vert"
             android:transitionGroup="true"
-            android:transitionName="email_field"
+            android:transitionName="@string/fui_email_field_name"
             app:errorEnabled="true"
             tools:ignore="UnusedAttribute">
 

--- a/auth/src/main/res/values/strings.xml
+++ b/auth/src/main/res/values/strings.xml
@@ -100,5 +100,5 @@
     <string name="fui_verify_phone_number" translation_description="Button text to submit confirmation code and complete phone verification">Verify Phone Number</string>
     <string name="fui_continue_phone_login" translation_description="Button text to submit phone number and send sms">Continue</string>
     <string name="fui_sms_terms_of_service" translation_description="Fine print warning displayed below Verify Phone Number button">By tapping “%1$s”, an SMS may be sent. Message &amp; data rates may apply.</string>
-    <string name="email_field_name">email_field</string>
+    <string name="fui_email_field_name">email_field</string>
 </resources>

--- a/auth/src/main/res/values/strings.xml
+++ b/auth/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="fui_create_account_preamble_pp_only" translation_description="Text shown when creating an account with only privacy policy">By tapping <xliff:g example="SAVE" id="btn" translation_description="">%1$s</xliff:g> you are indicating that you agree to the <xliff:g example="https://google.com/privacy" id="pp" translation_description="">%2$s</xliff:g>.</string>
     <string name="fui_terms_of_service" translation_description="Link text to web url containing the app's terms of service">Terms of Service</string>
     <string name="fui_privacy_policy" translation_description="Link text to web url containing the app's privacy policy">Privacy Policy</string>
+    <string name="fui_email_field_name" translatable="false">email_field</string>
 
     <!-- Idp/Email welcome back -->
     <string name="fui_title_welcome_back_idp_prompt" translatable="false">@string/fui_sign_in_default</string>
@@ -100,5 +101,4 @@
     <string name="fui_verify_phone_number" translation_description="Button text to submit confirmation code and complete phone verification">Verify Phone Number</string>
     <string name="fui_continue_phone_login" translation_description="Button text to submit phone number and send sms">Continue</string>
     <string name="fui_sms_terms_of_service" translation_description="Fine print warning displayed below Verify Phone Number button">By tapping “%1$s”, an SMS may be sent. Message &amp; data rates may apply.</string>
-    <string name="fui_email_field_name">email_field</string>
 </resources>

--- a/auth/src/main/res/values/strings.xml
+++ b/auth/src/main/res/values/strings.xml
@@ -100,4 +100,5 @@
     <string name="fui_verify_phone_number" translation_description="Button text to submit confirmation code and complete phone verification">Verify Phone Number</string>
     <string name="fui_continue_phone_login" translation_description="Button text to submit phone number and send sms">Continue</string>
     <string name="fui_sms_terms_of_service" translation_description="Fine print warning displayed below Verify Phone Number button">By tapping “%1$s”, an SMS may be sent. Message &amp; data rates may apply.</string>
+    <string name="email_field_name">email_field</string>
 </resources>


### PR DESCRIPTION
Once more with style - using email authentication on Android API 19 results in a crash from the library. This PR resolves that issue (#1036).
