### PR TITLE
Avoid error when canceling google signin

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/data/remote/GoogleSignInHandler.java
+++ b/auth/src/main/java/com/firebase/ui/auth/data/remote/GoogleSignInHandler.java
@@ -15,6 +15,7 @@ import com.firebase.ui.auth.IdpResponse;
 import com.firebase.ui.auth.data.model.IntentRequiredException;
 import com.firebase.ui.auth.data.model.Resource;
 import com.firebase.ui.auth.data.model.User;
+import com.firebase.ui.auth.data.model.UserCancellationException;
 import com.firebase.ui.auth.ui.HelperActivityBase;
 import com.firebase.ui.auth.util.ExtraConstants;
 import com.firebase.ui.auth.viewmodel.ProviderSignInBase;
@@ -96,7 +97,10 @@ public class GoogleSignInHandler extends ProviderSignInBase<GoogleSignInHandler.
                 // Hack for https://github.com/googlesamples/google-services/issues/345
                 // Google remembers the account so the picker doesn't appear twice for the user.
                 start();
-            } else {
+            }else if(e.getStatusCode() == GoogleSignInStatusCodes.SIGN_IN_CANCELLED){
+                setResult(Resource.<IdpResponse>forFailure(new UserCancellationException()));
+            }
+            else {
                 if (e.getStatusCode() == CommonStatusCodes.DEVELOPER_ERROR) {
                     Log.w(TAG, "Developer error: this application is misconfigured. " +
                             "Check your SHA1 and package name in the Firebase console.");

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -58,8 +58,9 @@ object Config {
         }
 
         object PlayServices {
-            const val auth = "com.google.android.gms:play-services-auth:15.0.1"
+            const val auth = "com.google.android.gms:play-services-auth:16.0.0"
         }
+
 
         object Provider {
             const val facebook = "com.facebook.android:facebook-login:4.33.0"


### PR DESCRIPTION
Currently if user cancel signin with google an error is shown as a toast instead of the message of user cancellation #1404, to avoid this play-services-auth is upgraded
Also the handle of the error code 12501 is added in order to set an UserCancellationException instead of FirebaseUiException
