### PR TITLE
Improve network error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Fixes issue with custom parameters for OAuth providers (#1805)
 - Restore `setGithubButtonId` when using custom layouts (#1783)
+- Improve how network errors display when they are non-fatal (#1803)

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/CheckEmailFragment.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/CheckEmailFragment.java
@@ -23,7 +23,9 @@ import com.firebase.ui.auth.util.data.PrivacyDisclosureUtils;
 import com.firebase.ui.auth.util.ui.ImeHelper;
 import com.firebase.ui.auth.util.ui.fieldvalidators.EmailFieldValidator;
 import com.firebase.ui.auth.viewmodel.ResourceObserver;
+import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.textfield.TextInputLayout;
+import com.google.firebase.FirebaseNetworkException;
 import com.google.firebase.auth.EmailAuthProvider;
 
 import androidx.annotation.NonNull;
@@ -150,6 +152,11 @@ public class CheckEmailFragment extends FragmentBase implements
                         && ((FirebaseUiException) e).getErrorCode() == ErrorCodes.DEVELOPER_ERROR) {
                     mListener.onDeveloperFailure(e);
                 }
+
+                if (e instanceof FirebaseNetworkException) {
+                    Snackbar.make(getView(), getString(R.string.fui_no_internet), Snackbar.LENGTH_SHORT).show();
+                }
+
                 // Otherwise just let the user enter their data
             }
         });

--- a/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/idp/AuthMethodPickerActivity.java
@@ -47,6 +47,7 @@ import com.firebase.ui.auth.util.data.PrivacyDisclosureUtils;
 import com.firebase.ui.auth.viewmodel.ProviderSignInBase;
 import com.firebase.ui.auth.viewmodel.ResourceObserver;
 import com.firebase.ui.auth.viewmodel.idp.SocialProviderResponseHandler;
+import com.google.android.material.snackbar.Snackbar;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.auth.EmailAuthProvider;
 import com.google.firebase.auth.FacebookAuthProvider;
@@ -362,7 +363,7 @@ public class AuthMethodPickerActivity extends AppCompatBase {
             @Override
             public void onClick(View view) {
                 if (isOffline()) {
-                    Toast.makeText(AuthMethodPickerActivity.this, getString(R.string.fui_no_internet), Toast.LENGTH_SHORT).show();
+                    Snackbar.make(findViewById(android.R.id.content), getString(R.string.fui_no_internet), Snackbar.LENGTH_SHORT).show();
                     return;
                 }
 


### PR DESCRIPTION
See #1803 

We don't actually error out and return control to the developer (since that would not be very forgiving) but we do now show a snackbar instead of a silent fail.
