### PR TITLE
Fix to allow bolding of text that coincides with the end of body.

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/util/ui/TextHelper.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/ui/TextHelper.java
@@ -18,7 +18,7 @@ public class TextHelper {
         while (fromIndex < text.length()) {
             int start = text.indexOf(textToBold, fromIndex);
             int end = start + textToBold.length();
-            if (start == -1 || end >= text.length()) {
+            if (start == -1 || end > text.length()) {
                 break;
             }
             builder.setSpan(new StyleSpan(Typeface.BOLD),


### PR DESCRIPTION
`textToBold` that is a suffix of `text` would be rejected by the `end>=text.length` test.
`end > text.length()` is the correct indication that `text.indexof` gave us a bogus offset.