### PR TITLE
Insane full build perf improvements

### DIFF
--- a/proguard-tests/build.gradle.kts
+++ b/proguard-tests/build.gradle.kts
@@ -13,7 +13,6 @@ android {
                 isRemoveUnusedCode = true
                 isRemoveUnusedResources = true
                 isObfuscate = true
-                isOptimizeCode = true
             }
         }
     }


### PR DESCRIPTION
The `proguard-tests` module was running a full optimize routine which isn't necessary to check our proguard config. Our Travis builds are faster by **_5-10 minutes_**! 💯
![image](https://user-images.githubusercontent.com/9490724/42194796-8d49c012-7e2a-11e8-92ae-2585d05b998e.png)
