### PR TITLE
Scroll to end when keyboard is shown.

### DIFF
--- a/app/src/main/java/com/firebase/uidemo/database/firestore/FirestoreChatActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/database/firestore/FirestoreChatActivity.java
@@ -78,6 +78,21 @@ public class FirestoreChatActivity extends AppCompatActivity
         mRecyclerView.setHasFixedSize(true);
         mRecyclerView.setLayoutManager(manager);
 
+        mRecyclerView.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
+            @Override
+            public void onLayoutChange(View view, int left, int top, int right, int bottom,
+                                       int oldLeft, int oldTop, int oldRight, int oldBottom) {
+                if (bottom < oldBottom) {
+                    mRecyclerView.postDelayed(new Runnable() {
+                        @Override
+                        public void run() {
+                            mRecyclerView.smoothScrollToPosition(0);
+                        }
+                    }, 100);
+                }
+            }
+        });
+
         ImeHelper.setImeOnDoneListener(mMessageEdit, new ImeHelper.DonePressedListener() {
             @Override
             public void onDonePressed() {


### PR DESCRIPTION
Scroll to the end of the chat when a new message is being written and the keyboard is shown.
Previous to this, when the keyboard popped up it was hiding the last messages of the chat.
