### PR TITLE
Prevent back-button state loss bug with phone verification

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/data/model/CountryInfo.java
+++ b/auth/src/main/java/com/firebase/ui/auth/data/model/CountryInfo.java
@@ -18,13 +18,26 @@
  */
 package com.firebase.ui.auth.data.model;
 
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.RestrictTo;
 
 import java.text.Collator;
 import java.util.Locale;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-public final class CountryInfo implements Comparable<CountryInfo> {
+public final class CountryInfo implements Comparable<CountryInfo>,Parcelable {
+
+    public static final Parcelable.Creator<CountryInfo> CREATOR = new Parcelable.Creator<CountryInfo>() {
+        @Override
+        public CountryInfo createFromParcel(Parcel source) {return new CountryInfo(source);}
+
+        @Override
+        public CountryInfo[] newArray(int size) {
+            return new CountryInfo[size];
+        }
+    };
+
     private final Collator mCollator;
     private final Locale mLocale;
     private final int mCountryCode;
@@ -34,6 +47,14 @@ public final class CountryInfo implements Comparable<CountryInfo> {
         mCollator.setStrength(Collator.PRIMARY);
         mLocale = locale;
         mCountryCode = countryCode;
+    }
+
+    protected CountryInfo(Parcel in) {
+        mCollator = Collator.getInstance(Locale.getDefault());
+        mCollator.setStrength(Collator.PRIMARY);
+
+        mLocale = (Locale) in.readSerializable();
+        mCountryCode = in.readInt();
     }
 
     public static String localeToEmoji(Locale locale) {
@@ -84,5 +105,14 @@ public final class CountryInfo implements Comparable<CountryInfo> {
     @Override
     public int compareTo(CountryInfo info) {
         return mCollator.compare(mLocale.getDisplayCountry(), info.mLocale.getDisplayCountry());
+    }
+
+    @Override
+    public int describeContents() { return 0; }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeSerializable(this.mLocale);
+        dest.writeInt(this.mCountryCode);
     }
 }

--- a/auth/src/main/java/com/firebase/ui/auth/data/model/CountryInfo.java
+++ b/auth/src/main/java/com/firebase/ui/auth/data/model/CountryInfo.java
@@ -26,11 +26,13 @@ import java.text.Collator;
 import java.util.Locale;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-public final class CountryInfo implements Comparable<CountryInfo>,Parcelable {
+public final class CountryInfo implements Comparable<CountryInfo>, Parcelable {
 
     public static final Parcelable.Creator<CountryInfo> CREATOR = new Parcelable.Creator<CountryInfo>() {
         @Override
-        public CountryInfo createFromParcel(Parcel source) {return new CountryInfo(source);}
+        public CountryInfo createFromParcel(Parcel source) {
+            return new CountryInfo(source);
+        }
 
         @Override
         public CountryInfo[] newArray(int size) {
@@ -108,11 +110,13 @@ public final class CountryInfo implements Comparable<CountryInfo>,Parcelable {
     }
 
     @Override
-    public int describeContents() { return 0; }
+    public int describeContents() {
+        return 0;
+    }
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
-        dest.writeSerializable(this.mLocale);
-        dest.writeInt(this.mCountryCode);
+        dest.writeSerializable(mLocale);
+        dest.writeInt(mCountryCode);
     }
 }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/VerifyPhoneNumberFragment.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/VerifyPhoneNumberFragment.java
@@ -202,13 +202,14 @@ public class VerifyPhoneNumberFragment extends FragmentBase implements View.OnCl
         if (phoneNumber == null) {
             mPhoneInputLayout.setError(getString(R.string.fui_invalid_phone_number));
         } else {
+            mPhoneInputLayout.setError(null);
             mVerifier.verifyPhoneNumber(phoneNumber, false);
         }
     }
 
     @Nullable
     private String getPseudoValidPhoneNumber() {
-        final CountryInfo countryInfo = (CountryInfo) mCountryListSpinner.getTag();
+        final CountryInfo countryInfo = mCountryListSpinner.getSelectedCountryInfo();
         final String everythingElse = mPhoneEditText.getText().toString();
 
         if (TextUtils.isEmpty(everythingElse)) {

--- a/auth/src/test/java/com/firebase/ui/auth/ui/phone/PhoneActivityTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/phone/PhoneActivityTest.java
@@ -131,7 +131,7 @@ public class PhoneActivityTest {
 
         assertEquals(PHONE_NO_COUNTRY_CODE, mPhoneEditText.getText().toString());
         assertEquals(YE_COUNTRY_CODE,
-                String.valueOf(((CountryInfo) mCountryListSpinner.getTag()).getCountryCode()));
+                String.valueOf((mCountryListSpinner.getSelectedCountryInfo()).getCountryCode()));
     }
 
     @Test
@@ -157,9 +157,9 @@ public class PhoneActivityTest {
 
         assertEquals(PHONE_NO_COUNTRY_CODE, mPhoneEditText.getText().toString());
         assertEquals(CA_COUNTRY_CODE,
-                String.valueOf(((CountryInfo) mCountryListSpinner.getTag()).getCountryCode()));
+                String.valueOf((mCountryListSpinner.getSelectedCountryInfo()).getCountryCode()));
         assertEquals(new Locale("", CA_ISO2),
-                ((CountryInfo) mCountryListSpinner.getTag()).getLocale());
+                ((CountryInfo) mCountryListSpinner.getSelectedCountryInfo()).getLocale());
     }
 
     @Test


### PR DESCRIPTION
Here's the bug (as reported by a developer on another channel):

  * Enter phone flow, set country to Bangladesh in the dropdown
  * Enter a valid Bandladesh number, hi verify
  * See "code sent"
  * Press back
  * Hit verify again
  * Get told the number is invalid

The problem is that the `CountryListSpinner` was using `setTag/getTag` to store the `CountryInfo` which means it's not persisted across the flow.  I made `CountryListSpinner` into a `Parcelable` and properly store it as part of the `savedInstanceState`.
