### PR TITLE
Log errors by default

### DIFF
--- a/database/src/main/java/com/firebase/ui/database/paging/FirebaseRecyclerPagingAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/paging/FirebaseRecyclerPagingAdapter.java
@@ -229,8 +229,8 @@ public abstract class FirebaseRecyclerPagingAdapter<T, VH extends RecyclerView.V
      *
      * When {@link DatabaseError} is caught the adapter will stop loading any data
      */
-    protected void onError(@NonNull DatabaseError databaseError){
-
+    protected void onError(@NonNull DatabaseError databaseError) {
+        Log.w(TAG, "onError", databaseError.toException());
     }
 
     @NonNull

--- a/firestore/src/main/java/com/firebase/ui/firestore/paging/FirestorePagingAdapter.java
+++ b/firestore/src/main/java/com/firebase/ui/firestore/paging/FirestorePagingAdapter.java
@@ -223,6 +223,6 @@ public abstract class FirestorePagingAdapter<T, VH extends RecyclerView.ViewHold
      * When {@link Exception} is caught the adapter will stop loading any data
      */
     protected void onError(@NonNull Exception e) {
-        // For overriding
+        Log.w(TAG, "onError", e);
     }
 }


### PR DESCRIPTION
See #1652 

Adds default error logging to the Paging Adapters, matching the behavior of the regular adapters.