### PR TITLE
Make country spinner survive rotation

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/CheckPhoneNumberFragment.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/CheckPhoneNumberFragment.java
@@ -98,6 +98,7 @@ public class CheckPhoneNumberFragment extends FragmentBase implements View.OnCli
         mSubmitButton.setOnClickListener(this);
 
         setupPrivacyDisclosures(view.<TextView>findViewById(R.id.email_footer_tos_and_pp_text));
+        setupCountrySpinner();
     }
 
     @Override
@@ -115,12 +116,12 @@ public class CheckPhoneNumberFragment extends FragmentBase implements View.OnCli
             }
         });
 
-        if (savedInstanceState != null || mCalled) { return; }
+        if (savedInstanceState != null || mCalled) {
+            return;
+        }
         // Fragment back stacks are the stuff of nightmares (what's new?): the fragment isn't
         // destroyed so its state isn't saved and we have to rely on an instance field. Sigh.
         mCalled = true;
-
-        setupCountrySpinner();
     }
 
     @Override


### PR DESCRIPTION
See #1518

I think the old logic comes from when "setupCountrySpinner" was a long async operation.  We should do it in `onViewCreated` now.  This works great in manual testing, fixes the issue.