### PR TITLE
Fix Issue #1608 - retry() failing in FirestorePagingAdapter

### DIFF
--- a/app/src/main/java/com/firebase/uidemo/database/firestore/FirestorePagingActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/database/firestore/FirestorePagingActivity.java
@@ -4,6 +4,7 @@ import android.arch.paging.PagedList;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -40,8 +41,8 @@ public class FirestorePagingActivity extends AppCompatActivity {
     @BindView(R.id.paging_recycler)
     RecyclerView mRecycler;
 
-    @BindView(R.id.paging_loading)
-    ProgressBar mProgressBar;
+    @BindView(R.id.swipe_refresh_layout)
+    SwipeRefreshLayout mSwipeRefreshLayout;
 
     private FirebaseFirestore mFirestore;
     private CollectionReference mItemsCollection;
@@ -72,7 +73,7 @@ public class FirestorePagingActivity extends AppCompatActivity {
                 .setQuery(baseQuery, config, Item.class)
                 .build();
 
-        FirestorePagingAdapter<Item, ItemViewHolder> adapter =
+        final FirestorePagingAdapter<Item, ItemViewHolder> adapter =
                 new FirestorePagingAdapter<Item, ItemViewHolder>(options) {
                     @NonNull
                     @Override
@@ -95,13 +96,13 @@ public class FirestorePagingActivity extends AppCompatActivity {
                         switch (state) {
                             case LOADING_INITIAL:
                             case LOADING_MORE:
-                                mProgressBar.setVisibility(View.VISIBLE);
+                                mSwipeRefreshLayout.setRefreshing(true);
                                 break;
                             case LOADED:
-                                mProgressBar.setVisibility(View.GONE);
+                                mSwipeRefreshLayout.setRefreshing(false);
                                 break;
                             case FINISHED:
-                                mProgressBar.setVisibility(View.GONE);
+                                mSwipeRefreshLayout.setRefreshing(false);
                                 showToast("Reached end of data set.");
                                 break;
                             case ERROR:
@@ -114,6 +115,13 @@ public class FirestorePagingActivity extends AppCompatActivity {
 
         mRecycler.setLayoutManager(new LinearLayoutManager(this));
         mRecycler.setAdapter(adapter);
+
+        mSwipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
+            @Override
+            public void onRefresh() {
+                adapter.refresh();
+            }
+        });
     }
 
     @Override

--- a/app/src/main/res/layout/activity_firestore_paging.xml
+++ b/app/src/main/res/layout/activity_firestore_paging.xml
@@ -1,20 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
+<android.support.v4.widget.SwipeRefreshLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/swipe_refresh_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="com.firebase.uidemo.database.firestore.FirestorePagingActivity">
-
-    <ProgressBar
-        android:id="@+id/paging_loading"
-        style="?android:attr/progressBarStyleHorizontal"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="-6dp"
-        android:background="@android:color/transparent"
-        android:indeterminate="true"
-        tools:ignore="NegativeMargin" />
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/paging_recycler"
@@ -27,4 +18,4 @@
         android:clipToPadding="false"
         tools:listitem="@layout/item_item" />
 
-</RelativeLayout>
+</android.support.v4.widget.SwipeRefreshLayout>

--- a/database/src/main/java/com/firebase/ui/database/paging/FirebaseRecyclerPagingAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/paging/FirebaseRecyclerPagingAdapter.java
@@ -35,7 +35,10 @@ public abstract class FirebaseRecyclerPagingAdapter<T, VH extends RecyclerView.V
     private final LiveData<FirebaseDataSource> mDataSource;
 
 
-    //Data Source Observer
+    /*
+        LiveData created via Transformation do not have a value until an Observer is attached.  
+        We attach this empty observer so that our getValue() calls return non-null later.
+    */
     private final Observer<FirebaseDataSource> mDataSourceObserver = new Observer<FirebaseDataSource>() {
         @Override
         public void onChanged(@Nullable FirebaseDataSource source) {

--- a/firestore/src/main/java/com/firebase/ui/firestore/paging/FirestorePagingAdapter.java
+++ b/firestore/src/main/java/com/firebase/ui/firestore/paging/FirestorePagingAdapter.java
@@ -34,7 +34,10 @@ public abstract class FirestorePagingAdapter<T, VH extends RecyclerView.ViewHold
     private final LiveData<LoadingState> mLoadingState;
     private final LiveData<FirestoreDataSource> mDataSource;
 
-
+    /*
+        LiveData created via Transformation do not have a value until an Observer is attached.  
+        We attach this empty observer so that our getValue() calls return non-null later.
+    */
     private final Observer<FirestoreDataSource> mDataSourceObserver = new Observer<FirestoreDataSource>() {
         @Override
         public void onChanged(@Nullable FirestoreDataSource source) {

--- a/firestore/src/main/java/com/firebase/ui/firestore/paging/FirestorePagingAdapter.java
+++ b/firestore/src/main/java/com/firebase/ui/firestore/paging/FirestorePagingAdapter.java
@@ -34,6 +34,14 @@ public abstract class FirestorePagingAdapter<T, VH extends RecyclerView.ViewHold
     private final LiveData<LoadingState> mLoadingState;
     private final LiveData<FirestoreDataSource> mDataSource;
 
+
+    private final Observer<FirestoreDataSource> mDataSourceObserver = new Observer<FirestoreDataSource>() {
+        @Override
+        public void onChanged(@Nullable FirestoreDataSource source) {
+
+        }
+    };
+
     private final Observer<LoadingState> mStateObserver =
             new Observer<LoadingState>() {
                 @Override
@@ -105,12 +113,25 @@ public abstract class FirestorePagingAdapter<T, VH extends RecyclerView.ViewHold
     }
 
     /**
+     * To attempt to refresh the list. It will reload the list from beginning.
+     */
+    public void refresh(){
+        FirestoreDataSource mFirebaseDataSource = mDataSource.getValue();
+        if (mFirebaseDataSource == null) {
+            Log.w(TAG, "Called refresh() when FirestoreDataSource is null!");
+            return;
+        }
+        mFirebaseDataSource.invalidate();
+    }
+
+    /**
      * Start listening to paging / scrolling events and populating adapter data.
      */
     @OnLifecycleEvent(Lifecycle.Event.ON_START)
     public void startListening() {
         mSnapshots.observeForever(mDataObserver);
         mLoadingState.observeForever(mStateObserver);
+        mDataSource.observeForever(mDataSourceObserver);
     }
 
     /**
@@ -121,6 +142,7 @@ public abstract class FirestorePagingAdapter<T, VH extends RecyclerView.ViewHold
     public void stopListening() {
         mSnapshots.removeObserver(mDataObserver);
         mLoadingState.removeObserver(mStateObserver);
+        mDataSource.removeObserver(mDataSourceObserver);
     }
 
     @Override


### PR DESCRIPTION
I have fixed `retry()` failing and added a new method `refresh()` to refresh the list from the beginning as issue #1608 