### PR TITLE
Improve exception error messages

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ErrorCodes.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ErrorCodes.java
@@ -1,6 +1,8 @@
 package com.firebase.ui.auth;
 
 import android.support.annotation.IntDef;
+import android.support.annotation.NonNull;
+import android.support.annotation.RestrictTo;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -49,5 +51,24 @@ public final class ErrorCodes {
 
     private ErrorCodes() {
         throw new AssertionError("No instance for you!");
+    }
+
+    @NonNull
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public static String toFriendlyMessage(@Code int code) {
+        switch (code) {
+            case UNKNOWN_ERROR:
+                return "Unknown error";
+            case NO_NETWORK:
+                return "No internet connection";
+            case PLAY_SERVICES_UPDATE_CANCELLED:
+                return "Play Services update cancelled";
+            case DEVELOPER_ERROR:
+                return "Developer error";
+            case PROVIDER_ERROR:
+                return "Provider error";
+            default:
+                throw new IllegalArgumentException("Unknown code: " + code);
+        }
     }
 }

--- a/auth/src/main/java/com/firebase/ui/auth/FirebaseUiException.java
+++ b/auth/src/main/java/com/firebase/ui/auth/FirebaseUiException.java
@@ -11,7 +11,7 @@ public class FirebaseUiException extends Exception {
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     public FirebaseUiException(@ErrorCodes.Code int code) {
-        mErrorCode = code;
+        this(code, ErrorCodes.toFriendlyMessage(code));
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -21,16 +21,15 @@ public class FirebaseUiException extends Exception {
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public FirebaseUiException(@ErrorCodes.Code int code, @NonNull Throwable cause) {
+        this(code, ErrorCodes.toFriendlyMessage(code), cause);
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     public FirebaseUiException(@ErrorCodes.Code int code,
                                @NonNull String message,
                                @NonNull Throwable cause) {
         super(message, cause);
-        mErrorCode = code;
-    }
-
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    public FirebaseUiException(@ErrorCodes.Code int code, @NonNull Throwable cause) {
-        super(cause);
         mErrorCode = code;
     }
 

--- a/auth/src/main/java/com/firebase/ui/auth/IdpResponse.java
+++ b/auth/src/main/java/com/firebase/ui/auth/IdpResponse.java
@@ -103,7 +103,9 @@ public class IdpResponse implements Parcelable {
         if (e instanceof FirebaseUiException) {
             return new IdpResponse((FirebaseUiException) e);
         } else {
-            return new IdpResponse(new FirebaseUiException(ErrorCodes.UNKNOWN_ERROR, e));
+            FirebaseUiException wrapped = new FirebaseUiException(ErrorCodes.UNKNOWN_ERROR, e);
+            wrapped.setStackTrace(e.getStackTrace());
+            return new IdpResponse(wrapped);
         }
     }
 
@@ -213,7 +215,11 @@ public class IdpResponse implements Parcelable {
         } catch (IOException e) {
             // Somewhere down the line, the exception is holding on to an object that isn't
             // serializable so default to some exception. It's the best we can do in this case.
-            dest.writeSerializable(new FirebaseUiException(ErrorCodes.UNKNOWN_ERROR));
+            FirebaseUiException fake = new FirebaseUiException(ErrorCodes.UNKNOWN_ERROR,
+                    "Fake exception created, original: " + mException
+                            + ", original cause: " + mException.getCause());
+            fake.setStackTrace(mException.getStackTrace());
+            dest.writeSerializable(fake);
         } finally {
             if (oos != null) {
                 try {


### PR DESCRIPTION
While testing some changes in #1203, I noticed that we don't say anything about our exceptions by default which makes for somewhat useless logs. This PR fixes that.