### PR TITLE
Adds FirebaseOpensoure.com Badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # FirebaseUI for Android — UI Bindings for Firebase
 
+[![FirebaseOpensource.com](https://img.shields.io/badge/Documentation-FirebaseOpensource.com-orange.svg)](
+https://firebaseopensource.com/projects/firebase/firebaseui-android
+)
 [![Build Status](https://travis-ci.org/firebase/FirebaseUI-Android.svg?branch=master)](https://travis-ci.org/firebase/FirebaseUI-Android)
 
 FirebaseUI is an open-source library for Android that allows you to

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FirebaseUI for Android — UI Bindings for Firebase
 
-[![FirebaseOpensource.com](https://img.shields.io/badge/Documentation-FirebaseOpensource.com-orange.svg)](
+[![FirebaseOpensource.com](https://img.shields.io/badge/Docs-firebaseopensource.com-orange.svg)](
 https://firebaseopensource.com/projects/firebase/firebaseui-android
 )
 [![Build Status](https://travis-ci.org/firebase/FirebaseUI-Android.svg?branch=master)](https://travis-ci.org/firebase/FirebaseUI-Android)


### PR DESCRIPTION
Playing around with adding a badge to link to FirebaseOpensource.com

[Thoughts?](https://github.com/firebase/FirebaseUI-Android/blob/abehaskins-fosdc-badge/README.md)