### PR TITLE
Catch setFirebaseUIVersion crashes

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
@@ -210,7 +210,11 @@ public class AuthUI {
         mApp = app;
         mAuth = FirebaseAuth.getInstance(mApp);
 
-        mAuth.setFirebaseUIVersion(BuildConfig.VERSION_NAME);
+        try {
+            mAuth.setFirebaseUIVersion(BuildConfig.VERSION_NAME);
+        } catch (Exception e) {
+            Log.e(TAG, "Couldn't set the FUI version.", e);
+        }
         mAuth.useAppLanguage();
     }
 


### PR DESCRIPTION
@samtstern I'm still getting crashes with 12.0.1 so I've kinda given up on that method.

Stack trace:
```java
Fatal Exception: java.lang.NullPointerException
Attempt to invoke virtual method 'com.google.android.gms.g.f com.google.android.gms.common.api.e.b(com.google.android.gms.common.api.internal.cb)' on a null object reference
com.google.android.gms.internal.zzdza.zzb (Unknown Source)
com.firebase.ui.auth.AuthUI.com.google.android.gms.internal.zzdzh.setFirebaseUIVersion (SourceFile:2000)
com.firebase.ui.auth.AuthUI.getInstance (SourceFile:255)
com.firebase.ui.auth.AuthUI.getInstance (SourceFile:243)
com.supercilex.robotscouter.util.AuthKt$onSignedIn$2$1.onAuthStateChanged (SourceFile:42)
com.google.firebase.auth.zzj.run (Unknown Source)
android.os.Handler.handleCallback (Handler.java:751)
android.os.Handler.dispatchMessage (Handler.java:95)
android.os.Looper.loop (Looper.java:241)
android.app.ActivityThread.main (ActivityThread.java:6281)
java.lang.reflect.Method.invoke (Method.java)
com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run (ZygoteInit.java:886)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:776)
```