### PR TITLE
Error dialog for email link same device anonymous user mismatch flow

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ErrorCodes.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ErrorCodes.java
@@ -60,6 +60,12 @@ public final class ErrorCodes {
      * */
     public static final int EMAIL_LINK_CROSS_DEVICE_LINKING_ERROR = 10;
 
+    /**
+     * Attempting to open an email link from the same device, with anonymous upgrade enabled,
+     * but the underlying anonymous user has been changed.
+     */
+    public static final int EMAIL_LINK_DIFFERENT_ANONYMOUS_USER_ERROR = 11;
+
     private ErrorCodes() {
         throw new AssertionError("No instance for you!");
     }
@@ -91,6 +97,9 @@ public final class ErrorCodes {
                 return "You must open the email link on the same device.";
             case EMAIL_LINK_CROSS_DEVICE_LINKING_ERROR:
                 return "You must determine if you want to continue linking or complete the sign in";
+            case EMAIL_LINK_DIFFERENT_ANONYMOUS_USER_ERROR:
+                return "The session associated with this sign-in request has either expired or " +
+                        "was cleared";
             default:
                 throw new IllegalArgumentException("Unknown code: " + code);
         }
@@ -110,7 +119,8 @@ public final class ErrorCodes {
             INVALID_EMAIL_LINK_ERROR,
             EMAIL_LINK_WRONG_DEVICE_ERROR,
             EMAIL_LINK_PROMPT_FOR_EMAIL_ERROR,
-            EMAIL_LINK_CROSS_DEVICE_LINKING_ERROR
+            EMAIL_LINK_CROSS_DEVICE_LINKING_ERROR,
+            EMAIL_LINK_DIFFERENT_ANONYMOUS_USER_ERROR
     })
     @Retention(RetentionPolicy.SOURCE)
     public @interface Code {

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/EmailLinkCatcherActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/EmailLinkCatcherActivity.java
@@ -64,7 +64,8 @@ public class EmailLinkCatcherActivity extends InvisibleActivityBase {
                 } else if (e instanceof FirebaseUiException) {
                     int errorCode = ((FirebaseUiException) e).getErrorCode();
                     if (errorCode == ErrorCodes.EMAIL_LINK_WRONG_DEVICE_ERROR
-                            || errorCode == ErrorCodes.INVALID_EMAIL_LINK_ERROR) {
+                            || errorCode == ErrorCodes.INVALID_EMAIL_LINK_ERROR
+                            || errorCode == ErrorCodes.EMAIL_LINK_DIFFERENT_ANONYMOUS_USER_ERROR) {
                         buildAlertDialog(errorCode).show();
                     } else if (errorCode == ErrorCodes.EMAIL_LINK_PROMPT_FOR_EMAIL_ERROR
                             || errorCode == ErrorCodes.EMAIL_MISMATCH_ERROR) {
@@ -97,28 +98,32 @@ public class EmailLinkCatcherActivity extends InvisibleActivityBase {
         startActivityForResult(intent, flow);
     }
 
-    private AlertDialog buildAlertDialog(int errorCode) {
+    private AlertDialog buildAlertDialog(final int errorCode) {
         AlertDialog.Builder alertDialog = new AlertDialog.Builder(this);
-        if (errorCode == ErrorCodes.EMAIL_LINK_WRONG_DEVICE_ERROR) {
-            alertDialog.setTitle(R.string.fui_email_link_wrong_device_header)
-                    .setMessage(R.string.fui_email_link_wrong_device_message)
-                    .setPositiveButton(R.string.fui_email_link_dismiss_button,
-                            new DialogInterface.OnClickListener() {
-                                public void onClick(DialogInterface dialog, int id) {
-                                    finish(RequestCodes.EMAIL_LINK_WRONG_DEVICE_FLOW, null);
-                                }
-                            });
+
+        String titleText;
+        String messageText;
+        if (errorCode == ErrorCodes.EMAIL_LINK_DIFFERENT_ANONYMOUS_USER_ERROR) {
+            titleText = getString(R.string.fui_email_link_different_anonymous_user_header);
+            messageText = getString(R.string.fui_email_link_different_anonymous_user_message);
         } else if (errorCode == ErrorCodes.INVALID_EMAIL_LINK_ERROR) {
-            alertDialog.setTitle(R.string.fui_email_link_invalid_link_header)
-                    .setMessage(R.string.fui_email_link_invalid_link_message)
-                    .setPositiveButton(R.string.fui_email_link_dismiss_button,
-                            new DialogInterface.OnClickListener() {
-                                public void onClick(DialogInterface dialog, int id) {
-                                    finish(RequestCodes.EMAIL_LINK_INVALID_LINK_FLOW, null);
-                                }
-                            });
+            titleText = getString(R.string.fui_email_link_invalid_link_header);
+            messageText = getString(R.string.fui_email_link_invalid_link_message);
+        } else {
+            // Default value - ErrorCodes.EMAIL_LINK_WRONG_DEVICE_ERROR
+            titleText = getString(R.string.fui_email_link_wrong_device_header);
+            messageText = getString(R.string.fui_email_link_wrong_device_message);
         }
-        return alertDialog.create();
+
+        return alertDialog.setTitle(titleText)
+                .setMessage(messageText)
+                .setPositiveButton(R.string.fui_email_link_dismiss_button,
+                        new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int id) {
+                                finish(errorCode, null);
+                            }
+                        })
+                .create();
     }
 
     @Override

--- a/auth/src/main/java/com/firebase/ui/auth/viewmodel/email/EmailLinkSignInHandler.java
+++ b/auth/src/main/java/com/firebase/ui/auth/viewmodel/email/EmailLinkSignInHandler.java
@@ -88,9 +88,9 @@ public class EmailLinkSignInHandler extends SignInViewModelBase {
             if (getAuth().getCurrentUser() == null
                     || (getAuth().getCurrentUser().isAnonymous()
                     && !anonymousUserIdFromLink.equals(getAuth().getCurrentUser().getUid()))) {
-                // TODO(lsirac): add new error?
                 setResult(Resource.<IdpResponse>forFailure(
-                        new FirebaseUiException(ErrorCodes.EMAIL_LINK_WRONG_DEVICE_ERROR)));
+                        new FirebaseUiException(
+                                ErrorCodes.EMAIL_LINK_DIFFERENT_ANONYMOUS_USER_ERROR)));
                 return;
             }
         }

--- a/auth/src/main/res/values/strings.xml
+++ b/auth/src/main/res/values/strings.xml
@@ -103,6 +103,8 @@
     <string name="fui_email_link_wrong_device_message" translation_description="Message shown when the user opens a link that was sent from a different device">Try opening the link using the same device or browser where you started the sign-in process.</string>
     <string name="fui_email_link_invalid_link_header" translation_description="Header shown when the user opens a link that was sent from a different device">Unable to complete sign in</string>
     <string name="fui_email_link_invalid_link_message" translation_description="Message shown when the user opens a link that was sent from a different device">The action code is invalid. This can happen if the code is malformed, expired, or has already been used.</string>
+    <string name="fui_email_link_different_anonymous_user_header" translation_description="Header shown when the user opens a link but the underlying session has changed">Session ended</string>
+    <string name="fui_email_link_different_anonymous_user_message" translation_description="Message shown when the user opens a link but the underlying session has changed">The session associated with this sign-in request has either expired or was cleared.</string>
     <string name="fui_email_link_confirm_email_header" translation_description="Header shown when prompting the user to confirm their email to complete the sign in">Confirm email</string>
     <string name="fui_email_link_confirm_email_message" translation_description="Message shown when prompting the user to confirm their email to finish the sign in flow">Confirm email to continue sign in</string>
     <string name="fui_email_link_dismiss_button" translation_description="Dismiss button for the wrong device or invalid link dialog">Dismiss</string>


### PR DESCRIPTION
Adds a new error dialog when there is a mismatch between the anonymous user id on the link and the underlying anonymous user in the same device anonymous upgrade flow. 