### PR TITLE
add option to specify a default provider to skip the selection screen

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/data/model/FlowParameters.java
+++ b/auth/src/main/java/com/firebase/ui/auth/data/model/FlowParameters.java
@@ -44,6 +44,7 @@ public class FlowParameters implements Parcelable {
         public FlowParameters createFromParcel(Parcel in) {
             String appName = in.readString();
             List<IdpConfig> providerInfo = in.createTypedArrayList(IdpConfig.CREATOR);
+            IdpConfig defaultProvider = in.readParcelable(IdpConfig.class.getClassLoader());
             int themeId = in.readInt();
             int logoId = in.readInt();
             String termsOfServiceUrl = in.readString();
@@ -58,6 +59,7 @@ public class FlowParameters implements Parcelable {
             return new FlowParameters(
                     appName,
                     providerInfo,
+                    defaultProvider,
                     themeId,
                     logoId,
                     termsOfServiceUrl,
@@ -81,6 +83,9 @@ public class FlowParameters implements Parcelable {
 
     @NonNull
     public final List<IdpConfig> providers;
+
+    @Nullable
+    public final IdpConfig defaultProvider;
 
     @StyleRes
     public final int themeId;
@@ -108,6 +113,7 @@ public class FlowParameters implements Parcelable {
     public FlowParameters(
             @NonNull String appName,
             @NonNull List<IdpConfig> providers,
+            @Nullable IdpConfig defaultProvider,
             @StyleRes int themeId,
             @DrawableRes int logoId,
             @Nullable String termsOfServiceUrl,
@@ -121,6 +127,7 @@ public class FlowParameters implements Parcelable {
         this.appName = Preconditions.checkNotNull(appName, "appName cannot be null");
         this.providers = Collections.unmodifiableList(
                 Preconditions.checkNotNull(providers, "providers cannot be null"));
+        this.defaultProvider = defaultProvider;
         this.themeId = themeId;
         this.logoId = logoId;
         this.termsOfServiceUrl = termsOfServiceUrl;
@@ -144,6 +151,7 @@ public class FlowParameters implements Parcelable {
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(appName);
         dest.writeTypedList(providers);
+        dest.writeParcelable(defaultProvider, flags);
         dest.writeInt(themeId);
         dest.writeInt(logoId);
         dest.writeString(termsOfServiceUrl);
@@ -178,6 +186,10 @@ public class FlowParameters implements Parcelable {
     }
 
     public boolean shouldShowProviderChoice() {
-        return !isSingleProviderFlow() || alwaysShowProviderChoice;
+        return defaultProvider == null && (!isSingleProviderFlow() || alwaysShowProviderChoice);
+    }
+
+    public IdpConfig getDefaultOrFirstProvider() {
+        return defaultProvider != null ? defaultProvider : providers.get(0);
     }
 }

--- a/auth/src/main/java/com/firebase/ui/auth/data/remote/SignInKickstarter.java
+++ b/auth/src/main/java/com/firebase/ui/auth/data/remote/SignInKickstarter.java
@@ -135,9 +135,8 @@ public class SignInKickstarter extends SignInViewModelBase {
     }
 
     private void startAuthMethodChoice() {
-        // If there is only one provider selected, launch the flow directly
         if (!getArguments().shouldShowProviderChoice()) {
-            AuthUI.IdpConfig firstIdpConfig = getArguments().providers.get(0);
+            AuthUI.IdpConfig firstIdpConfig = getArguments().getDefaultOrFirstProvider();
             String firstProvider = firstIdpConfig.getProviderId();
             switch (firstProvider) {
                 case EMAIL_LINK_PROVIDER:

--- a/auth/src/test/java/com/firebase/ui/auth/testhelpers/TestHelper.java
+++ b/auth/src/test/java/com/firebase/ui/auth/testhelpers/TestHelper.java
@@ -157,6 +157,7 @@ public final class TestHelper {
         return new FlowParameters(
                 DEFAULT_APP_NAME,
                 idpConfigs,
+                null,
                 AuthUI.getDefaultTheme(),
                 AuthUI.NO_LOGO,
                 null,

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -1,5 +1,5 @@
 object Config {
-    const val version = "6.3.0"
+    const val version = "6.4.0-SNAPSHOT"
     val submodules = listOf("auth", "common", "firestore", "database", "storage")
 
     private const val kotlinVersion = "1.3.72"


### PR DESCRIPTION
Here is my attempt to address #1825 as discussed.

New tests added add and all tests pass.

I don't believe this feature is necessary in the iOS version of the library, as you can already get this behavior due to the fact that the providers are not specified as part of the flow.