### PR TITLE
Don't notify data changed if there were no document changes

### DIFF
--- a/firestore/src/main/java/com/firebase/ui/firestore/FirestoreArray.java
+++ b/firestore/src/main/java/com/firebase/ui/firestore/FirestoreArray.java
@@ -91,7 +91,7 @@ public class FirestoreArray<T> extends ObservableSnapshotArray<T>
             }
         }
 
-        notifyOnDataChanged();
+        if (!changes.isEmpty()) { notifyOnDataChanged(); }
     }
 
     private void onDocumentAdded(DocumentChange change) {


### PR DESCRIPTION
I ran into issues with my loading animations being broken if Firestore sent an update event with no changes. Also, doesn't make sense to have an `onDataChanged` event callback when no data changed. 😉