### PR TITLE
Allow most auth flows without Play services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Allow most auth flows on devices without Google Play services (#1858)

--- a/auth/src/main/java/com/firebase/ui/auth/KickoffActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/KickoffActivity.java
@@ -14,6 +14,9 @@ import com.firebase.ui.auth.viewmodel.ResourceObserver;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.auth.GoogleAuthProvider;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -53,8 +56,11 @@ public class KickoffActivity extends InvisibleActivityBase {
             }
         });
 
-        GoogleApiAvailability.getInstance()
-                .makeGooglePlayServicesAvailable(this)
+        Task<Void> checkPlayServicesTask = getFlowParams().isPlayServicesRequired()
+                ? GoogleApiAvailability.getInstance().makeGooglePlayServicesAvailable(this)
+                : Tasks.forResult((Void) null);
+
+        checkPlayServicesTask
                 .addOnSuccessListener(this, new OnSuccessListener<Void>() {
                     @Override
                     public void onSuccess(Void aVoid) {

--- a/auth/src/main/java/com/firebase/ui/auth/data/model/FlowParameters.java
+++ b/auth/src/main/java/com/firebase/ui/auth/data/model/FlowParameters.java
@@ -19,10 +19,12 @@ import android.os.Parcelable;
 import android.text.TextUtils;
 
 import com.firebase.ui.auth.AuthMethodPickerLayout;
+import com.firebase.ui.auth.AuthUI;
 import com.firebase.ui.auth.AuthUI.IdpConfig;
 import com.firebase.ui.auth.util.ExtraConstants;
 import com.firebase.ui.auth.util.Preconditions;
 import com.google.firebase.auth.ActionCodeSettings;
+import com.google.firebase.auth.GoogleAuthProvider;
 
 import java.util.Collections;
 import java.util.List;
@@ -198,6 +200,23 @@ public class FlowParameters implements Parcelable {
 
     public boolean isAnonymousUpgradeEnabled() {
         return enableAnonymousUpgrade;
+    }
+
+    public boolean isPlayServicesRequired() {
+        // Play services only required for Google Sign In and the Credentials API
+        return isProviderEnabled(GoogleAuthProvider.PROVIDER_ID)
+                || enableHints
+                || enableCredentials;
+    }
+
+    public boolean isProviderEnabled(@AuthUI.SupportedProvider String provider) {
+        for (AuthUI.IdpConfig idp : providers) {
+            if (idp.getProviderId().equals(provider)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public boolean shouldShowProviderChoice() {

--- a/auth/src/main/java/com/firebase/ui/auth/util/GoogleApiUtils.java
+++ b/auth/src/main/java/com/firebase/ui/auth/util/GoogleApiUtils.java
@@ -6,6 +6,8 @@ import android.content.Context;
 import com.google.android.gms.auth.api.credentials.Credentials;
 import com.google.android.gms.auth.api.credentials.CredentialsClient;
 import com.google.android.gms.auth.api.credentials.CredentialsOptions;
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.RestrictTo;
@@ -14,6 +16,12 @@ import androidx.annotation.RestrictTo;
 public final class GoogleApiUtils {
     private GoogleApiUtils() {
         throw new AssertionError("No instance for you!");
+    }
+
+    public static boolean isPlayServicesAvailable(@NonNull Context context) {
+        return GoogleApiAvailability
+                .getInstance()
+                .isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS;
     }
 
     @NonNull


### PR DESCRIPTION
See #1858

Originally I thought this would require a huge refactor to make the `play-services-auth` dependency a runtime dep but I realized that we can just gate certain operations (Google Sign In, SmartLock) on Play Services availability and leave the rest of the code the same.

Testing:

- [x] Create email/password account on non-play emulator
- [x] Sign out on non-play emulator
- [x] Delete account on non-play emulator
- [x] Confirm that non-Play emulator shows error dialog when attempting to do GSI or use SmartLock