### PR TITLE
Preserve unused classes

### DIFF
--- a/auth/build.gradle.kts
+++ b/auth/build.gradle.kts
@@ -4,6 +4,7 @@ android {
     buildTypes {
         named("release").configure {
             postprocessing {
+                isRemoveUnusedCode = false
                 consumerProguardFiles("auth-proguard.pro")
             }
         }

--- a/auth/build.gradle.kts
+++ b/auth/build.gradle.kts
@@ -3,10 +3,8 @@ import com.android.build.gradle.internal.dsl.TestOptions
 android {
     buildTypes {
         named("release").configure {
-            postprocessing {
-                isRemoveUnusedCode = false
-                consumerProguardFiles("auth-proguard.pro")
-            }
+            isMinifyEnabled = false
+            consumerProguardFiles("proguard-rules.pro")
         }
     }
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,3 +1,12 @@
+android {
+    buildTypes {
+        named("release").configure {
+            isMinifyEnabled = false
+            consumerProguardFiles("proguard-rules.pro")
+        }
+    }
+}
+
 dependencies {
     api(Config.Libs.Arch.runtime)
     api(Config.Libs.Arch.viewModel)

--- a/database/build.gradle.kts
+++ b/database/build.gradle.kts
@@ -7,10 +7,8 @@ android {
 
     buildTypes {
         named("release").configure {
-            postprocessing {
-                isRemoveUnusedCode = false
-                consumerProguardFiles("proguard-rules.pro")
-            }
+            isMinifyEnabled = false
+            consumerProguardFiles("proguard-rules.pro")
         }
     }
 }

--- a/database/build.gradle.kts
+++ b/database/build.gradle.kts
@@ -8,6 +8,7 @@ android {
     buildTypes {
         named("release").configure {
             postprocessing {
+                isRemoveUnusedCode = false
                 consumerProguardFiles("proguard-rules.pro")
             }
         }

--- a/firestore/build.gradle.kts
+++ b/firestore/build.gradle.kts
@@ -9,6 +9,7 @@ android {
     buildTypes {
         named("release").configure {
             postprocessing {
+                isRemoveUnusedCode = false
                 consumerProguardFiles("proguard-rules.pro")
             }
         }

--- a/firestore/build.gradle.kts
+++ b/firestore/build.gradle.kts
@@ -8,10 +8,8 @@ android {
 
     buildTypes {
         named("release").configure {
-            postprocessing {
-                isRemoveUnusedCode = false
-                consumerProguardFiles("proguard-rules.pro")
-            }
+            isMinifyEnabled = false
+            consumerProguardFiles("proguard-rules.pro")
         }
     }
 }

--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -1,9 +1,8 @@
 android {
     buildTypes {
         named("release").configure {
-            postprocessing {
-                isRemoveUnusedCode = false
-            }
+            isMinifyEnabled = false
+            consumerProguardFiles("proguard-rules.pro")
         }
     }
 }

--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -1,3 +1,13 @@
+android {
+    buildTypes {
+        named("release").configure {
+            postprocessing {
+                isRemoveUnusedCode = false
+            }
+        }
+    }
+}
+
 dependencies {
     api(Config.Libs.Misc.glide)
 


### PR DESCRIPTION
See issue #1676

For version 6.0.0 we went from AGP 3.2.1 to AGP 3.5.0, looks like the R8 enablement in 3.4.0 got us:
https://developer.android.com/studio/build/shrink-code#configuration-files

Here's how Firestore's dex methods list looks after this change (left is 5.1.0, right is this commit);
http://www.mergely.com/W2XBd87e/

Looks correct to me.