### PR TITLE
Fix crash when part of the exception tree isn't serializable

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/IdpResponse.java
+++ b/auth/src/main/java/com/firebase/ui/auth/IdpResponse.java
@@ -28,6 +28,10 @@ import com.firebase.ui.auth.util.ExtraConstants;
 import com.google.firebase.auth.GoogleAuthProvider;
 import com.google.firebase.auth.TwitterAuthProvider;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+
 /**
  * A container that encapsulates the result of authenticating with an Identity Provider.
  */
@@ -195,7 +199,19 @@ public class IdpResponse implements Parcelable {
         dest.writeParcelable(mUser, flags);
         dest.writeString(mToken);
         dest.writeString(mSecret);
-        dest.writeSerializable(mException);
+
+        try {
+            ObjectOutputStream oos = new ObjectOutputStream(new ByteArrayOutputStream());
+            oos.writeObject(mException);
+            oos.close();
+
+            // Success! The entire exception tree is serializable.
+            dest.writeSerializable(mException);
+        } catch (IOException e) {
+            // Somewhere down the line, the exception is holding on to an object that isn't
+            // serializable so default to some exception. It's the best we can do in this case.
+            dest.writeSerializable(new FirebaseUiException(ErrorCodes.UNKNOWN_ERROR));
+        }
     }
 
     @Override

--- a/auth/src/main/java/com/firebase/ui/auth/IdpResponse.java
+++ b/auth/src/main/java/com/firebase/ui/auth/IdpResponse.java
@@ -200,10 +200,10 @@ public class IdpResponse implements Parcelable {
         dest.writeString(mToken);
         dest.writeString(mSecret);
 
+        ObjectOutputStream oos = null;
         try {
-            ObjectOutputStream oos = new ObjectOutputStream(new ByteArrayOutputStream());
+            oos = new ObjectOutputStream(new ByteArrayOutputStream());
             oos.writeObject(mException);
-            oos.close();
 
             // Success! The entire exception tree is serializable.
             dest.writeSerializable(mException);
@@ -211,6 +211,12 @@ public class IdpResponse implements Parcelable {
             // Somewhere down the line, the exception is holding on to an object that isn't
             // serializable so default to some exception. It's the best we can do in this case.
             dest.writeSerializable(new FirebaseUiException(ErrorCodes.UNKNOWN_ERROR));
+        } finally {
+            if (oos != null) {
+                try {
+                    oos.close();
+                } catch (IOException ignored) {}
+            }
         }
     }
 


### PR DESCRIPTION
@samtstern Got this crash in my app. I couldn't figure out a good solution, so this is the hack I've come up with in the meantime. Also, could you possibly make the `Status` serializable? You would lose the `PendingIntent`, but all the other fields are serializable. If not, that totally makes sense since `Serializable` isn't really a thing in the Android world.

Stack trace:
```
Caused by java.io.NotSerializableException
com.google.android.gms.common.api.Status
java.io.ObjectOutputStream.writeNewObject (ObjectOutputStream.java:1364)
java.io.ObjectOutputStream.writeObjectInternal (ObjectOutputStream.java:1671)
java.io.ObjectOutputStream.writeObject (ObjectOutputStream.java:1517)
java.io.ObjectOutputStream.writeObject (ObjectOutputStream.java:1481)
java.io.ObjectOutputStream.writeFieldValues (ObjectOutputStream.java:979)
java.io.ObjectOutputStream.defaultWriteObject (ObjectOutputStream.java:368)
java.io.ObjectOutputStream.writeHierarchy (ObjectOutputStream.java:1074)
java.io.ObjectOutputStream.writeNewObject (ObjectOutputStream.java:1404)
java.io.ObjectOutputStream.writeObjectInternal (ObjectOutputStream.java:1671)
java.io.ObjectOutputStream.writeObject (ObjectOutputStream.java:1517)
java.io.ObjectOutputStream.writeObject (ObjectOutputStream.java:1481)
java.io.ObjectOutputStream.writeFieldValues (ObjectOutputStream.java:979)
java.io.ObjectOutputStream.defaultWriteObject (ObjectOutputStream.java:368)
java.lang.Throwable.writeObject (Throwable.java:440)
java.lang.reflect.Method.invokeNative (Method.java)
java.lang.reflect.Method.invoke (Method.java:511)
java.io.ObjectOutputStream.writeHierarchy (ObjectOutputStream.java:1053)
java.io.ObjectOutputStream.writeNewObject (ObjectOutputStream.java:1404)
java.io.ObjectOutputStream.writeObjectInternal (ObjectOutputStream.java:1671)
java.io.ObjectOutputStream.writeObject (ObjectOutputStream.java:1517)
java.io.ObjectOutputStream.writeObject (ObjectOutputStream.java:1481)
android.os.Parcel.writeSerializable (Parcel.java:1274)
com.firebase.ui.auth.IdpResponse.writeToParcel (SourceFile:212)
android.os.Parcel.writeParcelable (Parcel.java:1254)
android.os.Parcel.writeValue (Parcel.java:1173)
android.os.Parcel.writeMapInternal (Parcel.java:591)
android.os.Bundle.writeToParcel (Bundle.java:1619)
android.os.Parcel.writeBundle (Parcel.java:605)
android.content.Intent.writeToParcel (Intent.java:6790)
android.app.ActivityManagerProxy.finishActivity (ActivityManagerNative.java:2059)
android.app.Activity.finish (Activity.java:4167)
com.firebase.ui.auth.ui.HelperActivityBase.finish (SourceFile:101)
com.firebase.ui.auth.ui.idp.CredentialSignInHandler$1.onFailure (SourceFile:85)
com.google.android.gms.tasks.zzh.run (Unknown Source:3000)
android.os.Handler.handleCallback (Handler.java:615)
android.os.Handler.dispatchMessage (Handler.java:92)
android.os.Looper.loop (Looper.java:137)
android.app.ActivityThread.main (ActivityThread.java:4895)
java.lang.reflect.Method.invokeNative (Method.java)
java.lang.reflect.Method.invoke (Method.java:511)
com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run (ZygoteInit.java:994)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:761)
dalvik.system.NativeStart.main (NativeStart.java)
```