### PR TITLE
Fix view model crashes when long-running task finishes after model is cleared

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/viewmodel/ViewModelBase.java
+++ b/auth/src/main/java/com/firebase/ui/auth/viewmodel/ViewModelBase.java
@@ -39,6 +39,5 @@ public abstract class ViewModelBase<T> extends AndroidViewModel {
     @Override
     protected void onCleared() {
         mIsInitialized.set(false);
-        mArguments = null;
     }
 }


### PR DESCRIPTION
Man, gotta love assumptions. 😆 Anyway, I looked through a few of our view models and since we operate on a subscription model, it doesn't really matter if the model keeps doing stuff beyond `onCleared`. The alternative is adding a gazillion `isActive` checks... so nah. 😉