### PR TITLE
Fix NPE in CountryListSpinner

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/CountryListSpinner.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/CountryListSpinner.java
@@ -55,8 +55,8 @@ public final class CountryListSpinner extends AppCompatEditText implements View.
     private String mSelectedCountryName;
     private CountryInfo mSelectedCountryInfo;
 
-    private Set<String> mWhitelistedCountryIsos;
-    private Set<String> mBlacklistedCountryIsos;
+    private Set<String> mWhitelistedCountryIsos = new HashSet<>();
+    private Set<String> mBlacklistedCountryIsos = new HashSet<>();
 
     public CountryListSpinner(Context context) {
         this(context, null, android.R.attr.spinnerStyle);
@@ -86,11 +86,11 @@ public final class CountryListSpinner extends AppCompatEditText implements View.
 
     private List<CountryInfo> getCountriesToDisplayInSpinner(Bundle params) {
         initCountrySpinnerIsosFromParams(params);
-
         Map<String, Integer> countryInfoMap = PhoneNumberUtils.getImmutableCountryIsoMap();
+        
         // We consider all countries to be whitelisted if there are no whitelisted
         // or blacklisted countries given as input.
-        if (mWhitelistedCountryIsos == null && mBlacklistedCountryIsos == null) {
+        if (mWhitelistedCountryIsos.isEmpty() && mBlacklistedCountryIsos.isEmpty()) {
             this.mWhitelistedCountryIsos = new HashSet<>(countryInfoMap.keySet());
         }
 
@@ -100,7 +100,7 @@ public final class CountryListSpinner extends AppCompatEditText implements View.
         // We assume no countries are to be excluded. Here, we correct this assumption based on the
         // contents of either lists.
         Set<String> excludedCountries = new HashSet<>();
-        if (mWhitelistedCountryIsos == null) {
+        if (!mBlacklistedCountryIsos.isEmpty()) {
             // Exclude all countries in the mBlacklistedCountryIsos list.
             excludedCountries.addAll(mBlacklistedCountryIsos);
         } else {
@@ -129,7 +129,9 @@ public final class CountryListSpinner extends AppCompatEditText implements View.
 
         if (whitelistedCountries != null) {
             mWhitelistedCountryIsos = convertCodesToIsos(whitelistedCountries);
-        } else if (blacklistedCountries != null) {
+        }
+
+        if (blacklistedCountries != null) {
             mBlacklistedCountryIsos = convertCodesToIsos(blacklistedCountries);
         }
     }
@@ -164,9 +166,16 @@ public final class CountryListSpinner extends AppCompatEditText implements View.
 
     public boolean isValidIso(String iso) {
         iso = iso.toUpperCase(Locale.getDefault());
-        return ((mWhitelistedCountryIsos == null && mBlacklistedCountryIsos == null)
-                || (mWhitelistedCountryIsos != null && mWhitelistedCountryIsos.contains(iso))
-                || (mBlacklistedCountryIsos != null && !mBlacklistedCountryIsos.contains(iso)));
+        boolean valid = true;
+        if (!mWhitelistedCountryIsos.isEmpty()) {
+            valid = valid && mWhitelistedCountryIsos.contains(iso);
+        }
+
+        if (!mBlacklistedCountryIsos.isEmpty()) {
+            valid = valid && !mBlacklistedCountryIsos.contains(iso);
+        }
+
+        return valid;
     }
 
     @Override


### PR DESCRIPTION
See #1734 

Makes the offending `Set` never null and changes the logic accordingly.