### PR TITLE
Firestore adapter lifecycle lint checks

### DIFF
--- a/app/src/main/java/com/firebase/uidemo/database/firestore/Foo.java
+++ b/app/src/main/java/com/firebase/uidemo/database/firestore/Foo.java
@@ -1,0 +1,7 @@
+package com.firebase.uidemo.database.firestore;
+
+import com.firebase.ui.firestore.FirestoreRecyclerAdapter;
+
+public class Foo {
+  private FirestoreRecyclerAdapter adapter;
+}

--- a/app/src/main/java/com/firebase/uidemo/database/firestore/Foo.java
+++ b/app/src/main/java/com/firebase/uidemo/database/firestore/Foo.java
@@ -1,7 +1,0 @@
-package com.firebase.uidemo.database.firestore;
-
-import com.firebase.ui.firestore.FirestoreRecyclerAdapter;
-
-public class Foo {
-  private FirestoreRecyclerAdapter adapter;
-}

--- a/internal/lint/src/main/java/com/firebaseui/lint/FirestoreRecyclerAdapterLifecycleDetector.kt
+++ b/internal/lint/src/main/java/com/firebaseui/lint/FirestoreRecyclerAdapterLifecycleDetector.kt
@@ -1,0 +1,176 @@
+package com.firebaseui.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category.Companion.CORRECTNESS
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity.WARNING
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UField
+import org.jetbrains.uast.visitor.AbstractUastVisitor
+import java.util.EnumSet
+
+class FirestoreRecyclerAdapterLifecycleDetector : Detector(), Detector.UastScanner {
+
+  override fun getApplicableUastTypes() = listOf(UClass::class.java)
+
+  override fun createUastHandler(context: JavaContext) = MissingLifecycleMethodsVisitor(context)
+
+  class MissingLifecycleMethodsVisitor(
+      private val context: JavaContext
+  ) : UElementHandler() {
+    private val FIRESTORE_RECYCLER_ADAPTER_TYPE =
+        "FirestoreRecyclerAdapter"
+    private val FIRESTORE_REYCLER_OPTIONS_BUILDER_TYPE =
+        "FirestoreRecyclerOptions.Builder"
+
+    override fun visitClass(node: UClass) {
+      val adapterReferences = node
+          .fields
+          .filter { FIRESTORE_RECYCLER_ADAPTER_TYPE == it.type.canonicalText }
+          .map { AdapterReference(it) }
+
+      val recyclerOptionsReferences = node
+          .fields
+          .filter { FIRESTORE_REYCLER_OPTIONS_BUILDER_TYPE == it.type.canonicalText }
+          .toMutableSet()
+
+      node.accept(AdapterStartListeningMethodVisitor(adapterReferences))
+      node.accept(AdapterStopListeningMethodVisitor(adapterReferences))
+      node.accept(LifecycleOwnerMethodVisitor(recyclerOptionsReferences))
+
+      adapterReferences.forEach {
+        if (it.hasCalledStart && !it.hasCalledStop) {
+          context.report(
+              ISSUE_MISSING_LISTENING_STOP_METHOD,
+              it.uField,
+              context.getLocation(it.uField),
+              "Have called .startListening() without .stopListening()."
+          )
+        } else if (!it.hasCalledStart) {
+          context.report(
+              ISSUE_MISSING_LISTENING_START_METHOD,
+              it.uField,
+              context.getLocation(it.uField),
+              "Have not called .startListening()."
+          )
+        }
+      }
+
+      recyclerOptionsReferences.forEach {
+        context.report(
+            ISSUE_MISSING_LIFECYCLE_OWNER_METHODS,
+            it,
+            context.getLocation(it),
+            "Have not called .setLifecycleOwner() on FirestoreRecyclerOptions."
+        )
+      }
+    }
+  }
+
+  class AdapterStartListeningMethodVisitor(
+      private val adapterReferences: List<AdapterReference>
+  ) : AbstractUastVisitor() {
+    private val START_LISTENING_METHOD_NAME = "startListening"
+
+    override fun visitCallExpression(node: UCallExpression): Boolean =
+        if (START_LISTENING_METHOD_NAME == node.methodName) {
+          adapterReferences
+              .find { it.uField.name == node.receiver?.asRenderString() }
+              ?.let {
+                it.hasCalledStart = true
+              }
+          true
+        } else {
+          super.visitCallExpression(node)
+        }
+  }
+
+  class AdapterStopListeningMethodVisitor(
+      private val adapterReferences: List<AdapterReference>
+  ) : AbstractUastVisitor() {
+    private val STOP_LISTENING_METHOD_NAME = "stopListening"
+
+    override fun visitCallExpression(node: UCallExpression): Boolean =
+        if (STOP_LISTENING_METHOD_NAME == node.methodName) {
+          adapterReferences
+              .find { it.uField.name == node.receiver?.asRenderString() }
+              ?.let {
+                it.hasCalledStop = true
+              }
+          true
+        } else {
+          super.visitCallExpression(node)
+        }
+  }
+
+  class LifecycleOwnerMethodVisitor(
+      private val recyclerOptionsReferences: MutableSet<UField>
+  ) : AbstractUastVisitor() {
+
+    private val SET_LIFECYCLE_OWNER_METHOD_NAME = "setLifecycleOwner"
+
+    override fun visitCallExpression(node: UCallExpression): Boolean =
+        if (SET_LIFECYCLE_OWNER_METHOD_NAME == node.methodName) {
+          val iterator = recyclerOptionsReferences.iterator()
+          while (iterator.hasNext()) {
+            if (node.receiver?.asRenderString() == iterator.next().name) {
+              iterator.remove()
+            }
+          }
+
+          true
+        } else {
+          super.visitCallExpression(node)
+        }
+  }
+
+  companion object {
+    val ISSUE_MISSING_LIFECYCLE_OWNER_METHODS = Issue.create(
+        "FirestoreRecyclerOptionsMissingLifecycleOwnerMethod",
+        "Checks if FirestoreRecyclerOptions has called .setLifecycleOwner().",
+        "If a class is using a FirestoreAdapter with FirestoreRecyclerOptions and " +
+            "has not called .setLifecycleOwner() on FirestoreRecyclerOptions, it won't be " +
+            "notified on changes.",
+        CORRECTNESS, 10, WARNING,
+        Implementation(
+            FirestoreRecyclerAdapterLifecycleDetector::class.java,
+            EnumSet.of(Scope.JAVA_FILE)
+        )
+    )
+
+    val ISSUE_MISSING_LISTENING_START_METHOD = Issue.create(
+        "FirestoreAdapterMissingStartListeningMethod",
+        "Checks if FirestoreAdapter has called .startListening() method.",
+        "If a class is using a FirestoreAdapter and does not call startListening it won't be " +
+            "notified on changes.",
+        CORRECTNESS, 10, WARNING,
+        Implementation(
+            FirestoreRecyclerAdapterLifecycleDetector::class.java,
+            EnumSet.of(Scope.JAVA_FILE)
+        )
+    )
+
+    val ISSUE_MISSING_LISTENING_STOP_METHOD = Issue.create(
+        "FirestoreAdapterMissingStopListeningMethod",
+        "Checks if FirestoreAdapter has called .stopListening() method.",
+        "If a class is using a FirestoreAdapter and has called .startListening() but missing " +
+            " .stopListening() might cause issues with RecyclerView data changes.",
+        CORRECTNESS, 10, WARNING,
+        Implementation(
+            FirestoreRecyclerAdapterLifecycleDetector::class.java,
+            EnumSet.of(Scope.JAVA_FILE)
+        )
+    )
+  }
+}
+
+data class AdapterReference(
+    val uField: UField,
+    var hasCalledStart: Boolean = false,
+    var hasCalledStop: Boolean = false
+)

--- a/internal/lint/src/main/java/com/firebaseui/lint/LintIssueRegistry.kt
+++ b/internal/lint/src/main/java/com/firebaseui/lint/LintIssueRegistry.kt
@@ -8,7 +8,6 @@ import com.android.tools.lint.client.api.IssueRegistry
 class LintIssueRegistry : IssueRegistry() {
     override val issues = listOf(
         NonGlobalIdDetector.NON_GLOBAL_ID,
-        FirestoreRecyclerAdapterLifecycleDetector.ISSUE_MISSING_LIFECYCLE_OWNER_METHODS,
         FirestoreRecyclerAdapterLifecycleDetector.ISSUE_MISSING_LISTENING_START_METHOD,
         FirestoreRecyclerAdapterLifecycleDetector.ISSUE_MISSING_LISTENING_STOP_METHOD
     )

--- a/internal/lint/src/main/java/com/firebaseui/lint/LintIssueRegistry.kt
+++ b/internal/lint/src/main/java/com/firebaseui/lint/LintIssueRegistry.kt
@@ -6,5 +6,10 @@ import com.android.tools.lint.client.api.IssueRegistry
  * Registry for custom FirebaseUI lint checks.
  */
 class LintIssueRegistry : IssueRegistry() {
-    override val issues = listOf(NonGlobalIdDetector.NON_GLOBAL_ID)
+    override val issues = listOf(
+        NonGlobalIdDetector.NON_GLOBAL_ID,
+        FirestoreRecyclerAdapterLifecycleDetector.ISSUE_MISSING_LIFECYCLE_OWNER_METHODS,
+        FirestoreRecyclerAdapterLifecycleDetector.ISSUE_MISSING_LISTENING_START_METHOD,
+        FirestoreRecyclerAdapterLifecycleDetector.ISSUE_MISSING_LISTENING_STOP_METHOD
+    )
 }

--- a/internal/lint/src/test/java/com/firebaseui/lint/FirestoreRecyclerAdapterLifecycleDetectorTest.kt
+++ b/internal/lint/src/test/java/com/firebaseui/lint/FirestoreRecyclerAdapterLifecycleDetectorTest.kt
@@ -1,0 +1,107 @@
+package com.firebaseui.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.java
+import com.firebaseui.lint.FirestoreRecyclerAdapterLifecycleDetector.Companion.ISSUE_MISSING_LIFECYCLE_OWNER_METHODS
+import com.firebaseui.lint.FirestoreRecyclerAdapterLifecycleDetector.Companion.ISSUE_MISSING_LISTENING_START_METHOD
+import com.firebaseui.lint.FirestoreRecyclerAdapterLifecycleDetector.Companion.ISSUE_MISSING_LISTENING_STOP_METHOD
+import com.firebaseui.lint.LintTestHelper.configuredLint
+import org.junit.Test
+
+class FirestoreRecyclerAdapterLifecycleDetectorTest {
+
+  @Test
+  fun `Checks missing startListening() method call`() {
+    configuredLint()
+        .files(java("""
+          |public class MissingStartListeningMethodCall {
+          | private FirestoreRecyclerAdapter adapter;
+          |}
+          """.trimMargin()))
+        .issues(ISSUE_MISSING_LISTENING_START_METHOD)
+        .run()
+        .expect("""
+          |src/MissingStartListeningMethodCall.java:2: Warning: Have not called .startListening(). [FirestoreAdapterMissingStartListeningMethod]
+          | private FirestoreRecyclerAdapter adapter;
+          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          |0 errors, 1 warnings
+          """.trimMargin())
+  }
+
+  @Test
+  fun `Checks missing stopListening() method call`() {
+    configuredLint()
+        .files(java("""
+          |public class MissingStopListeningMethodCall {
+          | private FirestoreRecyclerAdapter adapter;
+          |
+          | public void onStart() {
+          |   adapter.startListening();
+          | }
+          |}
+          """.trimMargin()))
+        .issues(ISSUE_MISSING_LISTENING_STOP_METHOD)
+        .run()
+        .expect("""
+          |src/MissingStopListeningMethodCall.java:2: Warning: Have called .startListening() without .stopListening(). [FirestoreAdapterMissingStopListeningMethod]
+          | private FirestoreRecyclerAdapter adapter;
+          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          |0 errors, 1 warnings
+          """.trimMargin())
+  }
+
+  @Test
+  fun `Checks no warnings when startListening & stopListening methods called`() {
+    configuredLint()
+        .files(java("""
+          |public class HasCalledStartStopListeningMethods {
+          | private FirestoreRecyclerAdapter adapter;
+          |
+          | public void onStart() {
+          |   adapter.startListening();
+          | }
+          |
+          | public void onStop() {
+          |   adapter.stopListening();
+          | }
+          |}
+          """.trimMargin()))
+        .issues(ISSUE_MISSING_LISTENING_START_METHOD, ISSUE_MISSING_LISTENING_STOP_METHOD)
+        .run()
+        .expectClean()
+  }
+
+  @Test
+  fun `Checks missing setLifecycleOwner() method call`() {
+    configuredLint()
+        .files(java("""
+          |public class MissingSetLifecycleOwnerMethodCall {
+          | private FirestoreRecyclerOptions.Builder builder;
+          |}
+          """.trimMargin()))
+        .issues(ISSUE_MISSING_LIFECYCLE_OWNER_METHODS)
+        .run()
+        .expect("""
+          |src/MissingSetLifecycleOwnerMethodCall.java:2: Warning: Have not called .setLifecycleOwner() on FirestoreRecyclerOptions. [FirestoreRecyclerOptionsMissingLifecycleOwnerMethod]
+          | private FirestoreRecyclerOptions.Builder builder;
+          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          |0 errors, 1 warnings
+          """.trimMargin())
+  }
+
+  @Test
+  fun `Checks no warnings when setLifecycleOwner() has been called`() {
+    configuredLint()
+        .files(java("""
+          |public class HasCalledSetLifecyleOwnerMethod {
+          | private FirestoreRecyclerOptions.Builder builder;
+          |
+          | public void initializer() {
+          |   builder.setLifecycleOwner(this);
+          | }
+          |}
+          """.trimMargin()))
+        .issues(ISSUE_MISSING_LIFECYCLE_OWNER_METHODS)
+        .run()
+        .expectClean()
+  }
+}

--- a/internal/lint/src/test/java/com/firebaseui/lint/FirestoreRecyclerAdapterLifecycleDetectorTest.kt
+++ b/internal/lint/src/test/java/com/firebaseui/lint/FirestoreRecyclerAdapterLifecycleDetectorTest.kt
@@ -1,7 +1,6 @@
 package com.firebaseui.lint
 
 import com.android.tools.lint.checks.infrastructure.TestFiles.java
-import com.firebaseui.lint.FirestoreRecyclerAdapterLifecycleDetector.Companion.ISSUE_MISSING_LIFECYCLE_OWNER_METHODS
 import com.firebaseui.lint.FirestoreRecyclerAdapterLifecycleDetector.Companion.ISSUE_MISSING_LISTENING_START_METHOD
 import com.firebaseui.lint.FirestoreRecyclerAdapterLifecycleDetector.Companion.ISSUE_MISSING_LISTENING_STOP_METHOD
 import com.firebaseui.lint.LintTestHelper.configuredLint
@@ -66,41 +65,6 @@ class FirestoreRecyclerAdapterLifecycleDetectorTest {
           |}
           """.trimMargin()))
         .issues(ISSUE_MISSING_LISTENING_START_METHOD, ISSUE_MISSING_LISTENING_STOP_METHOD)
-        .run()
-        .expectClean()
-  }
-
-  @Test
-  fun `Checks missing setLifecycleOwner() method call`() {
-    configuredLint()
-        .files(java("""
-          |public class MissingSetLifecycleOwnerMethodCall {
-          | private FirestoreRecyclerOptions.Builder builder;
-          |}
-          """.trimMargin()))
-        .issues(ISSUE_MISSING_LIFECYCLE_OWNER_METHODS)
-        .run()
-        .expect("""
-          |src/MissingSetLifecycleOwnerMethodCall.java:2: Warning: Have not called .setLifecycleOwner() on FirestoreRecyclerOptions. [FirestoreRecyclerOptionsMissingLifecycleOwnerMethod]
-          | private FirestoreRecyclerOptions.Builder builder;
-          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          |0 errors, 1 warnings
-          """.trimMargin())
-  }
-
-  @Test
-  fun `Checks no warnings when setLifecycleOwner() has been called`() {
-    configuredLint()
-        .files(java("""
-          |public class HasCalledSetLifecyleOwnerMethod {
-          | private FirestoreRecyclerOptions.Builder builder;
-          |
-          | public void initializer() {
-          |   builder.setLifecycleOwner(this);
-          | }
-          |}
-          """.trimMargin()))
-        .issues(ISSUE_MISSING_LIFECYCLE_OWNER_METHODS)
         .run()
         .expectClean()
   }

--- a/internal/lint/src/test/java/com/firebaseui/lint/LintTestHelper.kt
+++ b/internal/lint/src/test/java/com/firebaseui/lint/LintTestHelper.kt
@@ -1,0 +1,18 @@
+package com.firebaseui.lint
+
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import java.io.File
+
+object LintTestHelper {
+  // Nasty hack to make lint tests pass on Windows. For some reason, lint doesn't
+  // automatically find the Android SDK in its standard path on Windows. This hack looks
+  // through the system properties to find the path defined in `local.properties` and then
+  // sets lint's SDK home to that path if it's found.
+  private val sdkPath = System.getProperty("java.library.path").split(';').find {
+    it.contains("SDK", true)
+  }
+
+  fun configuredLint(): TestLintTask = TestLintTask.lint().apply {
+    sdkHome(File(sdkPath ?: return@apply))
+  }
+}

--- a/internal/lint/src/test/java/com/firebaseui/lint/NonGlobalIdDetectorTest.kt
+++ b/internal/lint/src/test/java/com/firebaseui/lint/NonGlobalIdDetectorTest.kt
@@ -1,11 +1,9 @@
 package com.firebaseui.lint
 
 import com.android.tools.lint.checks.infrastructure.TestFiles.xml
-import com.android.tools.lint.checks.infrastructure.TestLintTask
-import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.firebaseui.lint.LintTestHelper.configuredLint
 import com.firebaseui.lint.NonGlobalIdDetector.Companion.NON_GLOBAL_ID
 import org.junit.Test
-import java.io.File
 
 class NonGlobalIdDetectorTest {
     @Test
@@ -41,19 +39,5 @@ class NonGlobalIdDetectorTest {
                         |@@ -4 +3
                         |+     android:id="@+id/invalid"/>
                         |""".trimMargin())
-    }
-
-    companion object {
-        // Nasty hack to make lint tests pass on Windows. For some reason, lint doesn't
-        // automatically find the Android SDK in its standard path on Windows. This hack looks
-        // through the system properties to find the path defined in `local.properties` and then
-        // sets lint's SDK home to that path if it's found.
-        private val sdkPath = System.getProperty("java.library.path").split(';').find {
-            it.contains("SDK", true)
-        }
-
-        fun configuredLint(): TestLintTask = lint().apply {
-            sdkHome(File(sdkPath ?: return@apply))
-        }
     }
 }


### PR DESCRIPTION
This PR adds the following Lint checks:

1) Missing call on `startListening()` when using a `FirestoreRecyclerAdapter`.

2) Missing call on `stopListening()` when a `startListening()` method call has occurred previously.

3) Missing call on `setLifecycleOwner()` in case `FirestoreRecyclerOptions` are being used.

Relevant issue: https://github.com/firebase/FirebaseUI-Android/issues/1339