### PR TITLE
Reverse Firestore chat

### DIFF
--- a/app/src/main/java/com/firebase/uidemo/database/firestore/FirestoreChatActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/database/firestore/FirestoreChatActivity.java
@@ -46,7 +46,8 @@ public class FirestoreChatActivity extends AppCompatActivity
     private static final CollectionReference sChatCollection =
             FirebaseFirestore.getInstance().collection("chats");
     /** Get the last 50 chat messages ordered by timestamp . */
-    private static final Query sChatQuery = sChatCollection.orderBy("timestamp").limit(50);
+    private static final Query sChatQuery =
+            sChatCollection.orderBy("timestamp", Query.Direction.DESCENDING).limit(50);
 
     static {
         FirebaseFirestore.setLoggingEnabled(true);
@@ -70,8 +71,12 @@ public class FirestoreChatActivity extends AppCompatActivity
         setContentView(R.layout.activity_chat);
         ButterKnife.bind(this);
 
+        LinearLayoutManager manager = new LinearLayoutManager(this);
+        manager.setReverseLayout(true);
+        manager.setStackFromEnd(true);
+
         mRecyclerView.setHasFixedSize(true);
-        mRecyclerView.setLayoutManager(new LinearLayoutManager(this));
+        mRecyclerView.setLayoutManager(manager);
 
         ImeHelper.setImeOnDoneListener(mMessageEdit, new ImeHelper.DonePressedListener() {
             @Override
@@ -118,7 +123,7 @@ public class FirestoreChatActivity extends AppCompatActivity
         adapter.registerAdapterDataObserver(new RecyclerView.AdapterDataObserver() {
             @Override
             public void onItemRangeInserted(int positionStart, int itemCount) {
-                mRecyclerView.smoothScrollToPosition(adapter.getItemCount());
+                mRecyclerView.smoothScrollToPosition(0);
             }
         });
 


### PR DESCRIPTION
Fixes #1267 by making the query `DESCENDING` and reversing the order of things in the `RecyclerView`.