### PR TITLE
#1658: Fix for using custom Layout icm Email Link

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
@@ -19,7 +19,11 @@ import android.arch.lifecycle.ViewModelProviders;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.annotation.*;
+import android.support.annotation.IdRes;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.RestrictTo;
 import android.support.constraint.ConstraintLayout;
 import android.support.constraint.ConstraintSet;
 import android.view.View;
@@ -29,8 +33,14 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.firebase.ui.auth.*;
+import com.firebase.ui.auth.AuthMethodPickerLayout;
+import com.firebase.ui.auth.AuthUI;
 import com.firebase.ui.auth.AuthUI.IdpConfig;
+import com.firebase.ui.auth.ErrorCodes;
+import com.firebase.ui.auth.FirebaseAuthAnonymousUpgradeException;
+import com.firebase.ui.auth.FirebaseUiException;
+import com.firebase.ui.auth.IdpResponse;
+import com.firebase.ui.auth.R;
 import com.firebase.ui.auth.data.model.FlowParameters;
 import com.firebase.ui.auth.data.model.UserCancellationException;
 import com.firebase.ui.auth.data.remote.AnonymousSignInHandler;
@@ -206,7 +216,7 @@ public class AuthMethodPickerActivity extends AppCompatBase {
     private void populateIdpListCustomLayout(List<IdpConfig> providerConfigs) {
         Map<String, Integer> providerButtonIds = customLayout.getProvidersButton();
         for (IdpConfig idpConfig : providerConfigs) {
-            final String providerId = handleAliasForEmailLinkProvider(idpConfig.getProviderId());
+            final String providerId = providerOrEmailLinkProvider(idpConfig.getProviderId());
 
             if (!providerButtonIds.containsKey(providerId)) {
                 throw new IllegalStateException("No button found for auth provider: " + providerId);
@@ -219,10 +229,11 @@ public class AuthMethodPickerActivity extends AppCompatBase {
     }
 
     @NonNull
-    private String handleAliasForEmailLinkProvider(@NonNull String providerId) {
-        if(providerId.equals(EmailAuthProvider.EMAIL_LINK_SIGN_IN_METHOD)){
+    private String providerOrEmailLinkProvider(@NonNull String providerId) {
+        if (providerId.equals(EmailAuthProvider.EMAIL_LINK_SIGN_IN_METHOD)) {
             return EmailAuthProvider.PROVIDER_ID;
         }
+
         return providerId;
     }
 
@@ -317,7 +328,9 @@ public class AuthMethodPickerActivity extends AppCompatBase {
             @Override
             public void onClick(View view) {
                 if (isOffline()) {
-                    Toast.makeText(AuthMethodPickerActivity.this, getString(R.string.fui_no_internet), Toast.LENGTH_SHORT).show();
+                    Toast.makeText(AuthMethodPickerActivity.this,
+                            getString(R.string.fui_no_internet),
+                            Toast.LENGTH_SHORT).show();
                     return;
                 }
 

--- a/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
@@ -19,11 +19,7 @@ import android.arch.lifecycle.ViewModelProviders;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.annotation.IdRes;
-import android.support.annotation.LayoutRes;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.RestrictTo;
+import android.support.annotation.*;
 import android.support.constraint.ConstraintLayout;
 import android.support.constraint.ConstraintSet;
 import android.view.View;
@@ -33,14 +29,8 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.firebase.ui.auth.AuthMethodPickerLayout;
-import com.firebase.ui.auth.AuthUI;
+import com.firebase.ui.auth.*;
 import com.firebase.ui.auth.AuthUI.IdpConfig;
-import com.firebase.ui.auth.ErrorCodes;
-import com.firebase.ui.auth.FirebaseAuthAnonymousUpgradeException;
-import com.firebase.ui.auth.FirebaseUiException;
-import com.firebase.ui.auth.IdpResponse;
-import com.firebase.ui.auth.R;
 import com.firebase.ui.auth.data.model.FlowParameters;
 import com.firebase.ui.auth.data.model.UserCancellationException;
 import com.firebase.ui.auth.data.remote.AnonymousSignInHandler;
@@ -328,9 +318,7 @@ public class AuthMethodPickerActivity extends AppCompatBase {
             @Override
             public void onClick(View view) {
                 if (isOffline()) {
-                    Toast.makeText(AuthMethodPickerActivity.this,
-                            getString(R.string.fui_no_internet),
-                            Toast.LENGTH_SHORT).show();
+                    Toast.makeText(AuthMethodPickerActivity.this, getString(R.string.fui_no_internet), Toast.LENGTH_SHORT).show();
                     return;
                 }
 

--- a/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
@@ -206,7 +206,8 @@ public class AuthMethodPickerActivity extends AppCompatBase {
     private void populateIdpListCustomLayout(List<IdpConfig> providerConfigs) {
         Map<String, Integer> providerButtonIds = customLayout.getProvidersButton();
         for (IdpConfig idpConfig : providerConfigs) {
-            final String providerId = idpConfig.getProviderId();
+            final String providerId = handleAliasForEmailLinkProvider(idpConfig.getProviderId());
+
             if (!providerButtonIds.containsKey(providerId)) {
                 throw new IllegalStateException("No button found for auth provider: " + providerId);
             }
@@ -215,6 +216,14 @@ public class AuthMethodPickerActivity extends AppCompatBase {
             View loginButton = findViewById(buttonId);
             handleSignInOperation(idpConfig, loginButton);
         }
+    }
+
+    @NonNull
+    private String handleAliasForEmailLinkProvider(@NonNull String providerId) {
+        if(providerId.equals(EmailAuthProvider.EMAIL_LINK_SIGN_IN_METHOD)){
+            return EmailAuthProvider.PROVIDER_ID;
+        }
+        return providerId;
     }
 
     private void handleSignInOperation(IdpConfig idpConfig, View view) {

--- a/auth/src/test/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivityTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivityTest.java
@@ -122,6 +122,28 @@ public class AuthMethodPickerActivityTest {
                 nextIntent.intent.getComponent().getClassName());
     }
 
+    @Test
+    public void testCustomAuthMethodPickerLayoutWithEmailLink() {
+        List<String> providers = Arrays.asList(EmailAuthProvider.EMAIL_LINK_SIGN_IN_METHOD);
+
+        AuthMethodPickerLayout customLayout = new AuthMethodPickerLayout
+                .Builder(R.layout.fui_provider_button_email)
+                .setEmailButtonId(R.id.email_button)
+                .build();
+
+        AuthMethodPickerActivity authMethodPickerActivity = createActivityWithCustomLayout(providers, customLayout);
+
+        Button emailButton = authMethodPickerActivity.findViewById(R.id.email_button);
+        emailButton.performClick();
+
+        //Expected result -> Directing users to EmailActivity
+        ShadowActivity.IntentForResult nextIntent =
+                Shadows.shadowOf(authMethodPickerActivity).getNextStartedActivityForResult();
+        assertEquals(
+                EmailActivity.class.getName(),
+                nextIntent.intent.getComponent().getClassName());
+    }
+
     private AuthMethodPickerActivity createActivityWithCustomLayout(List<String> providers,
                                                                     AuthMethodPickerLayout layout) {
         Intent startIntent = AuthMethodPickerActivity.createIntent(


### PR DESCRIPTION
Fix for #1658 .

After this is merged, it is possible to use the EmailLink setting in combination with a custom layout.

This is a work-around at best, because ideally, someone would spend some time to refactor the EmailLink settings. I think it is confusing, that by calling setEmailLinkEnabled(), the ID of the provider is changed (without) any notice.

Let me know your thoughts.
