### PR TITLE
Update README.md

### DIFF
--- a/storage/README.md
+++ b/storage/README.md
@@ -30,6 +30,7 @@ to your `app/build.gradle` file:
 ```groovy
 // Find the latest Glide releases here: https://goo.gl/LpksbR
 implementation 'com.github.bumptech.glide:glide:4.x'
+// If you're using Kotlin (and therefore, kapt), use kapt instead of annotationProcessor
 annotationProcessor 'com.github.bumptech.glide:compiler:4.x'
 ```
 


### PR DESCRIPTION
Kotlin users will need to use `kapt` instead of `annotationProcessor` or `GlideApp` will not be generated. Could be a bit clearer with this comment in the docs.

*Note*: I didn't file an issue for this since it's such a small change.

Hey there! So you want to contribute to FirebaseUI? Before you file this pull request, follow these steps:

  * Read [the contribution guidelines](CONTRIBUTING.md).
  * Run `./gradlew check` to ensure the Travis build passes.
  * If this has been discussed in an issue, make sure to mention the issue number here. If not, go file an issue about this to make sure this is a desirable change.
  * If this is a new feature please co-ordinate with someone on [FirebaseUI-iOS](https://github.com/firebase/firebaseui-ios) to make sure that we can implement this on both platforms and maintain feature parity.
