### PR TITLE
Allow setAllowNewAccounts(false) with email-link sign in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Fixes issue with custom parameters for OAuth providers (#1805)
 - Restore `setGithubButtonId` when using custom layouts (#1783)
 - Improve how network errors display when they are non-fatal (#1803)
+- Allow `setAllowNewAccounts(false)` to be used with email link sign in (#1762)

--- a/auth/src/main/java/com/firebase/ui/auth/util/data/ProviderUtils.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/data/ProviderUtils.java
@@ -212,6 +212,17 @@ public final class ProviderUtils {
                             }
                         }
 
+                        // In this case the developer has configured EMAIL_LINK sign in but the
+                        // user is a password user. The valid use case here is that the developer
+                        // is using admin-created accounts and combining email-link sign in with
+                        // setAllowNewAccounts(false). So we manually enable EMAIL_LINK.  See:
+                        // https://github.com/firebase/FirebaseUI-Android/issues/1762#issuecomment-661115293
+                        if (allowedProviders.contains(EMAIL_LINK_PROVIDER)
+                                && methods.contains(EmailAuthProvider.EMAIL_PASSWORD_SIGN_IN_METHOD)
+                                && !methods.contains(EMAIL_LINK_PROVIDER)) {
+                            lastSignedInProviders.add(0, signInMethodToProviderId(EMAIL_LINK_PROVIDER));
+                        }
+
                         if (task.isSuccessful() && lastSignedInProviders.isEmpty()
                                 && !methods.isEmpty()) {
                             // There is an existing user who only has unsupported sign in methods


### PR DESCRIPTION
See issue #1762, this is a strange workaround for a niche but useful developer situation.

cc @theHilikus 