### PR TITLE
Fix lintchecks module

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     testImplementation 'com.facebook.android:facebook-login:4.29.0'
     testImplementation("com.twitter.sdk.android:twitter-core:3.1.1@aar") { transitive = true }
 
-    implementation project(':internal:lintchecks')
+    debugImplementation project(':internal:lintchecks')
 }
 
 javadoc.include([


### PR DESCRIPTION
`Fixes` #1116

We'll only get lint errors on our debug builds, but this means we don't have to publish the module. 👍