### PR TITLE
Silent sign in

### DIFF
--- a/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
@@ -172,8 +172,7 @@ public class AuthUiActivity extends AppCompatActivity {
     @OnClick(R.id.sign_in_silent)
     public void silentSignIn(View view) {
         List<IdpConfig> providers = new ArrayList<>();
-        List<IdpConfig> selected = getSelectedProviders();
-        for (IdpConfig config : selected) {
+        for (IdpConfig config : getSelectedProviders()) {
             String provider = config.getProviderId();
             if (provider.equals(EmailAuthProvider.PROVIDER_ID)
                     || provider.equals(GoogleAuthProvider.PROVIDER_ID)) {

--- a/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
@@ -18,6 +18,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.DrawableRes;
+import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.support.annotation.StyleRes;
 import android.support.design.widget.Snackbar;
@@ -25,7 +26,6 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.app.AppCompatDelegate;
 import android.util.Log;
 import android.view.View;
-import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
@@ -38,7 +38,12 @@ import com.firebase.ui.auth.ErrorCodes;
 import com.firebase.ui.auth.IdpResponse;
 import com.firebase.uidemo.R;
 import com.google.android.gms.common.Scopes;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.auth.AuthResult;
+import com.google.firebase.auth.EmailAuthProvider;
 import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.GoogleAuthProvider;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -59,7 +64,6 @@ public class AuthUiActivity extends AppCompatActivity {
     private static final int RC_SIGN_IN = 100;
 
     @BindView(R.id.root) View mRootView;
-    @BindView(R.id.sign_in) Button mSignIn;
 
     @BindView(R.id.google_provider) CheckBox mUseGoogleProvider;
     @BindView(R.id.facebook_provider) CheckBox mUseFacebookProvider;
@@ -163,6 +167,31 @@ public class AuthUiActivity extends AppCompatActivity {
                                 mEnableHintSelector.isChecked())
                         .build(),
                 RC_SIGN_IN);
+    }
+
+    @OnClick(R.id.sign_in_silent)
+    public void silentSignIn(View view) {
+        List<IdpConfig> providers = new ArrayList<>();
+        List<IdpConfig> selected = getSelectedProviders();
+        for (IdpConfig config : selected) {
+            String provider = config.getProviderId();
+            if (provider.equals(EmailAuthProvider.PROVIDER_ID)
+                    || provider.equals(GoogleAuthProvider.PROVIDER_ID)) {
+                providers.add(config);
+            }
+        }
+
+        AuthUI.getInstance().silentSignIn(this, providers)
+                .addOnCompleteListener(new OnCompleteListener<AuthResult>() {
+                    @Override
+                    public void onComplete(@NonNull Task<AuthResult> task) {
+                        if (task.isSuccessful()) {
+                            startSignedInActivity(null);
+                        } else {
+                            showSnackbar(R.string.sign_in_failed);
+                        }
+                    }
+                });
     }
 
     @Override

--- a/app/src/main/res/layout/auth_ui_layout.xml
+++ b/app/src/main/res/layout/auth_ui_layout.xml
@@ -35,8 +35,17 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:layout_margin="16dp"
+                android:layout_marginTop="16dp"
                 android:text="@string/sign_in_start" />
+
+            <Button
+                android:id="@+id/sign_in_silent"
+                style="@style/Widget.AppCompat.Button.Colored"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginBottom="16dp"
+                android:text="@string/sign_in_silent" />
 
             <TextView
                 style="@style/Base.TextAppearance.AppCompat.Subhead"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <!-- Auth UI -->
     <string name="launch_title">FirebaseUI Auth Demo</string>
     <string name="sign_in_start">Start</string>
+    <string name="sign_in_silent">Sign in silently</string>
 
     <string name="providers_header">Auth providers</string>
     <string name="providers_google">Google</string>
@@ -70,6 +71,7 @@
     <string name="sign_out">Sign out</string>
     <string name="delete_account_label">Delete account</string>
 
+    <string name="sign_in_failed">Sign in failed</string>
     <string name="sign_out_failed">Sign out failed</string>
     <string name="delete_account_failed">Delete account failed</string>
 

--- a/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
@@ -271,14 +271,15 @@ public class AuthUI {
      * Signs the user in without any UI if possible. If this operation fails, you can safely start a
      * UI-based sign-in flow knowing it is required.
      *
-     * @param context the context requesting the user be signed in
+     * @param context requesting the user be signed in
+     * @param configs to use for silent sign in
      * @return a task which indicates whether or not the user was successfully signed in.
      */
     @NonNull
     public Task<AuthResult> silentSignIn(@NonNull final Context context,
                                          @NonNull List<IdpConfig> configs) {
         if (configs.isEmpty()) {
-            throw new IllegalArgumentException("Configs must not be empty.");
+            throw new IllegalArgumentException("At least one provider must be specified.");
         }
         for (IdpConfig config : configs) {
             String provider = config.getProviderId();

--- a/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
@@ -267,7 +267,16 @@ public class AuthUI {
         return R.style.FirebaseUI;
     }
 
-    public Task<AuthResult> silentSignIn(@NonNull final Context context, List<IdpConfig> configs) {
+    /**
+     * Signs the user in without any UI if possible. If this operation fails, you can safely start a
+     * UI-based sign-in flow knowing it is required.
+     *
+     * @param context the context requesting the user be signed in
+     * @return a task which indicates whether or not the user was successfully signed in.
+     */
+    @NonNull
+    public Task<AuthResult> silentSignIn(@NonNull final Context context,
+                                         @NonNull List<IdpConfig> configs) {
         if (configs.isEmpty()) {
             throw new IllegalArgumentException("Configs must not be empty.");
         }
@@ -279,9 +288,8 @@ public class AuthUI {
                         "for silent sign-in.");
             }
         }
-
         if (mAuth.getCurrentUser() != null) {
-            return Tasks.forException(new IllegalStateException("User already signed in!"));
+            throw new IllegalArgumentException("User already signed in!");
         }
 
         final IdpConfig google =


### PR DESCRIPTION
Proposal for #1039. @samtstern What do you think? Is this something that should go in FirebaseUI Auth? Personally, I think this is huge since it means a zero-effort way for developers to provide seamless sign-in after their users upgrade devices or reinstall their apps.

PS: to try it, just sign in with Google or email, clear app data, and then press the silent sign-in button.