### PR TITLE
Revert failed fixes for #1416

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/data/model/FlowParameters.java
+++ b/auth/src/main/java/com/firebase/ui/auth/data/model/FlowParameters.java
@@ -14,7 +14,6 @@
 package com.firebase.ui.auth.data.model;
 
 import android.content.Intent;
-import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.DrawableRes;
@@ -89,14 +88,8 @@ public class FlowParameters implements Parcelable {
      */
     public static FlowParameters fromIntent(Intent intent) {
         //this is required to fix #1416 - ClassNotFound for FlowParameters
-        Bundle bundle = intent.getBundleExtra(ExtraConstants.FLOW_BUNDLE);
-        return bundle.getParcelable(ExtraConstants.FLOW_PARAMS);
-    }
-
-    public Bundle toBundle() {
-        Bundle bundle = new Bundle();
-        bundle.putParcelable(ExtraConstants.FLOW_PARAMS, this);
-        return bundle;
+        intent.setExtrasClassLoader(AuthUI.class.getClassLoader());
+        return intent.getParcelableExtra(ExtraConstants.FLOW_PARAMS);
     }
 
     @Override

--- a/auth/src/main/java/com/firebase/ui/auth/data/model/FlowParameters.java
+++ b/auth/src/main/java/com/firebase/ui/auth/data/model/FlowParameters.java
@@ -87,8 +87,6 @@ public class FlowParameters implements Parcelable {
      * Extract FlowParameters from an Intent.
      */
     public static FlowParameters fromIntent(Intent intent) {
-        //this is required to fix #1416 - ClassNotFound for FlowParameters
-        intent.setExtrasClassLoader(AuthUI.class.getClassLoader());
         return intent.getParcelableExtra(ExtraConstants.FLOW_PARAMS);
     }
 

--- a/auth/src/main/java/com/firebase/ui/auth/ui/HelperActivityBase.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/HelperActivityBase.java
@@ -33,8 +33,8 @@ public abstract class HelperActivityBase extends AppCompatActivity implements Pr
         Intent intent = new Intent(
                 checkNotNull(context, "context cannot be null"),
                 checkNotNull(target, "target activity cannot be null"))
-                .putExtra(ExtraConstants.FLOW_BUNDLE,
-                        checkNotNull(flowParams, "flowParams cannot be null").toBundle());
+                .putExtra(ExtraConstants.FLOW_PARAMS,
+                        checkNotNull(flowParams, "flowParams cannot be null"));
         intent.setExtrasClassLoader(AuthUI.class.getClassLoader());
         return intent;
     }

--- a/auth/src/main/java/com/firebase/ui/auth/util/ExtraConstants.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/ExtraConstants.java
@@ -21,7 +21,6 @@ import android.support.annotation.RestrictTo;
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public final class ExtraConstants {
-    public static final String FLOW_BUNDLE = "extra_flow_bundle";
     public static final String FLOW_PARAMS = "extra_flow_params";
     public static final String IDP_RESPONSE = "extra_idp_response";
     public static final String USER = "extra_user";

--- a/auth/src/test/java/com/firebase/ui/auth/AuthUITest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/AuthUITest.java
@@ -45,9 +45,10 @@ public class AuthUITest {
 
     @Test
     public void testCreateStartIntent_shouldHaveEmailAsDefaultProvider() {
-        FlowParameters flowParameters = FlowParameters.fromIntent(mAuthUi
+        FlowParameters flowParameters = mAuthUi
                 .createSignInIntentBuilder()
-                .build());
+                .build()
+                .getParcelableExtra(ExtraConstants.FLOW_PARAMS);
         assertEquals(1, flowParameters.providers.size());
         assertEquals(EmailAuthProvider.PROVIDER_ID,
                 flowParameters.providers.get(0).getProviderId());
@@ -63,7 +64,7 @@ public class AuthUITest {
 
     @Test
     public void testCreatingStartIntent() {
-        FlowParameters flowParameters = FlowParameters.fromIntent(mAuthUi
+        FlowParameters flowParameters = mAuthUi
                 .createSignInIntentBuilder()
                 .setAvailableProviders(Arrays.asList(
                         new IdpConfig.EmailBuilder().build(),
@@ -71,7 +72,8 @@ public class AuthUITest {
                         new IdpConfig.FacebookBuilder().build(),
                         new IdpConfig.AnonymousBuilder().build()))
                 .setTosAndPrivacyPolicyUrls(TestConstants.TOS_URL, TestConstants.PRIVACY_URL)
-                .build());
+                .build()
+                .getParcelableExtra(ExtraConstants.FLOW_PARAMS);
 
         assertEquals(4, flowParameters.providers.size());
         assertEquals(TestHelper.MOCK_APP.getName(), flowParameters.appName);


### PR DESCRIPTION
As requested by @SUPERCILEX in #1470 

cc @dimipaun

This reverts these two commits:
https://github.com/firebase/FirebaseUI-Android/commit/1f3b18e1646704792804072e89f04d27b207e886
https://github.com/firebase/FirebaseUI-Android/commit/0786884eab33c7a41091d66d20149bc25d49353a

I think that's all the dead code hanging around for this issue.