### PR TITLE
Add indentation to dependencies block

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ libraries.
 
 ```groovy
 dependencies {
-// FirebaseUI for Firebase Realtime Database
-implementation 'com.firebaseui:firebase-ui-database:3.3.1'
+    // FirebaseUI for Firebase Realtime Database
+    implementation 'com.firebaseui:firebase-ui-database:3.3.1'
 
-// FirebaseUI for Cloud Firestore
-implementation 'com.firebaseui:firebase-ui-firestore:3.3.1'
+    // FirebaseUI for Cloud Firestore
+    implementation 'com.firebaseui:firebase-ui-firestore:3.3.1'
 
-// FirebaseUI for Firebase Auth
-implementation 'com.firebaseui:firebase-ui-auth:3.3.1'
+    // FirebaseUI for Firebase Auth
+    implementation 'com.firebaseui:firebase-ui-auth:3.3.1'
 
-// FirebaseUI for Cloud Storage
-implementation 'com.firebaseui:firebase-ui-storage:3.3.1'
+    // FirebaseUI for Cloud Storage
+    implementation 'com.firebaseui:firebase-ui-storage:3.3.1'
 }
 ```
 


### PR DESCRIPTION
I went hunting for who was to blame and it turns out [it was me](https://github.com/firebase/FirebaseUI-Android/pull/1013#pullrequestreview-77303352) 😆. I hadn't noticed the dependencies were in a `{}` block so TLDR: 🤦‍♂️😊.