### PR TITLE
Fix Github tests

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
@@ -120,13 +120,15 @@ public final class AuthUI {
 
     /**
      * The set of authentication providers supported in Firebase Auth UI.
+     *
+     * TODO: the Github provider is not included because these tests do not
+     *       depend on the required auth-github module.
      */
     public static final Set<String> SUPPORTED_PROVIDERS =
             Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
                     GoogleAuthProvider.PROVIDER_ID,
                     FacebookAuthProvider.PROVIDER_ID,
                     TwitterAuthProvider.PROVIDER_ID,
-                    GithubAuthProvider.PROVIDER_ID,
                     EmailAuthProvider.PROVIDER_ID,
                     PhoneAuthProvider.PROVIDER_ID,
                     ANONYMOUS_PROVIDER

--- a/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthUI.java
@@ -120,15 +120,13 @@ public final class AuthUI {
 
     /**
      * The set of authentication providers supported in Firebase Auth UI.
-     *
-     * TODO: the Github provider is not included because these tests do not
-     *       depend on the required auth-github module.
      */
     public static final Set<String> SUPPORTED_PROVIDERS =
             Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
                     GoogleAuthProvider.PROVIDER_ID,
                     FacebookAuthProvider.PROVIDER_ID,
                     TwitterAuthProvider.PROVIDER_ID,
+                    GithubAuthProvider.PROVIDER_ID,
                     EmailAuthProvider.PROVIDER_ID,
                     PhoneAuthProvider.PROVIDER_ID,
                     ANONYMOUS_PROVIDER

--- a/auth/src/test/java/com/firebase/ui/auth/viewmodel/SocialProviderResponseHandlerTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/viewmodel/SocialProviderResponseHandlerTest.java
@@ -44,7 +44,6 @@ import org.robolectric.RuntimeEnvironment;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -64,16 +63,19 @@ public class SocialProviderResponseHandlerTest {
 
     private SocialProviderResponseHandler mHandler;
 
+    private static final ArrayList<String> NON_GITHUB_PROVIDERS = new ArrayList<>();
+    static {
+        NON_GITHUB_PROVIDERS.addAll(AuthUI.SUPPORTED_PROVIDERS);
+        NON_GITHUB_PROVIDERS.remove(GithubAuthProvider.PROVIDER_ID);
+    }
+
     @Before
     public void setUp() {
         TestHelper.initialize();
         MockitoAnnotations.initMocks(this);
 
         mHandler = new SocialProviderResponseHandler(RuntimeEnvironment.application);
-
-        List<String> allExceptGitHub = new ArrayList<>(AuthUI.SUPPORTED_PROVIDERS);
-        allExceptGitHub.remove(GithubAuthProvider.PROVIDER_ID);
-        FlowParameters testParams = TestHelper.getFlowParameters(allExceptGitHub);
+        FlowParameters testParams = TestHelper.getFlowParameters(NON_GITHUB_PROVIDERS);
 
         mHandler.initializeForTesting(testParams, mMockAuth, null, null);
     }
@@ -316,7 +318,8 @@ public class SocialProviderResponseHandlerTest {
 
     private void setupAnonymousUpgrade() {
         // enableAnonymousUpgrade must be set to true
-        FlowParameters testParams = TestHelper.getFlowParameters(AuthUI.SUPPORTED_PROVIDERS, /* enableAnonymousUpgrade */ true);
+        FlowParameters testParams = TestHelper.getFlowParameters(NON_GITHUB_PROVIDERS,
+                /* enableAnonymousUpgrade */ true);
         mHandler.initializeForTesting(testParams, mMockAuth, null, null);
 
         when(mUser.isAnonymous()).thenReturn(true);


### PR DESCRIPTION
This fixes #1425 

We can't add a dependency from `auth` to `auth-github` because that would be circular.

Maybe we need an `auth-common` module in the long term?  That would be a bit unfortunate, but could fix the issue.