### PR TITLE
Make artifactory compatible with gradle 4.8

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -16,7 +16,7 @@ object Config {
         const val google = "com.google.gms:google-services:4.0.1"
 
         const val bintray = "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3"
-        const val buildInfo = "org.jfrog.buildinfo:build-info-extractor-gradle:4.5.4"
+        const val buildInfo = "org.jfrog.buildinfo:build-info-extractor-gradle:4.7.3"
     }
 
     object Libs {


### PR DESCRIPTION
See https://github.com/JFrogDev/build-info/issues/166

Was getting the same issue, updating `build-info-extractor` to `4.7.3` works for me locally.