### PR TITLE
Force ToS & Pp to be added to align with FirebaseUI Web & iOS

### DIFF
--- a/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/auth/AuthUiActivity.java
@@ -160,8 +160,8 @@ public class AuthUiActivity extends AppCompatActivity {
                         .setTheme(getSelectedTheme())
                         .setLogo(getSelectedLogo())
                         .setAvailableProviders(getSelectedProviders())
-                        .setTosUrl(getSelectedTosUrl())
-                        .setPrivacyPolicyUrl(getSelectedPrivacyPolicyUrl())
+                        .setTosAndPrivacyPolicyUrls(getSelectedTosUrl(),
+                                getSelectedPrivacyPolicyUrl())
                         .setIsSmartLockEnabled(mEnableCredentialSelector.isChecked(),
                                 mEnableHintSelector.isChecked())
                         .build(),

--- a/auth/README.md
+++ b/auth/README.md
@@ -231,15 +231,15 @@ startActivityForResult(
 
 ##### Adding a ToS and privacy policy
 
-If a terms of service URL and privacy policy URL are required:
+A terms of service URL and privacy policy URL are generally required:
 
 ```java
 startActivityForResult(
     AuthUI.getInstance()
         .createSignInIntentBuilder()
         .setAvailableProviders(...)
-        .setTosUrl("https://superapp.example.com/terms-of-service.html")
-        .setPrivacyPolicyUrl("https://superapp.example.com/privacy-policy.html")
+        .setTosAndPrivacyPolicyUrls("https://superapp.example.com/terms-of-service.html",
+                                    "https://superapp.example.com/privacy-policy.html")
         .build(),
     RC_SIGN_IN);
 ```

--- a/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
@@ -835,6 +835,8 @@ public final class AuthUI {
         @NonNull
         public T setTosAndPrivacyPolicyUrls(@NonNull String tosUrl,
                                             @NonNull String privacyPolicyUrl) {
+            Preconditions.checkNotNull(tosUrl, "tosUrl cannot be null");
+            Preconditions.checkNotNull(privacyPolicyUrl, "privacyPolicyUrl cannot be null");
             mTosUrl = tosUrl;
             mPrivacyPolicyUrl = privacyPolicyUrl;
             return (T) this;

--- a/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
@@ -808,8 +808,12 @@ public final class AuthUI {
 
         /**
          * Specifies the terms-of-service URL for the application.
+         *
+         * @deprecated Please use {@link #setTosAndPrivacyPolicyUrls(String, String)}
+         * For the Tos link to be displayed a Privacy Policy url must also be provided.
          */
         @NonNull
+        @Deprecated
         public T setTosUrl(@Nullable String tosUrl) {
             mTosUrl = tosUrl;
             return (T) this;
@@ -817,9 +821,21 @@ public final class AuthUI {
 
         /**
          * Specifies the privacy policy URL for the application.
+         *
+         * @deprecated Please use {@link #setTosAndPrivacyPolicyUrls(String, String)}
+         * For the Privacy Policy link to be displayed a Tos url must also be provided.
          */
         @NonNull
+        @Deprecated
         public T setPrivacyPolicyUrl(@Nullable String privacyPolicyUrl) {
+            mPrivacyPolicyUrl = privacyPolicyUrl;
+            return (T) this;
+        }
+
+        @NonNull
+        public T setTosAndPrivacyPolicyUrls(@NonNull String tosUrl,
+                                            @NonNull String privacyPolicyUrl) {
+            mTosUrl = tosUrl;
             mPrivacyPolicyUrl = privacyPolicyUrl;
             return (T) this;
         }

--- a/auth/src/main/java/com/firebase/ui/auth/util/data/PrivacyDisclosureUtils.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/data/PrivacyDisclosureUtils.java
@@ -49,10 +49,6 @@ public class PrivacyDisclosureUtils {
 
         if (termsOfServiceUrlProvided && privacyPolicyUrlProvided) {
             return R.string.fui_tos_and_pp;
-        } else if (termsOfServiceUrlProvided) {
-            return R.string.fui_tos_only;
-        } else if (privacyPolicyUrlProvided) {
-            return R.string.fui_pp_only;
         }
 
         return NO_TOS_OR_PP;
@@ -65,10 +61,6 @@ public class PrivacyDisclosureUtils {
 
         if (termsOfServiceUrlProvided && privacyPolicyUrlProvided) {
             return R.string.fui_tos_and_pp_footer;
-        } else if (termsOfServiceUrlProvided) {
-            return R.string.fui_tos_footer;
-        } else if (privacyPolicyUrlProvided) {
-            return R.string.fui_pp_footer;
         }
 
         return NO_TOS_OR_PP;
@@ -81,10 +73,6 @@ public class PrivacyDisclosureUtils {
 
         if (termsOfServiceUrlProvided && privacyPolicyUrlProvided) {
             return R.string.fui_sms_terms_of_service_and_privacy_policy_extended;
-        } else if (termsOfServiceUrlProvided) {
-            return R.string.fui_sms_terms_of_service_only_extended;
-        } else if (privacyPolicyUrlProvided) {
-            return R.string.fui_sms_privacy_policy_only_extended;
         }
 
         return NO_TOS_OR_PP;

--- a/auth/src/main/java/com/firebase/ui/auth/util/ui/PreambleHandler.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/ui/PreambleHandler.java
@@ -73,10 +73,7 @@ public class PreambleHandler {
         mBuilder = new SpannableStringBuilder(withTargets);
 
         replaceTarget(BTN_TARGET, mButtonText);
-        replaceUrlTarget(
-                TOS_TARGET,
-                R.string.fui_terms_of_service,
-                mFlowParameters.termsOfServiceUrl);
+        replaceUrlTarget(TOS_TARGET, R.string.fui_terms_of_service, mFlowParameters.termsOfServiceUrl);
         replaceUrlTarget(PP_TARGET, R.string.fui_privacy_policy, mFlowParameters.privacyPolicyUrl);
     }
 
@@ -109,35 +106,9 @@ public class PreambleHandler {
                     new Object[]{BTN_TARGET, TOS_TARGET, PP_TARGET}
                     : new Object[]{TOS_TARGET, PP_TARGET};
             return mContext.getString(textViewText, targets);
-        } else if (termsOfServiceUrlProvided) {
-            Object[] targets = hasButton ?
-                    new Object[]{BTN_TARGET, TOS_TARGET} : new Object[]{TOS_TARGET};
-            return mContext.getString(textViewText, targets);
-        } else if (privacyPolicyUrlProvided) {
-            Object[] targets = hasButton ?
-                    new Object[]{BTN_TARGET, PP_TARGET} : new Object[]{PP_TARGET};
-            return mContext.getString(textViewText, targets);
         }
         return null;
     }
-
-    @Nullable
-    private String getPreambleStringWithTargetsNoButton(@StringRes int textViewText) {
-        boolean hasTos = !TextUtils.isEmpty(mFlowParameters.termsOfServiceUrl);
-        boolean hasPp = !TextUtils.isEmpty(mFlowParameters.privacyPolicyUrl);
-        if (hasTos && hasPp) {
-            return mContext.getString(textViewText,
-                    TOS_TARGET, PP_TARGET);
-        } else if (hasTos) {
-            return mContext.getString(textViewText,
-                    TOS_TARGET);
-        } else if (hasPp) {
-            return mContext.getString(textViewText,
-                    PP_TARGET);
-        }
-        return null;
-    }
-
 
     private class CustomTabsSpan extends ClickableSpan {
         private final String mUrl;

--- a/auth/src/main/res/values-ar/strings.xml
+++ b/auth/src/main/res/values-ar/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">جارٍ التحميل…</string>
     <string name="fui_sign_in_default">تسجيل الدخول</string>
     <string name="fui_tos_and_pp">تشير المتابعة إلى موافقتك على %1$s و%2$s.</string>
-    <string name="fui_tos_only">تشير المتابعة إلى موافقتك على %1$s.</string>
-    <string name="fui_pp_only">تشير المتابعة إلى موافقتك على %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">متابعة</string>
     <string name="fui_sms_terms_of_service">عند النقر على “%1$s”، قد يتمّ إرسال رسالة قصيرة SMS وقد يتمّ تطبيق رسوم الرسائل والبيانات.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">يشير النقر على “%1$s” إلى موافقتك على %2$s و%3$s. وقد يتمّ إرسال رسالة قصيرة كما قد تنطبق رسوم الرسائل والبيانات.</string>
-    <string name="fui_sms_terms_of_service_only_extended">يشير النقر على “%1$s” إلى موافقتك على %2$s. وقد يتمّ إرسال رسالة قصيرة كما قد تنطبق رسوم الرسائل والبيانات.</string>
-    <string name="fui_sms_privacy_policy_only_extended">يشير النقر على “%1$s” إلى موافقتك على %2$s. وقد يتمّ إرسال رسالة قصيرة كما قد تنطبق رسوم الرسائل والبيانات.</string>
 </resources>

--- a/auth/src/main/res/values-b+es+419/strings.xml
+++ b/auth/src/main/res/values-b+es+419/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-bg/strings.xml
+++ b/auth/src/main/res/values-bg/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Зарежда се…</string>
     <string name="fui_sign_in_default">Вход</string>
     <string name="fui_tos_and_pp">Продължавайки, приемате нашите %1$s и %2$s.</string>
-    <string name="fui_tos_only">Продължавайки, приемате нашите %1$s.</string>
-    <string name="fui_pp_only">Продължавайки, приемате нашата %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Напред</string>
     <string name="fui_sms_terms_of_service">Докосвайки „%1$s“, може да получите SMS съобщение. То може да се таксува по тарифите за данни и SMS.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Докосвайки „%1$s“, приемате нашите %2$s и %3$s. Възможно е да получите SMS съобщение. То може да се таксува по тарифите за данни и SMS.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Докосвайки „%1$s“, приемате нашите %2$s. Възможно е да получите SMS съобщение. То може да се таксува по тарифите за данни и SMS.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Докосвайки „%1$s“, приемате нашата %2$s. Възможно е да получите SMS съобщение. То може да се таксува по тарифите за данни и SMS.</string>
 </resources>

--- a/auth/src/main/res/values-bn/strings.xml
+++ b/auth/src/main/res/values-bn/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">লোড হচ্ছে…</string>
     <string name="fui_sign_in_default">সাইন-ইন করুন</string>
     <string name="fui_tos_and_pp">চালিয়ে যাওয়ার অর্থ, আপনি আমাদের %1$s এবং %2$s-এর সাথে সম্মত।</string>
-    <string name="fui_tos_only">চালিয়ে যাওয়ার অর্থ, আপনি আমাদের %1$s-এর সাথে সম্মত।</string>
-    <string name="fui_pp_only">চালিয়ে যাওয়ার অর্থ, আপনি আমাদের %1$s-এর সাথে সম্মত।</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">চালিয়ে যান</string>
     <string name="fui_sms_terms_of_service">%1$s এ ট্যাপ করলে আপনি একটি এসএমএস পাঠাতে পারেন। মেসেজ ও ডেটার চার্জ প্রযোজ্য।</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">“%1$s” বোতামে ট্যাপ করার অর্থ, আপনি আমাদের %2$s এবং %3$s-এর সাথে সম্মত। একটি এসএমএস পাঠানো হতে পারে। মেসেজ এবং ডেটার উপরে প্রযোজ্য চার্জ লাগতে পারে।</string>
-    <string name="fui_sms_terms_of_service_only_extended">“%1$s” বোতামে ট্যাপ করার অর্থ, আপনি আমাদের %2$s-এর সাথে সম্মত। একটি এসএমএস পাঠানো হতে পারে। মেসেজ এবং ডেটার উপরে প্রযোজ্য চার্জ লাগতে পারে।</string>
-    <string name="fui_sms_privacy_policy_only_extended">“%1$s” বোতামে ট্যাপ করার অর্থ, আপনি আমাদের %2$s-এর সাথে সম্মত। একটি এসএমএস পাঠানো হতে পারে। মেসেজ এবং ডেটার উপরে প্রযোজ্য চার্জ লাগতে পারে।</string>
 </resources>

--- a/auth/src/main/res/values-ca/strings.xml
+++ b/auth/src/main/res/values-ca/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">S\'està carregant…</string>
     <string name="fui_sign_in_default">Inicia la sessió</string>
     <string name="fui_tos_and_pp">En continuar, acceptes les nostres %1$s i la nostra %2$s.</string>
-    <string name="fui_tos_only">En continuar, acceptes les nostres %1$s.</string>
-    <string name="fui_pp_only">En continuar, acceptes la nostra %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continua</string>
     <string name="fui_sms_terms_of_service">En tocar %1$s, és possible que s\'enviï un SMS. Es poden aplicar tarifes de dades i missatges.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">En tocar %1$s, acceptes les nostres %2$s i la nostra %3$s. És possible que s\'enviï un SMS. Es poden aplicar tarifes de dades i missatges.</string>
-    <string name="fui_sms_terms_of_service_only_extended">En tocar %1$s, acceptes les nostres %2$s. És possible que s\'enviï un SMS. Es poden aplicar tarifes de dades i missatges.</string>
-    <string name="fui_sms_privacy_policy_only_extended">En tocar %1$s, acceptes la nostra %2$s. És possible que s\'enviï un SMS. Es poden aplicar tarifes de dades i missatges.</string>
 </resources>

--- a/auth/src/main/res/values-cs/strings.xml
+++ b/auth/src/main/res/values-cs/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Načítání…</string>
     <string name="fui_sign_in_default">Přihlásit se</string>
     <string name="fui_tos_and_pp">Budete-li pokračovat, vyjadřujete svůj souhlas s dokumenty %1$s a %2$s.</string>
-    <string name="fui_tos_only">Budete-li pokračovat, vyjadřujete svůj souhlas s dokumentem %1$s.</string>
-    <string name="fui_pp_only">Budete-li pokračovat, vyjadřujete svůj souhlas s dokumentem %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Pokračovat</string>
     <string name="fui_sms_terms_of_service">Po klepnutí na možnost %1$s může být odeslána SMS. Mohou být účtovány poplatky za zprávy a data.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Klepnutím na tlačítko %1$s vyjadřujete svůj souhlas s dokumenty %2$s a %3$s. Může být odeslána SMS a mohou být účtovány poplatky za zprávy a data.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Klepnutím na tlačítko %1$s vyjadřujete svůj souhlas s dokumentem %2$s. Může být odeslána SMS a mohou být účtovány poplatky za zprávy a data.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Klepnutím na tlačítko %1$s vyjadřujete svůj souhlas s dokumentem %2$s. Může být odeslána SMS a mohou být účtovány poplatky za zprávy a data.</string>
 </resources>

--- a/auth/src/main/res/values-da/strings.xml
+++ b/auth/src/main/res/values-da/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Indlæser…</string>
     <string name="fui_sign_in_default">Log ind</string>
     <string name="fui_tos_and_pp">Ved at fortsætte indikerer du, at du accepterer vores %1$s og %2$s.</string>
-    <string name="fui_tos_only">Ved at fortsætte indikerer du, at du accepterer vores %1$s.</string>
-    <string name="fui_pp_only">Ved at fortsætte indikerer du, at du accepterer vores %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Fortsæt</string>
     <string name="fui_sms_terms_of_service">Når du trykker på “%1$s”, sendes der måske en sms. Der opkræves muligvis gebyrer for beskeder og data.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Når du trykker på “%1$s”, indikerer du, at du accepterer vores %2$s og %3$s. Der sendes måske en sms. Der opkræves muligvis gebyrer for beskeder og data.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Når du trykker på “%1$s”, indikerer du, at du accepterer vores %2$s. Der sendes måske en sms. Der opkræves muligvis gebyrer for beskeder og data.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Når du trykker på “%1$s”, indikerer du, at du accepterer vores %2$s. Der sendes måske en sms. Der opkræves muligvis gebyrer for beskeder og data.</string>
 </resources>

--- a/auth/src/main/res/values-de-rAT/strings.xml
+++ b/auth/src/main/res/values-de-rAT/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Wird geladen…</string>
     <string name="fui_sign_in_default">Anmelden</string>
     <string name="fui_tos_and_pp">Indem Sie fortfahren, stimmen Sie unseren %1$s und unserer %2$s zu.</string>
-    <string name="fui_tos_only">Indem Sie fortfahren, stimmen Sie unseren %1$s zu.</string>
-    <string name="fui_pp_only">Indem Sie fortfahren, stimmen Sie unserer %1$s zu.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Weiter</string>
     <string name="fui_sms_terms_of_service">Wenn Sie auf “%1$s” tippen, erhalten Sie möglicherweise eine SMS. Es können Gebühren für SMS und Datenübertragung anfallen.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Indem Sie auf “%1$s” tippen, stimmen Sie unseren %2$s und unserer %3$s zu. Sie erhalten möglicherweise eine SMS und es können Gebühren für die Nachricht und die Datenübertragung anfallen.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Indem Sie auf “%1$s” tippen, stimmen Sie unseren %2$s zu. Sie erhalten möglicherweise eine SMS und es können Gebühren für die Nachricht und die Datenübertragung anfallen.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Indem Sie auf “%1$s” tippen, stimmen Sie unserer %2$s zu. Sie erhalten möglicherweise eine SMS und es können Gebühren für die Nachricht und die Datenübertragung anfallen.</string>
 </resources>

--- a/auth/src/main/res/values-de-rCH/strings.xml
+++ b/auth/src/main/res/values-de-rCH/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Wird geladen…</string>
     <string name="fui_sign_in_default">Anmelden</string>
     <string name="fui_tos_and_pp">Indem Sie fortfahren, stimmen Sie unseren %1$s und unserer %2$s zu.</string>
-    <string name="fui_tos_only">Indem Sie fortfahren, stimmen Sie unseren %1$s zu.</string>
-    <string name="fui_pp_only">Indem Sie fortfahren, stimmen Sie unserer %1$s zu.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Weiter</string>
     <string name="fui_sms_terms_of_service">Wenn Sie auf “%1$s” tippen, erhalten Sie möglicherweise eine SMS. Es können Gebühren für SMS und Datenübertragung anfallen.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Indem Sie auf “%1$s” tippen, stimmen Sie unseren %2$s und unserer %3$s zu. Sie erhalten möglicherweise eine SMS und es können Gebühren für die Nachricht und die Datenübertragung anfallen.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Indem Sie auf “%1$s” tippen, stimmen Sie unseren %2$s zu. Sie erhalten möglicherweise eine SMS und es können Gebühren für die Nachricht und die Datenübertragung anfallen.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Indem Sie auf “%1$s” tippen, stimmen Sie unserer %2$s zu. Sie erhalten möglicherweise eine SMS und es können Gebühren für die Nachricht und die Datenübertragung anfallen.</string>
 </resources>

--- a/auth/src/main/res/values-de/strings.xml
+++ b/auth/src/main/res/values-de/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Wird geladen…</string>
     <string name="fui_sign_in_default">Anmelden</string>
     <string name="fui_tos_and_pp">Indem Sie fortfahren, stimmen Sie unseren %1$s und unserer %2$s zu.</string>
-    <string name="fui_tos_only">Indem Sie fortfahren, stimmen Sie unseren %1$s zu.</string>
-    <string name="fui_pp_only">Indem Sie fortfahren, stimmen Sie unserer %1$s zu.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Weiter</string>
     <string name="fui_sms_terms_of_service">Wenn Sie auf “%1$s” tippen, erhalten Sie möglicherweise eine SMS. Es können Gebühren für SMS und Datenübertragung anfallen.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Indem Sie auf “%1$s” tippen, stimmen Sie unseren %2$s und unserer %3$s zu. Sie erhalten möglicherweise eine SMS und es können Gebühren für die Nachricht und die Datenübertragung anfallen.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Indem Sie auf “%1$s” tippen, stimmen Sie unseren %2$s zu. Sie erhalten möglicherweise eine SMS und es können Gebühren für die Nachricht und die Datenübertragung anfallen.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Indem Sie auf “%1$s” tippen, stimmen Sie unserer %2$s zu. Sie erhalten möglicherweise eine SMS und es können Gebühren für die Nachricht und die Datenübertragung anfallen.</string>
 </resources>

--- a/auth/src/main/res/values-el/strings.xml
+++ b/auth/src/main/res/values-el/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Γίνεται φόρτωση…</string>
     <string name="fui_sign_in_default">Σύνδεση</string>
     <string name="fui_tos_and_pp">Αν συνεχίσετε, δηλώνετε ότι αποδέχεστε τους %1$s και την %2$s.</string>
-    <string name="fui_tos_only">Αν συνεχίσετε, δηλώνετε ότι αποδέχεστε τους %1$s.</string>
-    <string name="fui_pp_only">Αν συνεχίσετε, δηλώνετε ότι αποδέχεστε την %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Συνέχεια</string>
     <string name="fui_sms_terms_of_service">Αν πατήσετε “%1$s”, μπορεί να σταλεί ένα SMS. Ενδέχεται να ισχύουν χρεώσεις μηνυμάτων και δεδομένων.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Αν πατήσετε “%1$s”, δηλώνετε ότι αποδέχεστε τους %2$s και την %3$s. Μπορεί να σταλεί ένα SMS. Ενδέχεται να ισχύουν χρεώσεις μηνυμάτων και δεδομένων.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Αν πατήσετε “%1$s”, δηλώνετε ότι αποδέχεστε τους %2$s. Μπορεί να σταλεί ένα SMS. Ενδέχεται να ισχύουν χρεώσεις μηνυμάτων και δεδομένων.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Αν πατήσετε “%1$s”, δηλώνετε ότι αποδέχεστε την %2$s. Μπορεί να σταλεί ένα SMS. Ενδέχεται να ισχύουν χρεώσεις μηνυμάτων και δεδομένων.</string>
 </resources>

--- a/auth/src/main/res/values-en-rAU/strings.xml
+++ b/auth/src/main/res/values-en-rAU/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Loading…</string>
     <string name="fui_sign_in_default">Sign in</string>
     <string name="fui_tos_and_pp">By continuing, you are indicating that you accept our %1$s and %2$s.</string>
-    <string name="fui_tos_only">By continuing, you are indicating that you accept our %1$s.</string>
-    <string name="fui_pp_only">By continuing, you are indicating that you accept our %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continue</string>
     <string name="fui_sms_terms_of_service">By tapping “%1$s”, an SMS may be sent. Message &amp; data rates may apply.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">By tapping “%1$s”, you are indicating that you accept our %2$s and %3$s. An SMS may be sent. Message &amp; data rates may apply.</string>
-    <string name="fui_sms_terms_of_service_only_extended">By tapping “%1$s”, you are indicating that you accept our %2$s. An SMS may be sent. Message &amp; data rates may apply.</string>
-    <string name="fui_sms_privacy_policy_only_extended">By tapping “%1$s”, you are indicating that you accept our %2$s. An SMS may be sent. Message &amp; data rates may apply.</string>
 </resources>

--- a/auth/src/main/res/values-en-rCA/strings.xml
+++ b/auth/src/main/res/values-en-rCA/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Loading…</string>
     <string name="fui_sign_in_default">Sign in</string>
     <string name="fui_tos_and_pp">By continuing, you are indicating that you accept our %1$s and %2$s.</string>
-    <string name="fui_tos_only">By continuing, you are indicating that you accept our %1$s.</string>
-    <string name="fui_pp_only">By continuing, you are indicating that you accept our %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continue</string>
     <string name="fui_sms_terms_of_service">By tapping “%1$s”, an SMS may be sent. Message &amp; data rates may apply.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">By tapping “%1$s”, you are indicating that you accept our %2$s and %3$s. An SMS may be sent. Message &amp; data rates may apply.</string>
-    <string name="fui_sms_terms_of_service_only_extended">By tapping “%1$s”, you are indicating that you accept our %2$s. An SMS may be sent. Message &amp; data rates may apply.</string>
-    <string name="fui_sms_privacy_policy_only_extended">By tapping “%1$s”, you are indicating that you accept our %2$s. An SMS may be sent. Message &amp; data rates may apply.</string>
 </resources>

--- a/auth/src/main/res/values-en-rGB/strings.xml
+++ b/auth/src/main/res/values-en-rGB/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Loading…</string>
     <string name="fui_sign_in_default">Sign in</string>
     <string name="fui_tos_and_pp">By continuing, you are indicating that you accept our %1$s and %2$s.</string>
-    <string name="fui_tos_only">By continuing, you are indicating that you accept our %1$s.</string>
-    <string name="fui_pp_only">By continuing, you are indicating that you accept our %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continue</string>
     <string name="fui_sms_terms_of_service">By tapping “%1$s”, an SMS may be sent. Message &amp; data rates may apply.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">By tapping “%1$s”, you are indicating that you accept our %2$s and %3$s. An SMS may be sent. Message &amp; data rates may apply.</string>
-    <string name="fui_sms_terms_of_service_only_extended">By tapping “%1$s”, you are indicating that you accept our %2$s. An SMS may be sent. Message &amp; data rates may apply.</string>
-    <string name="fui_sms_privacy_policy_only_extended">By tapping “%1$s”, you are indicating that you accept our %2$s. An SMS may be sent. Message &amp; data rates may apply.</string>
 </resources>

--- a/auth/src/main/res/values-en-rIE/strings.xml
+++ b/auth/src/main/res/values-en-rIE/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Loading…</string>
     <string name="fui_sign_in_default">Sign in</string>
     <string name="fui_tos_and_pp">By continuing, you are indicating that you accept our %1$s and %2$s.</string>
-    <string name="fui_tos_only">By continuing, you are indicating that you accept our %1$s.</string>
-    <string name="fui_pp_only">By continuing, you are indicating that you accept our %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continue</string>
     <string name="fui_sms_terms_of_service">By tapping “%1$s”, an SMS may be sent. Message &amp; data rates may apply.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">By tapping “%1$s”, you are indicating that you accept our %2$s and %3$s. An SMS may be sent. Message &amp; data rates may apply.</string>
-    <string name="fui_sms_terms_of_service_only_extended">By tapping “%1$s”, you are indicating that you accept our %2$s. An SMS may be sent. Message &amp; data rates may apply.</string>
-    <string name="fui_sms_privacy_policy_only_extended">By tapping “%1$s”, you are indicating that you accept our %2$s. An SMS may be sent. Message &amp; data rates may apply.</string>
 </resources>

--- a/auth/src/main/res/values-en-rIN/strings.xml
+++ b/auth/src/main/res/values-en-rIN/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Loading…</string>
     <string name="fui_sign_in_default">Sign in</string>
     <string name="fui_tos_and_pp">By continuing, you are indicating that you accept our %1$s and %2$s.</string>
-    <string name="fui_tos_only">By continuing, you are indicating that you accept our %1$s.</string>
-    <string name="fui_pp_only">By continuing, you are indicating that you accept our %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continue</string>
     <string name="fui_sms_terms_of_service">By tapping “%1$s”, an SMS may be sent. Message &amp; data rates may apply.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">By tapping “%1$s”, you are indicating that you accept our %2$s and %3$s. An SMS may be sent. Message &amp; data rates may apply.</string>
-    <string name="fui_sms_terms_of_service_only_extended">By tapping “%1$s”, you are indicating that you accept our %2$s. An SMS may be sent. Message &amp; data rates may apply.</string>
-    <string name="fui_sms_privacy_policy_only_extended">By tapping “%1$s”, you are indicating that you accept our %2$s. An SMS may be sent. Message &amp; data rates may apply.</string>
 </resources>

--- a/auth/src/main/res/values-en-rSG/strings.xml
+++ b/auth/src/main/res/values-en-rSG/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Loading…</string>
     <string name="fui_sign_in_default">Sign in</string>
     <string name="fui_tos_and_pp">By continuing, you are indicating that you accept our %1$s and %2$s.</string>
-    <string name="fui_tos_only">By continuing, you are indicating that you accept our %1$s.</string>
-    <string name="fui_pp_only">By continuing, you are indicating that you accept our %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continue</string>
     <string name="fui_sms_terms_of_service">By tapping “%1$s”, an SMS may be sent. Message &amp; data rates may apply.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">By tapping “%1$s”, you are indicating that you accept our %2$s and %3$s. An SMS may be sent. Message &amp; data rates may apply.</string>
-    <string name="fui_sms_terms_of_service_only_extended">By tapping “%1$s”, you are indicating that you accept our %2$s. An SMS may be sent. Message &amp; data rates may apply.</string>
-    <string name="fui_sms_privacy_policy_only_extended">By tapping “%1$s”, you are indicating that you accept our %2$s. An SMS may be sent. Message &amp; data rates may apply.</string>
 </resources>

--- a/auth/src/main/res/values-en-rZA/strings.xml
+++ b/auth/src/main/res/values-en-rZA/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Loading…</string>
     <string name="fui_sign_in_default">Sign in</string>
     <string name="fui_tos_and_pp">By continuing, you are indicating that you accept our %1$s and %2$s.</string>
-    <string name="fui_tos_only">By continuing, you are indicating that you accept our %1$s.</string>
-    <string name="fui_pp_only">By continuing, you are indicating that you accept our %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continue</string>
     <string name="fui_sms_terms_of_service">By tapping “%1$s”, an SMS may be sent. Message &amp; data rates may apply.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">By tapping “%1$s”, you are indicating that you accept our %2$s and %3$s. An SMS may be sent. Message &amp; data rates may apply.</string>
-    <string name="fui_sms_terms_of_service_only_extended">By tapping “%1$s”, you are indicating that you accept our %2$s. An SMS may be sent. Message &amp; data rates may apply.</string>
-    <string name="fui_sms_privacy_policy_only_extended">By tapping “%1$s”, you are indicating that you accept our %2$s. An SMS may be sent. Message &amp; data rates may apply.</string>
 </resources>

--- a/auth/src/main/res/values-es-rAR/strings.xml
+++ b/auth/src/main/res/values-es-rAR/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-es-rBO/strings.xml
+++ b/auth/src/main/res/values-es-rBO/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-es-rCL/strings.xml
+++ b/auth/src/main/res/values-es-rCL/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-es-rCO/strings.xml
+++ b/auth/src/main/res/values-es-rCO/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-es-rCR/strings.xml
+++ b/auth/src/main/res/values-es-rCR/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-es-rDO/strings.xml
+++ b/auth/src/main/res/values-es-rDO/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-es-rEC/strings.xml
+++ b/auth/src/main/res/values-es-rEC/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-es-rGT/strings.xml
+++ b/auth/src/main/res/values-es-rGT/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-es-rHN/strings.xml
+++ b/auth/src/main/res/values-es-rHN/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-es-rMX/strings.xml
+++ b/auth/src/main/res/values-es-rMX/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-es-rNI/strings.xml
+++ b/auth/src/main/res/values-es-rNI/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-es-rPA/strings.xml
+++ b/auth/src/main/res/values-es-rPA/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-es-rPE/strings.xml
+++ b/auth/src/main/res/values-es-rPE/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-es-rPR/strings.xml
+++ b/auth/src/main/res/values-es-rPR/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-es-rPY/strings.xml
+++ b/auth/src/main/res/values-es-rPY/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-es-rSV/strings.xml
+++ b/auth/src/main/res/values-es-rSV/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-es-rUS/strings.xml
+++ b/auth/src/main/res/values-es-rUS/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-es-rUY/strings.xml
+++ b/auth/src/main/res/values-es-rUY/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-es-rVE/strings.xml
+++ b/auth/src/main/res/values-es-rVE/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
-    <string name="fui_tos_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, indicas que aceptas nuestras %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Si presionas “%1$s”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s y %3$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si presionas “%1$s”, indicas que aceptas nuestras %2$s. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</string>
 </resources>

--- a/auth/src/main/res/values-es/strings.xml
+++ b/auth/src/main/res/values-es/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Iniciar sesión</string>
     <string name="fui_tos_and_pp">Si continúas, confirmas que aceptas nuestras %1$s y nuestra %2$s.</string>
-    <string name="fui_tos_only">Si continúas, confirmas que aceptas nuestras %1$s.</string>
-    <string name="fui_pp_only">Si continúas, confirmas que aceptas nuestra %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Al tocar %1$s, podría enviarse un SMS. Es posible que se apliquen cargos de mensajería y de uso de datos.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Si tocas %1$s, confirmas que aceptas nuestras %2$s y nuestra %3$s. Podría enviarse un SMS, por lo que es posible que se apliquen cargos de mensajería y de uso de datos.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Si tocas %1$s, confirmas que aceptas nuestras %2$s. Podría enviarse un SMS, por lo que es posible que se apliquen cargos de mensajería y de uso de datos.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Si tocas %1$s, confirmas que aceptas nuestra %2$s. Podría enviarse un SMS, por lo que es posible que se apliquen cargos de mensajería y de uso de datos.</string>
 </resources>

--- a/auth/src/main/res/values-fa/strings.xml
+++ b/auth/src/main/res/values-fa/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">درحال بارگیری…</string>
     <string name="fui_sign_in_default">ورود به سیستم</string>
     <string name="fui_tos_and_pp">درصورت ادامه‌دادن، موافقتتان را با %1$s و %2$s اعلام می‌کنید.</string>
-    <string name="fui_tos_only">درصورت ادامه‌دادن موافقتتان را با %1$s اعلام می‌کنید.</string>
-    <string name="fui_pp_only">درصورت ادامه‌دادن موافقتتان را با %1$s اعلام می‌کنید.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google‏</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">ادامه</string>
     <string name="fui_sms_terms_of_service">با ضربه زدن روی «%1$s»، پیامکی برایتان ارسال می‌شود. هزینه پیام و داده اعمال می‌شود.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">درصورت ضربه‌زدن روی «%1$s»، موافقتتان را با %2$s و %3$s اعلام می‌کنید. پیامکی ارسال می‌شود. ممکن است هزینه داده و «پیام» محاسبه شود.</string>
-    <string name="fui_sms_terms_of_service_only_extended">درصورت ضربه‌زدن روی «%1$s»، موافقتتان را با %2$s اعلام می‌کنید. پیامکی ارسال می‌شود. ممکن است هزینه داده و «پیام» محاسبه شود.</string>
-    <string name="fui_sms_privacy_policy_only_extended">درصورت ضربه‌زدن روی «%1$s»، موافقتتان را با %2$s اعلام می‌کنید. پیامکی ارسال می‌شود. ممکن است هزینه داده و «پیام» محاسبه شود.</string>
 </resources>

--- a/auth/src/main/res/values-fi/strings.xml
+++ b/auth/src/main/res/values-fi/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Ladataan…</string>
     <string name="fui_sign_in_default">Kirjaudu sisään</string>
     <string name="fui_tos_and_pp">Jatkamalla vahvistat, että hyväksyt seuraavat: %1$s ja %2$s.</string>
-    <string name="fui_tos_only">Jatkamalla vahvistat, että hyväksyt %1$s.</string>
-    <string name="fui_pp_only">Jatkamalla vahvistat, että hyväksyt seuraavan: %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Jatka</string>
     <string name="fui_sms_terms_of_service">Kun napautat %1$s, tekstiviesti voidaan lähettää. Datan ja viestien käyttö voi olla maksullista.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Napauttamalla %1$s vahvistat hyväksyväsi seuraavat: %2$s ja %3$s. Tekstiviesti voidaan lähettää, ja datan ja viestien käyttö voi olla maksullista.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Napauttamalla %1$s vahvistat hyväksyväsi %2$s. Tekstiviesti voidaan lähettää, ja datan ja viestien käyttö voi olla maksullista.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Napauttamalla %1$s vahvistat hyväksyväsi seuraavan: %2$s. Tekstiviesti voidaan lähettää, ja datan ja viestien käyttö voi olla maksullista.</string>
 </resources>

--- a/auth/src/main/res/values-fil/strings.xml
+++ b/auth/src/main/res/values-fil/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Naglo-load…</string>
     <string name="fui_sign_in_default">Mag-sign in</string>
     <string name="fui_tos_and_pp">Sa pagpapatuloy, ipinababatid mo na tinatanggap mo ang aming %1$s at %2$s.</string>
-    <string name="fui_tos_only">Sa pagpapatuloy, ipinababatid mo na tinatanggap mo ang aming %1$s.</string>
-    <string name="fui_pp_only">Sa pagpapatuloy, ipinababatid mo na tinatanggap mo ang aming %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Fecebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Magpatuloy</string>
     <string name="fui_sms_terms_of_service">Sa pag-tap sa “%1$s,“ maaaring magpadala ng SMS. Maaaring ipatupad ang mga rate ng pagmemensahe at data.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Sa pag-tap sa “%1$s”, ipinababatid mo na tinatanggap mo ang aming %2$s at %3$s. Maaaring magpadala ng SMS. Maaaring ipatupad ang mga rate ng pagmemensahe at data.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Sa pag-tap sa “%1$s”, ipinababatid mo na tinatanggap mo ang aming %2$s. Maaaring magpadala ng SMS. Maaaring ipatupad ang mga rate ng pagmemensahe at data.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Sa pag-tap sa “%1$s”, ipinababatid mo na tinatanggap mo ang aming %2$s. Maaaring magpadala ng SMS. Maaaring ipatupad ang mga rate ng pagmemensahe at data.</string>
 </resources>

--- a/auth/src/main/res/values-fr-rCH/strings.xml
+++ b/auth/src/main/res/values-fr-rCH/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Chargement…</string>
     <string name="fui_sign_in_default">Se connecter</string>
     <string name="fui_tos_and_pp">En continuant, vous acceptez les %1$s et les %2$s.</string>
-    <string name="fui_tos_only">En continuant, vous acceptez les %1$s.</string>
-    <string name="fui_pp_only">En continuant, vous acceptez les %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s   %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuer</string>
     <string name="fui_sms_terms_of_service">En appuyant sur “%1$s”, vous déclencherez peut-être l\'envoi d\'un SMS. Des frais de messages et de données peuvent être facturés.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">En appuyant sur “%1$s”, vous acceptez les %2$s et les %3$s. Vous déclencherez peut-être l\'envoi d\'un SMS. Des frais de messages et de données peuvent être facturés.</string>
-    <string name="fui_sms_terms_of_service_only_extended">En appuyant sur “%1$s”, vous acceptez les %2$s. Vous déclencherez peut-être l\'envoi d\'un SMS. Des frais de messages et de données peuvent être facturés.</string>
-    <string name="fui_sms_privacy_policy_only_extended">En appuyant sur “%1$s”, vous acceptez les %2$s. Vous déclencherez peut-être l\'envoi d\'un SMS. Des frais de messages et de données peuvent être facturés.</string>
 </resources>

--- a/auth/src/main/res/values-fr/strings.xml
+++ b/auth/src/main/res/values-fr/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Chargement…</string>
     <string name="fui_sign_in_default">Se connecter</string>
     <string name="fui_tos_and_pp">En continuant, vous acceptez les %1$s et les %2$s.</string>
-    <string name="fui_tos_only">En continuant, vous acceptez les %1$s.</string>
-    <string name="fui_pp_only">En continuant, vous acceptez les %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s   %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuer</string>
     <string name="fui_sms_terms_of_service">En appuyant sur “%1$s”, vous déclencherez peut-être l\'envoi d\'un SMS. Des frais de messages et de données peuvent être facturés.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">En appuyant sur “%1$s”, vous acceptez les %2$s et les %3$s. Vous déclencherez peut-être l\'envoi d\'un SMS. Des frais de messages et de données peuvent être facturés.</string>
-    <string name="fui_sms_terms_of_service_only_extended">En appuyant sur “%1$s”, vous acceptez les %2$s. Vous déclencherez peut-être l\'envoi d\'un SMS. Des frais de messages et de données peuvent être facturés.</string>
-    <string name="fui_sms_privacy_policy_only_extended">En appuyant sur “%1$s”, vous acceptez les %2$s. Vous déclencherez peut-être l\'envoi d\'un SMS. Des frais de messages et de données peuvent être facturés.</string>
 </resources>

--- a/auth/src/main/res/values-gsw/strings.xml
+++ b/auth/src/main/res/values-gsw/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Wird geladen…</string>
     <string name="fui_sign_in_default">Anmelden</string>
     <string name="fui_tos_and_pp">Indem Sie fortfahren, stimmen Sie unseren %1$s und unserer %2$s zu.</string>
-    <string name="fui_tos_only">Indem Sie fortfahren, stimmen Sie unseren %1$s zu.</string>
-    <string name="fui_pp_only">Indem Sie fortfahren, stimmen Sie unserer %1$s zu.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Weiter</string>
     <string name="fui_sms_terms_of_service">Wenn Sie auf “%1$s” tippen, erhalten Sie möglicherweise eine SMS. Es können Gebühren für SMS und Datenübertragung anfallen.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Indem Sie auf “%1$s” tippen, stimmen Sie unseren %2$s und unserer %3$s zu. Sie erhalten möglicherweise eine SMS und es können Gebühren für die Nachricht und die Datenübertragung anfallen.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Indem Sie auf “%1$s” tippen, stimmen Sie unseren %2$s zu. Sie erhalten möglicherweise eine SMS und es können Gebühren für die Nachricht und die Datenübertragung anfallen.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Indem Sie auf “%1$s” tippen, stimmen Sie unserer %2$s zu. Sie erhalten möglicherweise eine SMS und es können Gebühren für die Nachricht und die Datenübertragung anfallen.</string>
 </resources>

--- a/auth/src/main/res/values-gu/strings.xml
+++ b/auth/src/main/res/values-gu/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">લોડ કરી રહ્યું છે…</string>
     <string name="fui_sign_in_default">સાઇન ઇન કરો</string>
     <string name="fui_tos_and_pp">ચાલુ રાખીને, તમે સૂચવી રહ્યાં છો કે તમે અમારી %1$s અને %2$sને સ્વીકારો છો.</string>
-    <string name="fui_tos_only">ચાલુ રાખીને, તમે સૂચવી રહ્યાં છો કે તમે અમારી %1$sને સ્વીકારો છો.</string>
-    <string name="fui_pp_only">ચાલુ રાખીને, તમે સૂચવી રહ્યાં છો કે તમે અમારી %1$sને સ્વીકારો છો.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">આગળ વધો</string>
     <string name="fui_sms_terms_of_service">“%1$s”ને ટૅપ કરવાથી, કદાચ એક SMS મોકલવામાં આવી શકે છે. સંદેશ અને ડેટા શુલ્ક લાગુ થઈ શકે છે.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">“%1$s” ટૅપ કરીને, તમે સૂચવી રહ્યાં છો કે તમે અમારી %2$s અને %3$sને સ્વીકારો છો. SMS મોકલવામાં આવી શકે છે. સંદેશ અને ડેટા શુલ્ક લાગુ થઈ શકે છે.</string>
-    <string name="fui_sms_terms_of_service_only_extended">“%1$s” ટૅપ કરીને, તમે સૂચવી રહ્યાં છો કે તમે અમારી %2$sને સ્વીકારો છો. SMS મોકલવામાં આવી શકે છે. સંદેશ અને ડેટા શુલ્ક લાગુ થઈ શકે છે.</string>
-    <string name="fui_sms_privacy_policy_only_extended">“%1$s” ટૅપ કરીને, તમે સૂચવી રહ્યાં છો કે તમે અમારી %2$sને સ્વીકારો છો. SMS મોકલવામાં આવી શકે છે. સંદેશ અને ડેટા શુલ્ક લાગુ થઈ શકે છે.</string>
 </resources>

--- a/auth/src/main/res/values-hi/strings.xml
+++ b/auth/src/main/res/values-hi/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">लोड हो रहा है…</string>
     <string name="fui_sign_in_default">प्रवेश करें</string>
     <string name="fui_tos_and_pp">जारी रखकर, आप यह बताते हैं कि आप हमारी %1$s और %2$s को मंज़ूर करते हैं.</string>
-    <string name="fui_tos_only">जारी रखकर, आप यह बताते हैं कि आप हमारी %1$s मंज़ूर करते हैं.</string>
-    <string name="fui_pp_only">जारी रखकर, आप यह बताते हैं कि आप हमारी %1$s मंज़ूर करते हैं.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">जारी रखें</string>
     <string name="fui_sms_terms_of_service">“%1$s” पर टैप करने पर, एक मैसेज (एसएमएस) भेजा जा सकता है. मैसेज और डेटा दरें लागू हो सकती हैं.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">“%1$s” पर टैप करके, आप यह बताते हैं कि आप हमारी %2$s और %3$s को मंज़ूर करते हैं. एक मैसेज (एसएमएस) भेजा जा सकता है. मैसेज और डेटा दरें लागू हो सकती हैं.</string>
-    <string name="fui_sms_terms_of_service_only_extended">“%1$s” पर टैप करके, आप यह बताते हैं कि आप हमारी %2$s मंज़ूर करते हैं. एक मैसेज (एसएमएस) भेजा जा सकता है. मैसेज और डेटा दरें लागू हो सकती हैं.</string>
-    <string name="fui_sms_privacy_policy_only_extended">“%1$s” पर टैप करके, आप यह बताते हैं कि आप हमारी %2$s मंज़ूर करते हैं. एक मैसेज (एसएमएस) भेजा जा सकता है. मैसेज और डेटा दरें लागू हो सकती हैं.</string>
 </resources>

--- a/auth/src/main/res/values-hr/strings.xml
+++ b/auth/src/main/res/values-hr/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Učitavanje…</string>
     <string name="fui_sign_in_default">Prijava</string>
     <string name="fui_tos_and_pp">Ako nastavite, potvrđujete da prihvaćate odredbe koje sadrže %1$s i %2$s.</string>
-    <string name="fui_tos_only">Ako nastavite, potvrđujete da prihvaćate odredbe koje sadrži %1$s.</string>
-    <string name="fui_pp_only">Ako nastavite, potvrđujete da prihvaćate odredbe koje sadrži %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Nastavi</string>
     <string name="fui_sms_terms_of_service">Dodirivanje gumba “%1$s” može dovesti do slanja SMS poruke. Mogu se primijeniti naknade za slanje poruka i podatkovni promet.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Ako dodirnete “%1$s”, potvrđujete da prihvaćate odredbe koje sadrže %2$s i %3$s. Možda ćemo vam poslati SMS. Moguća je naplata poruke i podatkovnog prometa.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Ako dodirnete “%1$s”, potvrđujete da prihvaćate odredbe koje sadrži %2$s. Možda ćemo vam poslati SMS. Moguća je naplata poruke i podatkovnog prometa.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Ako dodirnete “%1$s”, potvrđujete da prihvaćate odredbe koje sadrži %2$s. Možda ćemo vam poslati SMS. Moguća je naplata poruke i podatkovnog prometa.</string>
 </resources>

--- a/auth/src/main/res/values-hu/strings.xml
+++ b/auth/src/main/res/values-hu/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Betöltés…</string>
     <string name="fui_sign_in_default">Bejelentkezés</string>
     <string name="fui_tos_and_pp">A folytatással elfogadja a következő dokumentumokat: %1$s és %2$s.</string>
-    <string name="fui_tos_only">A folytatással elfogadja a következő dokumentumot: %1$s.</string>
-    <string name="fui_pp_only">A folytatással elfogadja a következő dokumentumot: %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Folytatás</string>
     <string name="fui_sms_terms_of_service">Ha a(z) „%1$s” gombra koppint, a rendszer SMS-t küldhet Önnek. A szolgáltató ezért üzenet- és adatforgalmi díjat számíthat fel.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">A(z) „%1$s” gombra való koppintással elfogadja a következő dokumentumokat: %2$s és %3$s. A rendszer SMS-t küldhet Önnek. A szolgáltató ezért üzenet- és adatforgalmi díjat számíthat fel.</string>
-    <string name="fui_sms_terms_of_service_only_extended">A(z) „%1$s” gombra való koppintással elfogadja a következő dokumentumot: %2$s. A rendszer SMS-t küldhet Önnek. A szolgáltató ezért üzenet- és adatforgalmi díjat számíthat fel.</string>
-    <string name="fui_sms_privacy_policy_only_extended">A(z) „%1$s” gombra való koppintással elfogadja a következő dokumentumot: %2$s. A rendszer SMS-t küldhet Önnek. A szolgáltató ezért üzenet- és adatforgalmi díjat számíthat fel.</string>
 </resources>

--- a/auth/src/main/res/values-in/strings.xml
+++ b/auth/src/main/res/values-in/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Memuat…</string>
     <string name="fui_sign_in_default">Login</string>
     <string name="fui_tos_and_pp">Dengan melanjutkan, Anda menyatakan bahwa Anda menyetujui %1$s dan %2$s kami.</string>
-    <string name="fui_tos_only">Dengan melanjutkan, Anda menyatakan bahwa Anda menyetujui %1$s kami.</string>
-    <string name="fui_pp_only">Dengan melanjutkan, Anda menyatakan bahwa Anda menyetujui %1$s kami.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Lanjutkan</string>
     <string name="fui_sms_terms_of_service">Dengan menge-tap “%1$s\", SMS mungkin akan dikirim. Mungkin dikenakan biaya pesan &amp; data.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Dengan menge-tap “%1$s”, Anda menyatakan bahwa Anda menyetujui %2$s dan %3$s kami. SMS mungkin akan dikirim. Mungkin dikenakan biaya pesan &amp; data.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Dengan menge-tap “%1$s”, Anda menyatakan bahwa Anda menyetujui %2$s kami. SMS mungkin akan dikirim. Mungkin dikenakan biaya pesan &amp; data.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Dengan menge-tap “%1$s”, Anda menyatakan bahwa Anda menyetujui %2$s kami. SMS mungkin akan dikirim. Mungkin dikenakan biaya pesan &amp; data.</string>
 </resources>

--- a/auth/src/main/res/values-it/strings.xml
+++ b/auth/src/main/res/values-it/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Caricamento in corso…</string>
     <string name="fui_sign_in_default">Accedi</string>
     <string name="fui_tos_and_pp">Se continui, accetti le nostre %1$s e i nostri %2$s.</string>
-    <string name="fui_tos_only">Se continui, accetti i nostri %1$s.</string>
-    <string name="fui_pp_only">Se continui, accetti le nostre %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continua</string>
     <string name="fui_sms_terms_of_service">Se tocchi “%1$s”, è possibile che venga inviato un SMS. Potrebbero essere applicate le tariffe per l\'invio dei messaggi e per il traffico dati.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Se tocchi “%1$s”, accetti le nostre %2$s e i nostri %3$s. È possibile che venga inviato un SMS. Potrebbero essere applicate le tariffe per l\'invio dei messaggi e per il traffico dati.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Se tocchi “%1$s”, accetti i nostri %2$s. È possibile che venga inviato un SMS. Potrebbero essere applicate le tariffe per l\'invio dei messaggi e per il traffico dati.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Se tocchi “%1$s”, accetti le nostre %2$s. È possibile che venga inviato un SMS. Potrebbero essere applicate le tariffe per l\'invio dei messaggi e per il traffico dati.</string>
 </resources>

--- a/auth/src/main/res/values-iw/strings.xml
+++ b/auth/src/main/res/values-iw/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">טוען…</string>
     <string name="fui_sign_in_default">כניסה</string>
     <string name="fui_tos_and_pp">המשך התהליך יפורש כהסכמתך ל%1$s ול%2$s.</string>
-    <string name="fui_tos_only">המשך התהליך יפורש כהסכמתך ל%1$s.</string>
-    <string name="fui_pp_only">המשך התהליך יפורש כהסכמתך ל%1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">המשך</string>
     <string name="fui_sms_terms_of_service">הקשה על “%1$s” עשויה לגרום לשליחה של הודעת SMS. ייתכן שיחולו תעריפי הודעות והעברת נתונים.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">הקשה על “%1$s”, תפורש כהסכמתך ל%2$s ול%3$s. ייתכן שתישלח הודעת SMS. ייתכנו חיובים בגין שליחת הודעות ושימוש בנתונים.</string>
-    <string name="fui_sms_terms_of_service_only_extended">הקשה על “%1$s”, תפורש כהסכמתך ל%2$s. ייתכן שתישלח הודעת SMS. ייתכנו חיובים בגין שליחת הודעות ושימוש בנתונים.</string>
-    <string name="fui_sms_privacy_policy_only_extended">הקשה על “%1$s”, תפורש כהסכמתך ל%2$s. ייתכן שתישלח הודעת SMS. ייתכנו חיובים בגין שליחת הודעות ושימוש בנתונים.</string>
 </resources>

--- a/auth/src/main/res/values-ja/strings.xml
+++ b/auth/src/main/res/values-ja/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">読み込んでいます…</string>
     <string name="fui_sign_in_default">ログイン</string>
     <string name="fui_tos_and_pp">続行すると、%1$s と %2$s に同意したことになります。</string>
-    <string name="fui_tos_only">続行すると、%1$s に同意したことになります。</string>
-    <string name="fui_pp_only">続行すると、%1$s に同意したことになります。</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">続行</string>
     <string name="fui_sms_terms_of_service">[%1$s] をタップすると、SMS が送信されます。データ通信料がかかることがあります。</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">[%1$s] をタップすると、%2$s と %3$s に同意したことになり、SMS が送信されます。データ通信料がかかることがあります。</string>
-    <string name="fui_sms_terms_of_service_only_extended">[%1$s] をタップすると、%2$s に同意したことになり、SMS が送信されます。データ通信料がかかることがあります。</string>
-    <string name="fui_sms_privacy_policy_only_extended">[%1$s] をタップすると、%2$s に同意したことになり、SMS が送信されます。データ通信料がかかることがあります。</string>
 </resources>

--- a/auth/src/main/res/values-kn/strings.xml
+++ b/auth/src/main/res/values-kn/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">ಲೋಡ್‌ ಮಾಡಲಾಗುತ್ತಿದೆ…</string>
     <string name="fui_sign_in_default">ಸೈನ್ ಇನ್‌</string>
     <string name="fui_tos_and_pp">ಮುಂದುವರಿಸುವ ಮೂಲಕ, ನೀವು ನಮ್ಮ %1$s ಮತ್ತು %2$s ಸ್ವೀಕರಿಸುತ್ತೀರಿ ಎಂದು ನೀವು ಸೂಚಿಸುತ್ತಿರುವಿರಿ</string>
-    <string name="fui_tos_only">ಮುಂದುವರಿಸುವ ಮೂಲಕ, ನೀವು ನಮ್ಮ %1$s ಅನ್ನು ಸ್ವೀಕರಿಸುತ್ತೀರಿ ಎಂದು ನೀವು ಸೂಚಿಸುತ್ತಿರುವಿರಿ</string>
-    <string name="fui_pp_only">ಮುಂದುವರಿಸುವ ಮೂಲಕ, ನೀವು ನಮ್ಮ %1$s ಅನ್ನು ಸ್ವೀಕರಿಸುತ್ತೀರಿ ಎಂದು ನೀವು ಸೂಚಿಸುತ್ತಿರುವಿರಿ</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">ಮುಂದುವರಿಸಿ</string>
     <string name="fui_sms_terms_of_service">“%1$s” ಅನ್ನು ಟ್ಯಾಪ್ ಮಾಡುವ ಮೂಲಕ, ಎಸ್‌ಎಂಎಸ್‌ ಅನ್ನು ಕಳುಹಿಸಬಹುದಾಗಿದೆ. ಸಂದೇಶ ಮತ್ತು ಡೇಟಾ ದರಗಳು ಅನ್ವಯಿಸಬಹುದು.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">“%1$s” ಅನ್ನು ಟ್ಯಾಪ್ ಮಾಡುವ ಮೂಲಕ, ನೀವು ನಮ್ಮ %2$s ಮತ್ತು %3$s ಸ್ವೀಕರಿಸುತ್ತೀರಿ ಎಂದು ನೀವು ಸೂಚಿಸುತ್ತಿರುವಿರಿ. ಎಸ್‌ಎಂಎಸ್‌ ಅನ್ನು ಕಳುಹಿಸಬಹುದಾಗಿದೆ. ಸಂದೇಶ ಮತ್ತು ಡೇಟಾ ದರಗಳು ಅನ್ವಯಿಸಬಹುದು.</string>
-    <string name="fui_sms_terms_of_service_only_extended">“%1$s” ಅನ್ನು ಟ್ಯಾಪ್ ಮಾಡುವ ಮೂಲಕ, ನೀವು ನಮ್ಮ %2$s ಅನ್ನು ಸ್ವೀಕರಿಸುತ್ತೀರಿ ಎಂದು ನೀವು ಸೂಚಿಸುತ್ತಿರುವಿರಿ. ಎಸ್‌ಎಂಎಸ್‌ ಅನ್ನು ಕಳುಹಿಸಬಹುದಾಗಿದೆ. ಸಂದೇಶ ಮತ್ತು ಡೇಟಾ ದರಗಳು ಅನ್ವಯಿಸಬಹುದು.</string>
-    <string name="fui_sms_privacy_policy_only_extended">“%1$s” ಅನ್ನು ಟ್ಯಾಪ್ ಮಾಡುವ ಮೂಲಕ, ನೀವು ನಮ್ಮ %2$s ಅನ್ನು ಸ್ವೀಕರಿಸುತ್ತೀರಿ ಎಂದು ನೀವು ಸೂಚಿಸುತ್ತಿರುವಿರಿ. ಎಸ್‌ಎಂಎಸ್‌ ಅನ್ನು ಕಳುಹಿಸಬಹುದಾಗಿದೆ. ಸಂದೇಶ ಮತ್ತು ಡೇಟಾ ದರಗಳು ಅನ್ವಯಿಸಬಹುದು.</string>
 </resources>

--- a/auth/src/main/res/values-ko/strings.xml
+++ b/auth/src/main/res/values-ko/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">로드 중…</string>
     <string name="fui_sign_in_default">로그인</string>
     <string name="fui_tos_and_pp">계속 진행하면 %1$s 및 %2$s에 동의하는 것으로 간주됩니다.</string>
-    <string name="fui_tos_only">계속 진행하면 %1$s에 동의하는 것으로 간주됩니다.</string>
-    <string name="fui_pp_only">계속 진행하면 %1$s에 동의하는 것으로 간주됩니다.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">계속</string>
     <string name="fui_sms_terms_of_service">“%1$s” 버튼을 탭하면 SMS가 발송될 수 있으며, 메시지 및 데이터 요금이 부과될 수 있습니다.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">‘%1$s’ 버튼을 탭하면 %2$s 및 %3$s에 동의하는 것으로 간주됩니다. SMS가 발송될 수 있으며, 메시지 및 데이터 요금이 부과될 수 있습니다.</string>
-    <string name="fui_sms_terms_of_service_only_extended">‘%1$s’ 버튼을 탭하면 %2$s에 동의하는 것으로 간주됩니다. SMS가 발송될 수 있으며, 메시지 및 데이터 요금이 부과될 수 있습니다.</string>
-    <string name="fui_sms_privacy_policy_only_extended">‘%1$s’ 버튼을 탭하면 %2$s에 동의하는 것으로 간주됩니다. SMS가 발송될 수 있으며, 메시지 및 데이터 요금이 부과될 수 있습니다.</string>
 </resources>

--- a/auth/src/main/res/values-ln/strings.xml
+++ b/auth/src/main/res/values-ln/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Chargement…</string>
     <string name="fui_sign_in_default">Se connecter</string>
     <string name="fui_tos_and_pp">En continuant, vous acceptez les %1$s et les %2$s.</string>
-    <string name="fui_tos_only">En continuant, vous acceptez les %1$s.</string>
-    <string name="fui_pp_only">En continuant, vous acceptez les %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s   %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuer</string>
     <string name="fui_sms_terms_of_service">En appuyant sur “%1$s”, vous déclencherez peut-être l\'envoi d\'un SMS. Des frais de messages et de données peuvent être facturés.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">En appuyant sur “%1$s”, vous acceptez les %2$s et les %3$s. Vous déclencherez peut-être l\'envoi d\'un SMS. Des frais de messages et de données peuvent être facturés.</string>
-    <string name="fui_sms_terms_of_service_only_extended">En appuyant sur “%1$s”, vous acceptez les %2$s. Vous déclencherez peut-être l\'envoi d\'un SMS. Des frais de messages et de données peuvent être facturés.</string>
-    <string name="fui_sms_privacy_policy_only_extended">En appuyant sur “%1$s”, vous acceptez les %2$s. Vous déclencherez peut-être l\'envoi d\'un SMS. Des frais de messages et de données peuvent être facturés.</string>
 </resources>

--- a/auth/src/main/res/values-lt/strings.xml
+++ b/auth/src/main/res/values-lt/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Įkeliama…</string>
     <string name="fui_sign_in_default">Prisijungti</string>
     <string name="fui_tos_and_pp">Tęsdami nurodote, kad sutinkate su %1$s ir %2$s.</string>
-    <string name="fui_tos_only">Tęsdami nurodote, kad sutinkate su %1$s.</string>
-    <string name="fui_pp_only">Tęsdami nurodote, kad sutinkate su %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Tęsti</string>
     <string name="fui_sms_terms_of_service">Palietus „%1$s“ gali būti išsiųstas SMS pranešimas. Gali būti taikomi pranešimų ir duomenų įkainiai.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Paliesdami „%1$s“ nurodote, kad sutinkate su %2$s ir %3$s. Gali būti išsiųstas SMS pranešimas, taip pat – taikomi pranešimų ir duomenų įkainiai.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Paliesdami „%1$s“ nurodote, kad sutinkate su %2$s. Gali būti išsiųstas SMS pranešimas, taip pat – taikomi pranešimų ir duomenų įkainiai.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Paliesdami „%1$s“ nurodote, kad sutinkate su %2$s. Gali būti išsiųstas SMS pranešimas, taip pat – taikomi pranešimų ir duomenų įkainiai.</string>
 </resources>

--- a/auth/src/main/res/values-lv/strings.xml
+++ b/auth/src/main/res/values-lv/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Notiek ielāde…</string>
     <string name="fui_sign_in_default">Pierakstīties</string>
     <string name="fui_tos_and_pp">Turpinot jūs norādāt, ka piekrītat šādiem dokumentiem: %1$s un %2$s.</string>
-    <string name="fui_tos_only">Turpinot jūs norādāt, ka piekrītat šādam dokumentam: %1$s.</string>
-    <string name="fui_pp_only">Turpinot jūs norādāt, ka piekrītat šādam dokumentam: %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Turpināt</string>
     <string name="fui_sms_terms_of_service">Pieskaroties pogai %1$s, var tikt nosūtīta īsziņa. Var tikt piemērota maksa par ziņojumiem un datu pārsūtīšanu.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Pieskaroties pogai “%1$s”, jūs norādāt, ka piekrītat šādiem dokumentiem: %2$s un %3$s. Var tikt nosūtīta īsziņa. Var tikt piemērota maksa par ziņojumiem un datu pārsūtīšanu.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Pieskaroties pogai “%1$s”, jūs norādāt, ka piekrītat šādam dokumentam: %2$s. Var tikt nosūtīta īsziņa. Var tikt piemērota maksa par ziņojumiem un datu pārsūtīšanu.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Pieskaroties pogai “%1$s”, jūs norādāt, ka piekrītat šādam dokumentam: %2$s. Var tikt nosūtīta īsziņa. Var tikt piemērota maksa par ziņojumiem un datu pārsūtīšanu.</string>
 </resources>

--- a/auth/src/main/res/values-mo/strings.xml
+++ b/auth/src/main/res/values-mo/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Se încarcă…</string>
     <string name="fui_sign_in_default">Conectați-vă</string>
     <string name="fui_tos_and_pp">Dacă alegeți să continuați, sunteți de acord cu %1$s și cu %2$s.</string>
-    <string name="fui_tos_only">Dacă alegeți să continuați, sunteți de acord cu %1$s.</string>
-    <string name="fui_pp_only">Dacă alegeți să continuați, sunteți de acord cu %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuați</string>
     <string name="fui_sms_terms_of_service">Dacă atingeți „%1$s”, poate fi trimis un SMS. Se pot aplica tarife pentru mesaje și date.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Dacă atingeți „%1$s”, sunteți de acord cu %2$s și cu %3$s. Poate fi trimis un SMS. Se pot aplica tarife pentru mesaje și date.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Dacă atingeți „%1$s”, sunteți de acord cu %2$s. Poate fi trimis un SMS. Se pot aplica tarife pentru mesaje și date.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Dacă atingeți „%1$s”, sunteți de acord cu %2$s. Poate fi trimis un SMS. Se pot aplica tarife pentru mesaje și date.</string>
 </resources>

--- a/auth/src/main/res/values-mr/strings.xml
+++ b/auth/src/main/res/values-mr/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">लोड करत आहे…</string>
     <string name="fui_sign_in_default">साइन इन करा</string>
     <string name="fui_tos_and_pp">पुढे सुरू ठेवून, तुम्ही सूचित करता की तुम्ही आमचे %1$s आणि %2$s स्वीकारता.</string>
-    <string name="fui_tos_only">पुढे सुरू ठेवून, तुम्ही सूचित करता की तुम्ही आमचे %1$s स्वीकारता.</string>
-    <string name="fui_pp_only">पुढे सुरू ठेवून, तुम्ही सूचित करता की तुम्ही आमचे %1$s स्वीकारता.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">सुरू ठेवा</string>
     <string name="fui_sms_terms_of_service">“%1$s“ वर टॅप केल्याने, एक एसएमएस पाठवला जाऊ शकतो. मेसेज आणि डेटा शुल्क लागू होऊ शकते.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">“%1$s” वर टॅप करून, तुम्ही सूचित करता की तुम्ही आमचे %2$s आणि %3$s स्वीकारता. एसएमएस पाठवला जाऊ शकतो. मेसेज आणि डेटा दर लागू केले जाऊ शकते.</string>
-    <string name="fui_sms_terms_of_service_only_extended">“%1$s” वर टॅप करून, तुम्ही सूचित करता की तुम्ही आमचे %2$s स्वीकारता. एसएमएस पाठवला जाऊ शकतो. मेसेज आणि डेटा दर लागू केले जाऊ शकते.</string>
-    <string name="fui_sms_privacy_policy_only_extended">“%1$s” वर टॅप करून, तुम्ही सूचित करता की तुम्ही आमचे %2$s स्वीकारता. एसएमएस पाठवला जाऊ शकतो. मेसेज आणि डेटा दर लागू केले जाऊ शकते.</string>
 </resources>

--- a/auth/src/main/res/values-ms/strings.xml
+++ b/auth/src/main/res/values-ms/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Memuatkan…</string>
     <string name="fui_sign_in_default">Log masuk</string>
     <string name="fui_tos_and_pp">Dengan meneruskan, anda menyatakan bahawa anda menerima %1$s dan %2$s kami.</string>
-    <string name="fui_tos_only">Dengan meneruskan, anda menyatakan bahawa anda menerima %1$s kami.</string>
-    <string name="fui_pp_only">Dengan meneruskan, anda menyatakan bahawa anda menerima %1$s kami.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Teruskan</string>
     <string name="fui_sms_terms_of_service">Dengan mengetik “%1$s”, SMS akan dihantar. Tertakluk pada kadar mesej &amp; data.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Dengan mengetik “%1$s”, anda menyatakan bahawa anda menerima %2$s dan %3$s kami. SMS akan dihantar. Tertakluk pada kadar mesej &amp; data.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Dengan mengetik “%1$s”, anda menyatakan bahawa anda menerima %2$s kami. SMS akan dihantar. Tertakluk pada kadar mesej &amp; data.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Dengan mengetik “%1$s”, anda menyatakan bahawa anda menerima %2$s kami. SMS akan dihantar. Tertakluk pada kadar mesej &amp; data.</string>
 </resources>

--- a/auth/src/main/res/values-nb/strings.xml
+++ b/auth/src/main/res/values-nb/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Laster inn…</string>
     <string name="fui_sign_in_default">Logg på</string>
     <string name="fui_tos_and_pp">Ved å fortsette godtar du %1$s og %2$s våre.</string>
-    <string name="fui_tos_only">Ved å fortsette godtar du %1$s.</string>
-    <string name="fui_pp_only">Ved å fortsette godtar du %1$s våre.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Fortsett</string>
     <string name="fui_sms_terms_of_service">Når du trykker på «%1$s», kan det bli sendt en SMS. Kostnader for meldinger og datatrafikk kan påløpe.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Ved å trykke på «%1$s» godtar du %2$s og %3$s våre. Du kan bli tilsendt en SMS. Kostnader for meldinger og datatrafikk kan påløpe.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Ved å trykke på «%1$s» godtar du %2$s. Du kan bli tilsendt en SMS. Kostnader for meldinger og datatrafikk kan påløpe.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Hvis du trykker på «%1$s», godtar du %2$s våre. Du kan bli tilsendt en SMS. Kostnader for meldinger og datatrafikk kan påløpe.</string>
 </resources>

--- a/auth/src/main/res/values-nl/strings.xml
+++ b/auth/src/main/res/values-nl/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Laden…</string>
     <string name="fui_sign_in_default">Inloggen</string>
     <string name="fui_tos_and_pp">Als u doorgaat, geeft u aan dat u onze %1$s en ons %2$s accepteert.</string>
-    <string name="fui_tos_only">Als u doorgaat, geeft u aan dat u onze %1$s accepteert.</string>
-    <string name="fui_pp_only">Als u doorgaat, geeft u aan dat u ons %1$s accepteert.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Doorgaan</string>
     <string name="fui_sms_terms_of_service">Als u op “%1$s” tikt, ontvangt u mogelijk een sms. Er kunnen sms- en datakosten in rekening worden gebracht.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Als u op “%1$s” tikt, geeft u aan dat u onze %2$s en ons %3$s accepteert. Mogelijk ontvangt u een sms. Er kunnen sms- en datakosten in rekening worden gebracht.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Als u op “%1$s” tikt, geeft u aan dat u onze %2$s accepteert. Mogelijk ontvangt u een sms. Er kunnen sms- en datakosten in rekening worden gebracht.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Als u op “%1$s” tikt, geeft u aan dat u ons %2$s accepteert. Mogelijk ontvangt u een sms. Er kunnen sms- en datakosten in rekening worden gebracht.</string>
 </resources>

--- a/auth/src/main/res/values-no/strings.xml
+++ b/auth/src/main/res/values-no/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Laster inn…</string>
     <string name="fui_sign_in_default">Logg på</string>
     <string name="fui_tos_and_pp">Ved å fortsette godtar du %1$s og %2$s våre.</string>
-    <string name="fui_tos_only">Ved å fortsette godtar du %1$s.</string>
-    <string name="fui_pp_only">Ved å fortsette godtar du %1$s våre.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Fortsett</string>
     <string name="fui_sms_terms_of_service">Når du trykker på «%1$s», kan det bli sendt en SMS. Kostnader for meldinger og datatrafikk kan påløpe.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Ved å trykke på «%1$s» godtar du %2$s og %3$s våre. Du kan bli tilsendt en SMS. Kostnader for meldinger og datatrafikk kan påløpe.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Ved å trykke på «%1$s» godtar du %2$s. Du kan bli tilsendt en SMS. Kostnader for meldinger og datatrafikk kan påløpe.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Hvis du trykker på «%1$s», godtar du %2$s våre. Du kan bli tilsendt en SMS. Kostnader for meldinger og datatrafikk kan påløpe.</string>
 </resources>

--- a/auth/src/main/res/values-pl/strings.xml
+++ b/auth/src/main/res/values-pl/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Wczytuję…</string>
     <string name="fui_sign_in_default">Zaloguj się</string>
     <string name="fui_tos_and_pp">Kontynuując, potwierdzasz, że akceptujesz te dokumenty: %1$s i %2$s.</string>
-    <string name="fui_tos_only">Kontynuując, potwierdzasz, że akceptujesz ten dokument: %1$s.</string>
-    <string name="fui_pp_only">Kontynuując, potwierdzasz, że akceptujesz ten dokument: %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Dalej</string>
     <string name="fui_sms_terms_of_service">Gdy klikniesz „%1$s”, może zostać wysłany SMS. Może to skutkować pobraniem opłaty za przesłanie wiadomości i danych.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Klikając „%1$s”, potwierdzasz, że akceptujesz te dokumenty: %2$s i %3$s. Może zostać wysłany SMS. Może to skutkować pobraniem opłat za przesłanie wiadomości i danych.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Klikając „%1$s”, potwierdzasz, że akceptujesz ten dokument: %2$s. Może zostać wysłany SMS. Może to skutkować pobraniem opłat za przesłanie wiadomości i danych.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Klikając „%1$s”, potwierdzasz, że akceptujesz ten dokument: %2$s. Może zostać wysłany SMS. Może to skutkować pobraniem opłat za przesłanie wiadomości i danych.</string>
 </resources>

--- a/auth/src/main/res/values-pt-rBR/strings.xml
+++ b/auth/src/main/res/values-pt-rBR/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Carregando…</string>
     <string name="fui_sign_in_default">Fazer login</string>
     <string name="fui_tos_and_pp">Ao continuar, você concorda com nossos %1$s e a %2$s.</string>
-    <string name="fui_tos_only">Ao continuar, você concorda com nossos %1$s.</string>
-    <string name="fui_pp_only">Ao continuar, você concorda com nossa %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Se você tocar em “%1$s”, um SMS poderá ser enviado e tarifas de mensagens e de dados serão cobradas.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Ao tocar em “%1$s”, você concorda com nossos %2$s e a %3$s. Um SMS poderá ser enviado e tarifas de mensagens e de dados poderão ser cobradas.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Ao tocar em “%1$s”, você concorda com nossos %2$s. Um SMS poderá ser enviado e tarifas de mensagens e de dados poderão ser cobradas.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Ao tocar em “%1$s”, você concorda com nossa %2$s. Um SMS poderá ser enviado e tarifas de mensagens e de dados poderão ser cobradas.</string>
 </resources>

--- a/auth/src/main/res/values-pt-rPT/strings.xml
+++ b/auth/src/main/res/values-pt-rPT/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">A carregar…</string>
     <string name="fui_sign_in_default">Iniciar sessão</string>
     <string name="fui_tos_and_pp">Ao continuar, indica que aceita os %1$s e a %2$s.</string>
-    <string name="fui_tos_only">Ao continuar, indica que aceita os nossos %1$s.</string>
-    <string name="fui_pp_only">Ao continuar, indica que aceita a nossa %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Ao tocar em “%1$s”, pode gerar o envio de uma SMS. Podem aplicar-se tarifas de mensagens e dados.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Ao tocar em “%1$s”, indica que aceita os %2$s e a %3$s. Pode gerar o envio de uma SMS. Podem aplicar-se tarifas de dados e de mensagens.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Ao tocar em “%1$s”, indica que aceita os nossos %2$s. Pode gerar o envio de uma SMS. Podem aplicar-se tarifas de mensagens e dados.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Ao tocar em “%1$s”, indica que aceita a nossa %2$s. Pode gerar o envio de uma SMS. Podem aplicar-se tarifas de mensagens e dados.</string>
 </resources>

--- a/auth/src/main/res/values-pt/strings.xml
+++ b/auth/src/main/res/values-pt/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Carregando…</string>
     <string name="fui_sign_in_default">Fazer login</string>
     <string name="fui_tos_and_pp">Ao continuar, você concorda com nossos %1$s e a %2$s.</string>
-    <string name="fui_tos_only">Ao continuar, você concorda com nossos %1$s.</string>
-    <string name="fui_pp_only">Ao continuar, você concorda com nossa %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuar</string>
     <string name="fui_sms_terms_of_service">Se você tocar em “%1$s”, um SMS poderá ser enviado e tarifas de mensagens e de dados serão cobradas.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Ao tocar em “%1$s”, você concorda com nossos %2$s e a %3$s. Um SMS poderá ser enviado e tarifas de mensagens e de dados poderão ser cobradas.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Ao tocar em “%1$s”, você concorda com nossos %2$s. Um SMS poderá ser enviado e tarifas de mensagens e de dados poderão ser cobradas.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Ao tocar em “%1$s”, você concorda com nossa %2$s. Um SMS poderá ser enviado e tarifas de mensagens e de dados poderão ser cobradas.</string>
 </resources>

--- a/auth/src/main/res/values-ro/strings.xml
+++ b/auth/src/main/res/values-ro/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Se încarcă…</string>
     <string name="fui_sign_in_default">Conectați-vă</string>
     <string name="fui_tos_and_pp">Dacă alegeți să continuați, sunteți de acord cu %1$s și cu %2$s.</string>
-    <string name="fui_tos_only">Dacă alegeți să continuați, sunteți de acord cu %1$s.</string>
-    <string name="fui_pp_only">Dacă alegeți să continuați, sunteți de acord cu %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Continuați</string>
     <string name="fui_sms_terms_of_service">Dacă atingeți „%1$s”, poate fi trimis un SMS. Se pot aplica tarife pentru mesaje și date.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Dacă atingeți „%1$s”, sunteți de acord cu %2$s și cu %3$s. Poate fi trimis un SMS. Se pot aplica tarife pentru mesaje și date.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Dacă atingeți „%1$s”, sunteți de acord cu %2$s. Poate fi trimis un SMS. Se pot aplica tarife pentru mesaje și date.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Dacă atingeți „%1$s”, sunteți de acord cu %2$s. Poate fi trimis un SMS. Se pot aplica tarife pentru mesaje și date.</string>
 </resources>

--- a/auth/src/main/res/values-ru/strings.xml
+++ b/auth/src/main/res/values-ru/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Загрузка…</string>
     <string name="fui_sign_in_default">Войти</string>
     <string name="fui_tos_and_pp">Продолжая, вы принимаете %1$s и %2$s.</string>
-    <string name="fui_tos_only">Продолжая, вы принимаете %1$s.</string>
-    <string name="fui_pp_only">Продолжая, вы принимаете %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s  %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Продолжить</string>
     <string name="fui_sms_terms_of_service">Нажимая кнопку “%1$s”, вы соглашаетесь получить SMS. За его отправку и обмен данными может взиматься плата.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Нажимая кнопку “%1$s”, вы принимаете %2$s и %3$s, а также соглашаетесь получить SMS. За его отправку и обмен данными может взиматься плата.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Нажимая кнопку “%1$s”, вы принимаете %2$s и соглашаетесь получить SMS. За его отправку и обмен данными может взиматься плата.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Нажимая кнопку “%1$s”, вы принимаете %2$s и соглашаетесь получить SMS. За его отправку и обмен данными может взиматься плата.</string>
 </resources>

--- a/auth/src/main/res/values-sk/strings.xml
+++ b/auth/src/main/res/values-sk/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Načítava sa…</string>
     <string name="fui_sign_in_default">Prihlásiť sa</string>
     <string name="fui_tos_and_pp">Pokračovaním vyjadrujete súhlas s dokumentmi %1$s a %2$s.</string>
-    <string name="fui_tos_only">Pokračovaním vyjadrujete súhlas s dokumentom %1$s.</string>
-    <string name="fui_pp_only">Pokračovaním vyjadrujete súhlas s dokumentom %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Pokračovať</string>
     <string name="fui_sms_terms_of_service">Klepnutím na tlačidlo %1$s možno odoslať SMS. Môžu sa účtovať poplatky za správy a dáta.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Klepnutím na tlačidlo %1$s vyjadrujete súhlas s dokumentmi %2$s a %3$s. Môže byť odoslaná SMS a môžu sa účtovať poplatky za správy a dáta.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Klepnutím na tlačidlo %1$s vyjadrujete súhlas s dokumentom %2$s. Môže byť odoslaná SMS a môžu sa účtovať poplatky za správy a dáta.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Klepnutím na tlačidlo %1$s vyjadrujete súhlas s dokumentom %2$s. Môže byť odoslaná SMS a môžu sa účtovať poplatky za správy a dáta.</string>
 </resources>

--- a/auth/src/main/res/values-sl/strings.xml
+++ b/auth/src/main/res/values-sl/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Nalaganje…</string>
     <string name="fui_sign_in_default">Prijava</string>
     <string name="fui_tos_and_pp">Z nadaljevanjem potrjujete, da se strinjate z dokumentoma %1$s in %2$s.</string>
-    <string name="fui_tos_only">Z nadaljevanjem potrjujete, da se strinjate z dokumentom %1$s.</string>
-    <string name="fui_pp_only">Z nadaljevanjem potrjujete, da se strinjate z dokumentom %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Naprej</string>
     <string name="fui_sms_terms_of_service">Če se dotaknete možnosti »%1$s«, bo morda poslano sporočilo SMS. Pošiljanje sporočila in prenos podatkov boste morda morali plačati.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Če se dotaknete možnosti »%1$s«, potrjujete, da se strinjate z dokumentoma %2$s in %3$s. Morda bo poslano sporočilo SMS. Pošiljanje sporočila in prenos podatkov boste morda morali plačati.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Če se dotaknete možnosti »%1$s«, potrjujete, da se strinjate z dokumentom %2$s. Morda bo poslano sporočilo SMS. Pošiljanje sporočila in prenos podatkov boste morda morali plačati.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Če se dotaknete možnosti »%1$s«, potrjujete, da se strinjate z dokumentom %2$s. Morda bo poslano sporočilo SMS. Pošiljanje sporočila in prenos podatkov boste morda morali plačati.</string>
 </resources>

--- a/auth/src/main/res/values-sr/strings.xml
+++ b/auth/src/main/res/values-sr/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Учитава се…</string>
     <string name="fui_sign_in_default">Пријави ме</string>
     <string name="fui_tos_and_pp">Ако наставите, потврђујете да прихватате документе %1$s и %2$s.</string>
-    <string name="fui_tos_only">Ако наставите, потврђујете да прихватате документ %1$s.</string>
-    <string name="fui_pp_only">Ако наставите, потврђујете да прихватате документ %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Настави</string>
     <string name="fui_sms_terms_of_service">Ако додирнете „%1$s“, можда ћете послати SMS. Могу да вам буду наплаћени трошкови слања поруке и преноса података.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Ако додирнете „%1$s“, потврђујете да прихватате документе %2$s и %3$s. Можда ћете послати SMS. Могу да вам буду наплаћени трошкови слања поруке и преноса података.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Ако додирнете „%1$s“, потврђујете да прихватате документ %2$s. Можда ћете послати SMS. Могу да вам буду наплаћени трошкови слања поруке и преноса података.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Ако додирнете „%1$s“, потврђујете да прихватате документ %2$s. Можда ћете послати SMS. Могу да вам буду наплаћени трошкови слања поруке и преноса података.</string>
 </resources>

--- a/auth/src/main/res/values-sv/strings.xml
+++ b/auth/src/main/res/values-sv/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Läser in…</string>
     <string name="fui_sign_in_default">Logga in</string>
     <string name="fui_tos_and_pp">Genom att fortsätta godkänner du våra %1$s och vår %2$s.</string>
-    <string name="fui_tos_only">Genom att fortsätta godkänner du våra %1$s.</string>
-    <string name="fui_pp_only">Genom att fortsätta godkänner du vår %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Fortsätt</string>
     <string name="fui_sms_terms_of_service">Genom att trycka på %1$s skickas ett sms. Meddelande- och dataavgifter kan tillkomma.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Genom att trycka på %1$s godkänner du våra %2$s och vår %3$s. Ett sms kan skickas. Meddelande- och dataavgifter kan tillkomma.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Genom att trycka på %1$s godkänner du våra %2$s. Ett sms kan skickas. Meddelande- och dataavgifter kan tillkomma.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Genom att trycka på %1$s godkänner du vår %2$s. Ett sms kan skickas. Meddelande- och dataavgifter kan tillkomma.</string>
 </resources>

--- a/auth/src/main/res/values-ta/strings.xml
+++ b/auth/src/main/res/values-ta/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">ஏற்றுகிறது…</string>
     <string name="fui_sign_in_default">உள்நுழைக</string>
     <string name="fui_tos_and_pp">தொடர்வதன் மூலம், எங்கள் %1$s மற்றும் %2$sஐ ஏற்பதாகக் குறிப்பிடுகிறீர்கள்.</string>
-    <string name="fui_tos_only">தொடர்வதன் மூலம், எங்கள் %1$sஐ ஏற்பதாகக் குறிப்பிடுகிறீர்கள்.</string>
-    <string name="fui_pp_only">தொடர்வதன் மூலம், எங்கள் %1$sஐ ஏற்பதாகக் குறிப்பிடுகிறீர்கள்.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">தொடர்க</string>
     <string name="fui_sms_terms_of_service">“%1$s” என்பதைத் தட்டுவதன் மூலம், SMS அனுப்பப்படலாம். செய்தி மற்றும் தரவுக் கட்டணங்கள் விதிக்கப்படலாம்.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">“%1$s” என்பதைத் தட்டுவதன் மூலம், எங்கள் %2$s மற்றும் %3$sஐ ஏற்பதாகக் குறிப்பிடுகிறீர்கள். SMS அனுப்பப்படலாம். செய்தி மற்றும் தரவுக் கட்டணங்கள் விதிக்கப்படலாம்.</string>
-    <string name="fui_sms_terms_of_service_only_extended">“%1$s” என்பதைத் தட்டுவதன் மூலம், எங்கள் %2$sஐ ஏற்பதாகக் குறிப்பிடுகிறீர்கள். SMS அனுப்பப்படலாம். செய்தி மற்றும் தரவுக் கட்டணங்கள் விதிக்கப்படலாம்.</string>
-    <string name="fui_sms_privacy_policy_only_extended">“%1$s” என்பதைத் தட்டுவதன் மூலம், எங்கள் %2$sஐ ஏற்பதாகக் குறிப்பிடுகிறீர்கள். SMS அனுப்பப்படலாம். செய்தி மற்றும் தரவுக் கட்டணங்கள் விதிக்கப்படலாம்.</string>
 </resources>

--- a/auth/src/main/res/values-th/strings.xml
+++ b/auth/src/main/res/values-th/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">กำลังโหลด…</string>
     <string name="fui_sign_in_default">ลงชื่อเข้าใช้</string>
     <string name="fui_tos_and_pp">การดำเนินการต่อแสดงว่าคุณยอมรับ %1$s และ %2$s</string>
-    <string name="fui_tos_only">การดำเนินการต่อแสดงว่าคุณยอมรับ %1$s</string>
-    <string name="fui_pp_only">การดำเนินการต่อแสดงว่าคุณยอมรับ %1$s</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">ต่อไป</string>
     <string name="fui_sms_terms_of_service">เมื่อคุณแตะ “%1$s” ระบบจะส่ง SMS ให้คุณ อาจมีค่าบริการรับส่งข้อความและค่าบริการอินเทอร์เน็ต</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">การแตะ “%1$s” แสดงว่าคุณยอมรับ %2$s และ %3$s ระบบจะส่ง SMS ให้คุณ อาจมีค่าบริการรับส่งข้อความและค่าบริการอินเทอร์เน็ต</string>
-    <string name="fui_sms_terms_of_service_only_extended">การแตะ “%1$s” แสดงว่าคุณยอมรับ %2$s ระบบจะส่ง SMS ให้คุณ อาจมีค่าบริการรับส่งข้อความและค่าบริการอินเทอร์เน็ต</string>
-    <string name="fui_sms_privacy_policy_only_extended">การแตะ “%1$s” แสดงว่าคุณยอมรับ %2$s ระบบจะส่ง SMS ให้คุณ อาจมีค่าบริการรับส่งข้อความและค่าบริการอินเทอร์เน็ต</string>
 </resources>

--- a/auth/src/main/res/values-tl/strings.xml
+++ b/auth/src/main/res/values-tl/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Naglo-load…</string>
     <string name="fui_sign_in_default">Mag-sign in</string>
     <string name="fui_tos_and_pp">Sa pagpapatuloy, ipinababatid mo na tinatanggap mo ang aming %1$s at %2$s.</string>
-    <string name="fui_tos_only">Sa pagpapatuloy, ipinababatid mo na tinatanggap mo ang aming %1$s.</string>
-    <string name="fui_pp_only">Sa pagpapatuloy, ipinababatid mo na tinatanggap mo ang aming %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Fecebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Magpatuloy</string>
     <string name="fui_sms_terms_of_service">Sa pag-tap sa “%1$s,“ maaaring magpadala ng SMS. Maaaring ipatupad ang mga rate ng pagmemensahe at data.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Sa pag-tap sa “%1$s”, ipinababatid mo na tinatanggap mo ang aming %2$s at %3$s. Maaaring magpadala ng SMS. Maaaring ipatupad ang mga rate ng pagmemensahe at data.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Sa pag-tap sa “%1$s”, ipinababatid mo na tinatanggap mo ang aming %2$s. Maaaring magpadala ng SMS. Maaaring ipatupad ang mga rate ng pagmemensahe at data.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Sa pag-tap sa “%1$s”, ipinababatid mo na tinatanggap mo ang aming %2$s. Maaaring magpadala ng SMS. Maaaring ipatupad ang mga rate ng pagmemensahe at data.</string>
 </resources>

--- a/auth/src/main/res/values-tr/strings.xml
+++ b/auth/src/main/res/values-tr/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Yükleniyor…</string>
     <string name="fui_sign_in_default">Oturum aç</string>
     <string name="fui_tos_and_pp">Devam ederek %1$s ve %2$s hükümlerimizi kabul ettiğinizi bildirirsiniz.</string>
-    <string name="fui_tos_only">Devam ederek %1$s hükümlerimizi kabul ettiğinizi bildirirsiniz.</string>
-    <string name="fui_pp_only">Devam ederek %1$s hükümlerimizi kabul ettiğinizi bildirirsiniz.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Devam</string>
     <string name="fui_sms_terms_of_service">“%1$s” öğesine dokunarak SMS gönderilebilir. Mesaj ve veri ücretleri uygulanabilir.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">“%1$s” öğesine dokunarak %2$s ve %3$s hükümlerimizi kabul ettiğinizi bildirirsiniz. SMS gönderilebilir. Mesaj ve veri ücretleri uygulanabilir.</string>
-    <string name="fui_sms_terms_of_service_only_extended">%1$s öğesine dokunarak %2$s hükümlerimizi kabul ettiğinizi bildirirsiniz. SMS gönderilebilir. Mesaj ve veri ücretleri uygulanabilir.</string>
-    <string name="fui_sms_privacy_policy_only_extended">%1$s öğesine dokunarak %2$s hükümlerimizi kabul ettiğinizi bildirirsiniz. SMS gönderilebilir. Mesaj ve veri ücretleri uygulanabilir.</string>
 </resources>

--- a/auth/src/main/res/values-uk/strings.xml
+++ b/auth/src/main/res/values-uk/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Завантаження…</string>
     <string name="fui_sign_in_default">Увійти</string>
     <string name="fui_tos_and_pp">Продовжуючи, ви приймаєте такі документи: %1$s і %2$s.</string>
-    <string name="fui_tos_only">Продовжуючи, ви приймаєте такий документ: %1$s.</string>
-    <string name="fui_pp_only">Продовжуючи, ви приймаєте такий документ: %1$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Продовжити</string>
     <string name="fui_sms_terms_of_service">Коли ви торкнетесь опції “%1$s”, вам може надійти SMS-повідомлення. За SMS і використання трафіку може стягуватися плата.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Торкаючись кнопки “%1$s”, ви приймаєте такі документи: %2$s і %3$s. Вам може надійти SMS-повідомлення. За SMS і використання трафіку може стягуватися плата.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Торкаючись кнопки “%1$s”, ви приймаєте такий документ: %2$s. Вам може надійти SMS-повідомлення. За SMS і використання трафіку може стягуватися плата.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Торкаючись кнопки “%1$s”, ви приймаєте такий документ: %2$s. Вам може надійти SMS-повідомлення. За SMS і використання трафіку може стягуватися плата.</string>
 </resources>

--- a/auth/src/main/res/values-ur/strings.xml
+++ b/auth/src/main/res/values-ur/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">لوڈ ہو رہا ہے…</string>
     <string name="fui_sign_in_default">سائن ان کریں</string>
     <string name="fui_tos_and_pp">جاری رکھ کر، آپ نشاندہی کر رہے ہیں کہ آپ ہماری %1$s اور %2$s کو قبول کرتے ہیں۔</string>
-    <string name="fui_tos_only">جاری رکھ کر، آپ نشاندہی کر رہے ہیں کہ آپ ہماری %1$s کو قبول کرتے ہیں۔</string>
-    <string name="fui_pp_only">جاری رکھ کر، آپ نشاندہی کر رہے ہیں کہ آپ ہماری %1$s کو قبول کرتے ہیں۔</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">جاری رکھیں</string>
     <string name="fui_sms_terms_of_service">%1$s پر تھپتھپانے سے، ایک SMS بھیجا جا سکتا ہے۔ پیغام اور ڈیٹا کی شرحوں کا اطلاق ہو سکتا ہے۔</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">“%1$s” کو تھپتھپا کر، آپ نشاندہی کر رہے ہیں کہ آپ ہماری %2$s اور %3$s کو قبول کرتے ہیں۔ ایک SMS بھیجا جا سکتا ہے۔ پیغام اور ڈیٹا نرخ لاگو ہو سکتے ہیں۔</string>
-    <string name="fui_sms_terms_of_service_only_extended">“%1$s” کو تھپتھپا کر، آپ نشاندہی کر رہے ہیں کہ آپ ہماری %2$s کو قبول کرتے ہیں۔ ایک SMS بھیجا جا سکتا ہے۔ پیغام اور ڈیٹا نرخ لاگو ہو سکتے ہیں۔</string>
-    <string name="fui_sms_privacy_policy_only_extended">“%1$s” کو تھپتھپا کر، آپ نشاندہی کر رہے ہیں کہ آپ ہماری %2$s کو قبول کرتے ہیں۔ ایک SMS بھیجا جا سکتا ہے۔ پیغام اور ڈیٹا نرخ لاگو ہو سکتے ہیں۔</string>
 </resources>

--- a/auth/src/main/res/values-vi/strings.xml
+++ b/auth/src/main/res/values-vi/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">Đang tải…</string>
     <string name="fui_sign_in_default">Đăng nhập</string>
     <string name="fui_tos_and_pp">Bằng cách tiếp tục, bạn cho biết rằng bạn chấp nhận %1$s và %2$s của chúng tôi.</string>
-    <string name="fui_tos_only">Bằng cách tiếp tục, bạn cho biết rằng bạn chấp nhận %1$s của chúng tôi.</string>
-    <string name="fui_pp_only">Bằng cách tiếp tục, bạn cho biết rằng bạn chấp nhận %1$s của chúng tôi.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">Tiếp tục</string>
     <string name="fui_sms_terms_of_service">Bằng cách nhấn vào “%1$s”, bạn có thể nhận được một tin nhắn SMS. Cước tin nhắn và dữ liệu có thể áp dụng.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">Bằng cách nhấn vào “%1$s”, bạn cho biết rằng bạn chấp nhận %2$s và %3$s của chúng tôi. Bạn có thể nhận được một tin nhắn SMS. Cước tin nhắn và dữ liệu có thể áp dụng.</string>
-    <string name="fui_sms_terms_of_service_only_extended">Bằng cách nhấn vào “%1$s”, bạn cho biết rằng bạn chấp nhận %2$s của chúng tôi. Bạn có thể nhận được một tin nhắn SMS. Cước tin nhắn và dữ liệu có thể áp dụng.</string>
-    <string name="fui_sms_privacy_policy_only_extended">Bằng cách nhấn vào “%1$s”, bạn cho biết rằng bạn chấp nhận %2$s của chúng tôi. Bạn có thể nhận được một tin nhắn SMS. Cước tin nhắn và dữ liệu có thể áp dụng.</string>
 </resources>

--- a/auth/src/main/res/values-zh-rCN/strings.xml
+++ b/auth/src/main/res/values-zh-rCN/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">正在加载…</string>
     <string name="fui_sign_in_default">登录</string>
     <string name="fui_tos_and_pp">继续即表示您接受我们的%1$s和%2$s。</string>
-    <string name="fui_tos_only">继续即表示您接受我们的%1$s。</string>
-    <string name="fui_pp_only">继续即表示您接受我们的%1$s。</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">继续</string>
     <string name="fui_sms_terms_of_service">您点按“%1$s”后，系统会向您发送一条短信。这可能会产生短信费用和上网流量费。</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">点按“%1$s”即表示您接受我们的%2$s和%3$s。系统会向您发送一条短信。这可能会产生短信费用和上网流量费。</string>
-    <string name="fui_sms_terms_of_service_only_extended">点按“%1$s”即表示您接受我们的%2$s。系统会向您发送一条短信。这可能会产生短信费用和上网流量费。</string>
-    <string name="fui_sms_privacy_policy_only_extended">点按“%1$s”即表示您接受我们的%2$s。系统会向您发送一条短信。这可能会产生短信费用和上网流量费。</string>
 </resources>

--- a/auth/src/main/res/values-zh-rHK/strings.xml
+++ b/auth/src/main/res/values-zh-rHK/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">載入中…</string>
     <string name="fui_sign_in_default">登入</string>
     <string name="fui_tos_and_pp">選擇繼續即表示您同意接受我們的《%1$s》和《%2$s》。</string>
-    <string name="fui_tos_only">選擇繼續即表示您同意接受我們的《%1$s》。</string>
-    <string name="fui_pp_only">選擇繼續即表示您同意接受我們的《%1$s》。</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">繼續</string>
     <string name="fui_sms_terms_of_service">輕觸 [%1$s] 後，系統將會傳送一封簡訊。您可能需支付簡訊和數據傳輸費用。</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">輕觸 [%1$s] 即表示您同意接受我們的《%2$s》和《%3$s》。系統將會傳送簡訊給您，不過您可能需要支付簡訊和數據傳輸費用。</string>
-    <string name="fui_sms_terms_of_service_only_extended">輕觸 [%1$s] 即表示您同意接受我們的《%2$s》。系統將會傳送簡訊給您，不過您可能需要支付簡訊和數據傳輸費用。</string>
-    <string name="fui_sms_privacy_policy_only_extended">輕觸 [%1$s] 即表示您同意接受我們的《%2$s》。系統將會傳送簡訊給您，不過您可能需要支付簡訊和數據傳輸費用。</string>
 </resources>

--- a/auth/src/main/res/values-zh-rTW/strings.xml
+++ b/auth/src/main/res/values-zh-rTW/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">載入中…</string>
     <string name="fui_sign_in_default">登入</string>
     <string name="fui_tos_and_pp">選擇繼續即表示您同意接受我們的《%1$s》和《%2$s》。</string>
-    <string name="fui_tos_only">選擇繼續即表示您同意接受我們的《%1$s》。</string>
-    <string name="fui_pp_only">選擇繼續即表示您同意接受我們的《%1$s》。</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">繼續</string>
     <string name="fui_sms_terms_of_service">輕觸 [%1$s] 後，系統將會傳送一封簡訊。您可能需支付簡訊和數據傳輸費用。</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">輕觸 [%1$s] 即表示您同意接受我們的《%2$s》和《%3$s》。系統將會傳送簡訊給您，不過您可能需要支付簡訊和數據傳輸費用。</string>
-    <string name="fui_sms_terms_of_service_only_extended">輕觸 [%1$s] 即表示您同意接受我們的《%2$s》。系統將會傳送簡訊給您，不過您可能需要支付簡訊和數據傳輸費用。</string>
-    <string name="fui_sms_privacy_policy_only_extended">輕觸 [%1$s] 即表示您同意接受我們的《%2$s》。系統將會傳送簡訊給您，不過您可能需要支付簡訊和數據傳輸費用。</string>
 </resources>

--- a/auth/src/main/res/values-zh/strings.xml
+++ b/auth/src/main/res/values-zh/strings.xml
@@ -2,11 +2,7 @@
     <string name="fui_progress_dialog_loading">正在加载…</string>
     <string name="fui_sign_in_default">登录</string>
     <string name="fui_tos_and_pp">继续即表示您接受我们的%1$s和%2$s。</string>
-    <string name="fui_tos_only">继续即表示您接受我们的%1$s。</string>
-    <string name="fui_pp_only">继续即表示您接受我们的%1$s。</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
-    <string name="fui_tos_footer">%1$s</string>
-    <string name="fui_pp_footer">%1$s</string>
     <string name="fui_idp_name_google">Google</string>
     <string name="fui_idp_name_facebook">Facebook</string>
     <string name="fui_idp_name_twitter">Twitter</string>
@@ -69,6 +65,4 @@
     <string name="fui_continue_phone_login">继续</string>
     <string name="fui_sms_terms_of_service">您点按“%1$s”后，系统会向您发送一条短信。这可能会产生短信费用和上网流量费。</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended">点按“%1$s”即表示您接受我们的%2$s和%3$s。系统会向您发送一条短信。这可能会产生短信费用和上网流量费。</string>
-    <string name="fui_sms_terms_of_service_only_extended">点按“%1$s”即表示您接受我们的%2$s。系统会向您发送一条短信。这可能会产生短信费用和上网流量费。</string>
-    <string name="fui_sms_privacy_policy_only_extended">点按“%1$s”即表示您接受我们的%2$s。系统会向您发送一条短信。这可能会产生短信费用和上网流量费。</string>
 </resources>

--- a/auth/src/main/res/values/strings.xml
+++ b/auth/src/main/res/values/strings.xml
@@ -6,11 +6,7 @@
     <string name="fui_progress_dialog_loading" translation_description="Loading text in dialog">Loading…</string>
     <string name="fui_sign_in_default" translation_description="Button text to sign in">Sign in</string>
     <string name="fui_tos_and_pp" translation_description="Global ToS and privacy policy message">By continuing, you are indicating that you accept our <xliff:g example="https://google.com/terms" id="tos" translation_description="Terms of service text">%1$s</xliff:g> and <xliff:g example="https://google.com/privacy" id="pp" translation_description="Privacy policy text">%2$s</xliff:g>.</string>
-    <string name="fui_tos_only" translation_description="Global ToS and privacy policy message">By continuing, you are indicating that you accept our <xliff:g example="https://google.com/terms" id="tos" translation_description="Terms of service text">%1$s</xliff:g>.</string>
-    <string name="fui_pp_only" translation_description="Global ToS and privacy policy message">By continuing, you are indicating that you accept our <xliff:g example="https://google.com/privacy" id="pp" translation_description="Privacy policy text">%1$s</xliff:g>.</string>
     <string name="fui_tos_and_pp_footer" translation_description="Global ToS and Privacy policy footer"><xliff:g example="https://google.com/terms" id="tos" translation_description="Footer ToS text">%1$s</xliff:g> \u00A0 \u00A0 <xliff:g example="https://google.com/privacy" id="pp" translation_description="Footer privacy policy text">%2$s</xliff:g></string>
-    <string name="fui_tos_footer" translation_description="Global ToS footer"><xliff:g example="https://google.com/terms" id="tos" translation_description="Footer ToS only text">%1$s</xliff:g> </string>
-    <string name="fui_pp_footer" translation_description="Global privacy policy footer"><xliff:g example="https://google.com/privacy" id="pp" translation_description="Footer privacy policy only text">%1$s</xliff:g></string>
 
     <!-- Provider -->
     <string name="fui_idp_name_google">Google</string>
@@ -104,6 +100,4 @@
     <string name="fui_continue_phone_login" translation_description="Button text to submit phone number and send sms">Continue</string>
     <string name="fui_sms_terms_of_service" translation_description="Fine print warning displayed below Verify Phone Number button">By tapping “%1$s”, an SMS may be sent. Message &amp; data rates may apply.</string>
     <string name="fui_sms_terms_of_service_and_privacy_policy_extended" translation_description="Fine print warning displayed below Verify Phone Number button">By tapping “%1$s”, you are indicating that you accept our <xliff:g example="https://google.com/terms" id="tos" translation_description="">%2$s</xliff:g> and <xliff:g example="https://google.com/privacy" id="pp" translation_description="">%3$s</xliff:g>. An SMS may be sent. Message &amp; data rates may apply.</string>
-    <string name="fui_sms_terms_of_service_only_extended" translation_description="Fine print warning displayed below Verify Phone Number button">By tapping “%1$s”, you are indicating that you accept our <xliff:g example="https://google.com/terms" id="tos" translation_description="">%2$s</xliff:g>. An SMS may be sent. Message &amp; data rates may apply.</string>
-    <string name="fui_sms_privacy_policy_only_extended" translation_description="Fine print warning displayed below Verify Phone Number button">By tapping “%1$s”, you are indicating that you accept our <xliff:g example="https://google.com/privacy" id="pp" translation_description="">%2$s</xliff:g>. An SMS may be sent. Message &amp; data rates may apply.</string>
 </resources>

--- a/auth/src/test/java/com/firebase/ui/auth/AuthUITest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/AuthUITest.java
@@ -70,8 +70,7 @@ public class AuthUITest {
                         new IdpConfig.EmailBuilder().build(),
                         new IdpConfig.GoogleBuilder().build(),
                         new IdpConfig.FacebookBuilder().build()))
-                .setTosUrl(TestConstants.TOS_URL)
-                .setPrivacyPolicyUrl(TestConstants.PRIVACY_URL)
+                .setTosAndPrivacyPolicyUrls(TestConstants.TOS_URL, TestConstants.PRIVACY_URL)
                 .build()
                 .getParcelableExtra(ExtraConstants.FLOW_PARAMS);
 
@@ -80,5 +79,17 @@ public class AuthUITest {
         assertEquals(TestConstants.TOS_URL, flowParameters.termsOfServiceUrl);
         assertEquals(TestConstants.PRIVACY_URL, flowParameters.privacyPolicyUrl);
         assertEquals(AuthUI.getDefaultTheme(), flowParameters.themeId);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testCreatingStartIntent_withNullTos_expectEnforcesNonNullTosUrl() {
+        SignInIntentBuilder startIntent = AuthUI.getInstance().createSignInIntentBuilder();
+        startIntent.setTosAndPrivacyPolicyUrls(null, TestConstants.PRIVACY_URL);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testCreatingStartIntent_withNullPp_expectEnforcesNonNullPpUrl() {
+        SignInIntentBuilder startIntent = AuthUI.getInstance().createSignInIntentBuilder();
+        startIntent.setTosAndPrivacyPolicyUrls(TestConstants.TOS_URL, null);
     }
 }


### PR DESCRIPTION
Deprecated both #setTosUrl() and #setPrivacyPolicyUrl() and added #setTosAndPrivacyPolicyUrls(). 

If only one of ToS/Pp is provided nothing will be shown. Users must provide both.  


