### PR TITLE
Re-start SMS timer on resume

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/SubmitConfirmationCodeFragment.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/SubmitConfirmationCodeFragment.java
@@ -172,6 +172,9 @@ public class SubmitConfirmationCodeFragment extends FragmentBase {
                 }
             }
         }
+
+        mLooper.removeCallbacks(mCountdown);
+        mLooper.postDelayed(mCountdown, TICK_INTERVAL_MILLIS);
     }
 
     @Override


### PR DESCRIPTION
See #1703 

Previously if you moved the app to the background the countdown timer would never resume.  This is no longer the case.
