### PR TITLE
Revert baseline textview change

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/util/ui/BaselineTextInputLayout.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/ui/BaselineTextInputLayout.java
@@ -1,0 +1,28 @@
+package com.firebase.ui.auth.util.ui;
+
+import android.content.Context;
+import android.support.annotation.RestrictTo;
+import android.support.design.widget.TextInputLayout;
+import android.util.AttributeSet;
+import android.widget.EditText;
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+public class BaselineTextInputLayout extends TextInputLayout {
+    public BaselineTextInputLayout(Context context) {
+        super(context);
+    }
+
+    public BaselineTextInputLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public BaselineTextInputLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    public int getBaseline() {
+        EditText text = getEditText();
+        return text == null ? super.getBaseline() : text.getPaddingTop() + text.getBaseline();
+    }
+}

--- a/auth/src/main/res/layout/fui_phone_layout.xml
+++ b/auth/src/main/res/layout/fui_phone_layout.xml
@@ -25,7 +25,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintBaseline_toBaselineOf="@+id/phone_layout" />
 
-            <android.support.design.widget.TextInputLayout
+            <com.firebase.ui.auth.util.ui.BaselineTextInputLayout
                 android:id="@+id/phone_layout"
                 style="@style/FirebaseUI.TextInputLayout.PhoneField"
                 android:layout_width="0dp"
@@ -39,7 +39,7 @@
                     style="@style/FirebaseUI.TextInputEditText.PhoneField"
                     android:imeOptions="actionDone" />
 
-            </android.support.design.widget.TextInputLayout>
+            </com.firebase.ui.auth.util.ui.BaselineTextInputLayout>
 
             <Button
                 android:id="@+id/send_code"


### PR DESCRIPTION
See issue #1555, it looks like removing our baseline text input layout class was premature, it's not in the support design lib yet.