### PR TITLE
Update Support Library Version

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -340,7 +340,6 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (resultCode == RESULT_OK) {
             startActivity(SignedInActivity.createIntent(this, response));
             finish();
-            return;
         } else {
             // Sign in failed
             if (response == null) {
@@ -349,20 +348,16 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
                 return;
             }
 
-            if (response.getErrorCode() == ErrorCodes.NO_NETWORK) {
+            if (response.getError().getErrorCode() == ErrorCodes.NO_NETWORK) {
                 showSnackbar(R.string.no_internet_connection);
                 return;
             }
-
-            if (response.getErrorCode() == ErrorCodes.UNKNOWN_ERROR) {
-                showSnackbar(R.string.unknown_error);
-                return;
-            }
+        
+            showSnackbar(R.string.unknown_error);
+            Log.e(TAG, "Sign-in error: ", response.getError());
         }
-
-        showSnackbar(R.string.unknown_sign_in_response);
     }
- }
+}
 ```
 
 Alternatively, you can register a listener for authentication state changes;

--- a/constants.gradle
+++ b/constants.gradle
@@ -9,7 +9,7 @@ project.ext {
     minSdk = 14
 
     firebaseVersion = '11.8.0'
-    supportLibraryVersion = '27.0.2'
+    supportLibraryVersion = '27.1.0'
     architectureVersion = '1.1.0'
     kotlinVersion = '1.2.21'
 }


### PR DESCRIPTION
Support Library is updated to version 27.1.0 on February 2018 and I think FirebaseUI should update its dependency. In my current project updating support library results in "Unable to merge dex". Please upgrade and release a new version as soon as possible.

Hey there! So you want to contribute to FirebaseUI? Before you file this pull request, follow these steps:

  * Read [the contribution guidelines](CONTRIBUTING.md).
  * Run `./gradlew check` to ensure the Travis build passes.
  * If this has been discussed in an issue, make sure to mention the issue number here. If not, go file an issue about this to make sure this is a desirable change.
  * If this is a new feature please co-ordinate with someone on [FirebaseUI-iOS](https://github.com/firebase/firebaseui-ios) to make sure that we can implement this on both platforms and maintain feature parity.
