### PR TITLE
Fix for #1416: set the classloader at Intent creation time.

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/HelperActivityBase.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/HelperActivityBase.java
@@ -8,6 +8,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.RestrictTo;
 import android.support.v7.app.AppCompatActivity;
 
+import com.firebase.ui.auth.AuthUI;
 import com.firebase.ui.auth.ErrorCodes;
 import com.firebase.ui.auth.IdpResponse;
 import com.firebase.ui.auth.data.model.FlowParameters;
@@ -29,11 +30,13 @@ public abstract class HelperActivityBase extends AppCompatActivity implements Pr
             @NonNull Context context,
             @NonNull Class<? extends Activity> target,
             @NonNull FlowParameters flowParams) {
-        return new Intent(
+        Intent intent = new Intent(
                 checkNotNull(context, "context cannot be null"),
                 checkNotNull(target, "target activity cannot be null"))
                 .putExtra(ExtraConstants.FLOW_BUNDLE,
                         checkNotNull(flowParams, "flowParams cannot be null").toBundle());
+        intent.setExtrasClassLoader(AuthUI.class.getClassLoader());
+        return intent;
     }
 
     @Override


### PR DESCRIPTION
This is because the exception happens _before_ we get to
read the FlowParameters from the extras/bundle.

Hey there! So you want to contribute to FirebaseUI? Before you file this pull request, follow these steps:

  * Read [the contribution guidelines](CONTRIBUTING.md).
  * Run `./gradlew check` to ensure the Travis build passes.
  * If this has been discussed in an issue, make sure to mention the issue number here. If not, go file an issue about this to make sure this is a desirable change.
  * If this is a new feature please co-ordinate with someone on [FirebaseUI-iOS](https://github.com/firebase/firebaseui-ios) to make sure that we can implement this on both platforms and maintain feature parity.
