### PR TITLE
Jfk additional material migrations

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,7 +32,7 @@ android {
 }
 
 dependencies {
-    implementation(Config.Libs.Androidx.design)
+    implementation(Config.Libs.Androidx.materialDesign)
     implementation(Config.Libs.Androidx.multidex)
 
     implementation(project(":auth"))

--- a/app/src/main/java/com/firebase/uidemo/auth/SignedInActivity.java
+++ b/app/src/main/java/com/firebase/uidemo/auth/SignedInActivity.java
@@ -31,6 +31,7 @@ import com.firebase.uidemo.R;
 import com.firebase.uidemo.storage.GlideApp;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.firebase.auth.EmailAuthProvider;
 import com.google.firebase.auth.FacebookAuthProvider;
@@ -48,7 +49,6 @@ import java.util.List;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
-import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -113,7 +113,7 @@ public class SignedInActivity extends AppCompatActivity {
 
     @OnClick(R.id.delete_account)
     public void deleteAccountClicked() {
-        new AlertDialog.Builder(this)
+        new MaterialAlertDialogBuilder(this)
                 .setMessage("Are you sure you want to delete this account?")
                 .setPositiveButton("Yes, nuke it!", new DialogInterface.OnClickListener() {
                     @Override

--- a/auth/build.gradle.kts
+++ b/auth/build.gradle.kts
@@ -26,7 +26,7 @@ android {
 }
 
 dependencies {
-    implementation(Config.Libs.Androidx.design)
+    implementation(Config.Libs.Androidx.materialDesign)
     implementation(Config.Libs.Androidx.customTabs)
     implementation(Config.Libs.Androidx.constraint)
     implementation(Config.Libs.Misc.materialProgress)

--- a/auth/build.gradle.kts
+++ b/auth/build.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
     implementation(Config.Libs.Androidx.materialDesign)
     implementation(Config.Libs.Androidx.customTabs)
     implementation(Config.Libs.Androidx.constraint)
-    implementation(Config.Libs.Misc.materialProgress)
 
     implementation(Config.Libs.Androidx.lifecycleExtensions)
     annotationProcessor(Config.Libs.Androidx.lifecycleCompiler)

--- a/auth/src/main/java/com/firebase/ui/auth/ui/InvisibleActivityBase.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/InvisibleActivityBase.java
@@ -10,10 +10,10 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
 import com.firebase.ui.auth.R;
+import com.google.android.material.progressindicator.CircularProgressIndicator;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
-import me.zhanghai.android.materialprogressbar.MaterialProgressBar;
 
 /**
  * Base classes for activities that are just simple overlays.
@@ -25,7 +25,7 @@ public class InvisibleActivityBase extends HelperActivityBase {
     private static final long MIN_SPINNER_MS = 750;
 
     private Handler mHandler = new Handler();
-    private MaterialProgressBar mProgressBar;
+    private CircularProgressIndicator mProgressBar;
 
     // Last time that the progress bar was actually shown
     private long mLastShownTime = 0;
@@ -36,7 +36,7 @@ public class InvisibleActivityBase extends HelperActivityBase {
         setContentView(R.layout.fui_activity_invisible);
 
         // Create an indeterminate, circular progress bar in the app's theme
-        mProgressBar = new MaterialProgressBar(new ContextThemeWrapper(this, getFlowParams().themeId));
+        mProgressBar = new CircularProgressIndicator(new ContextThemeWrapper(this, getFlowParams().themeId));
         mProgressBar.setIndeterminate(true);
         mProgressBar.setVisibility(View.GONE);
 

--- a/auth/src/main/java/com/firebase/ui/auth/ui/InvisibleFragmentBase.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/InvisibleFragmentBase.java
@@ -9,11 +9,11 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
 import com.firebase.ui.auth.R;
+import com.google.android.material.progressindicator.CircularProgressIndicator;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
-import me.zhanghai.android.materialprogressbar.MaterialProgressBar;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class InvisibleFragmentBase extends FragmentBase {
@@ -23,7 +23,7 @@ public class InvisibleFragmentBase extends FragmentBase {
     protected FrameLayout mFrameLayout;
     protected View mTopLevelView;
     private Handler mHandler = new Handler();
-    private MaterialProgressBar mProgressBar;
+    private CircularProgressIndicator mProgressBar;
     // Last time that the progress bar was actually shown
     private long mLastShownTime = 0;
 
@@ -31,7 +31,7 @@ public class InvisibleFragmentBase extends FragmentBase {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
 
         // Create an indeterminate, circular progress bar in the app's theme
-        mProgressBar = new MaterialProgressBar(new ContextThemeWrapper(getContext(),
+        mProgressBar = new CircularProgressIndicator(new ContextThemeWrapper(getContext(),
                 getFlowParams().themeId));
         mProgressBar.setIndeterminate(true);
         mProgressBar.setVisibility(View.GONE);

--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/RecoverPasswordActivity.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/RecoverPasswordActivity.java
@@ -33,6 +33,7 @@ import com.firebase.ui.auth.util.ui.ImeHelper;
 import com.firebase.ui.auth.util.ui.fieldvalidators.EmailFieldValidator;
 import com.firebase.ui.auth.viewmodel.ResourceObserver;
 import com.firebase.ui.auth.viewmodel.email.RecoverPasswordHandler;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.textfield.TextInputLayout;
 import com.google.firebase.auth.ActionCodeSettings;
 import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException;
@@ -41,7 +42,6 @@ import com.google.firebase.auth.FirebaseAuthInvalidUserException;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
-import androidx.appcompat.app.AlertDialog;
 import androidx.lifecycle.ViewModelProvider;
 
 /**
@@ -132,7 +132,7 @@ public class RecoverPasswordActivity extends AppCompatBase implements View.OnCli
         mHandler.startReset(email, passwordResetSettings);
     }
     private void showEmailSentDialog(String email) {
-        new AlertDialog.Builder(this)
+        new MaterialAlertDialogBuilder(this)
                 .setTitle(R.string.fui_title_confirm_recover_password)
                 .setMessage(getString(R.string.fui_confirm_recovery_body, email))
                 .setOnDismissListener(new DialogInterface.OnDismissListener() {

--- a/auth/src/main/res/layout-land/fui_auth_method_picker_layout.xml
+++ b/auth/src/main/res/layout-land/fui_auth_method_picker_layout.xml
@@ -9,7 +9,7 @@
     android:clipChildren="false"
     android:clipToPadding="false">
 
-    <me.zhanghai.android.materialprogressbar.MaterialProgressBar
+    <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/top_progress_bar"
         style="@style/FirebaseUI.TopProgressBar"
         app:layout_constraintTop_toTopOf="parent"

--- a/auth/src/main/res/layout/fui_auth_method_picker_layout.xml
+++ b/auth/src/main/res/layout/fui_auth_method_picker_layout.xml
@@ -8,7 +8,7 @@
     android:layout_height="match_parent"
     android:clipToPadding="false">
 
-    <me.zhanghai.android.materialprogressbar.MaterialProgressBar
+    <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/top_progress_bar"
         style="@style/FirebaseUI.TopProgressBar"
         app:layout_constraintTop_toTopOf="parent"

--- a/auth/src/main/res/layout/fui_check_email_layout.xml
+++ b/auth/src/main/res/layout/fui_check_email_layout.xml
@@ -7,7 +7,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <me.zhanghai.android.materialprogressbar.MaterialProgressBar
+    <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/top_progress_bar"
         style="@style/FirebaseUI.TopProgressBar"
         tools:visibility="visible" />

--- a/auth/src/main/res/layout/fui_confirmation_code_layout.xml
+++ b/auth/src/main/res/layout/fui_confirmation_code_layout.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <me.zhanghai.android.materialprogressbar.MaterialProgressBar
+    <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/top_progress_bar"
         style="@style/FirebaseUI.TopProgressBar"
         app:layout_constraintTop_toTopOf="parent"

--- a/auth/src/main/res/layout/fui_email_link_cross_device_linking.xml
+++ b/auth/src/main/res/layout/fui_email_link_cross_device_linking.xml
@@ -6,7 +6,7 @@
               android:orientation="vertical"
               tools:ignore="MissingDefaultResource">
 
-    <me.zhanghai.android.materialprogressbar.MaterialProgressBar
+    <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/top_progress_bar"
         style="@style/FirebaseUI.TopProgressBar"
         tools:visibility="visible" />

--- a/auth/src/main/res/layout/fui_email_link_trouble_signing_in_layout.xml
+++ b/auth/src/main/res/layout/fui_email_link_trouble_signing_in_layout.xml
@@ -8,7 +8,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <me.zhanghai.android.materialprogressbar.MaterialProgressBar
+    <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/top_progress_bar"
         style="@style/FirebaseUI.TopProgressBar"
         tools:visibility="visible" />

--- a/auth/src/main/res/layout/fui_forgot_password_layout.xml
+++ b/auth/src/main/res/layout/fui_forgot_password_layout.xml
@@ -7,7 +7,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <me.zhanghai.android.materialprogressbar.MaterialProgressBar
+    <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/top_progress_bar"
         style="@style/FirebaseUI.TopProgressBar"
         tools:visibility="visible" />

--- a/auth/src/main/res/layout/fui_phone_layout.xml
+++ b/auth/src/main/res/layout/fui_phone_layout.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <me.zhanghai.android.materialprogressbar.MaterialProgressBar
+    <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/top_progress_bar"
         style="@style/FirebaseUI.TopProgressBar"
         app:layout_constraintTop_toTopOf="parent"

--- a/auth/src/main/res/layout/fui_register_email_layout.xml
+++ b/auth/src/main/res/layout/fui_register_email_layout.xml
@@ -7,7 +7,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <me.zhanghai.android.materialprogressbar.MaterialProgressBar
+    <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/top_progress_bar"
         style="@style/FirebaseUI.TopProgressBar"
         tools:visibility="visible" />

--- a/auth/src/main/res/layout/fui_welcome_back_email_link_prompt_layout.xml
+++ b/auth/src/main/res/layout/fui_welcome_back_email_link_prompt_layout.xml
@@ -8,7 +8,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <me.zhanghai.android.materialprogressbar.MaterialProgressBar
+    <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/top_progress_bar"
         style="@style/FirebaseUI.TopProgressBar"
         tools:visibility="visible" />

--- a/auth/src/main/res/layout/fui_welcome_back_idp_prompt_layout.xml
+++ b/auth/src/main/res/layout/fui_welcome_back_idp_prompt_layout.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <me.zhanghai.android.materialprogressbar.MaterialProgressBar
+    <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/top_progress_bar"
         style="@style/FirebaseUI.TopProgressBar"
         tools:visibility="visible" />

--- a/auth/src/main/res/layout/fui_welcome_back_password_prompt_layout.xml
+++ b/auth/src/main/res/layout/fui_welcome_back_password_prompt_layout.xml
@@ -7,7 +7,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <me.zhanghai.android.materialprogressbar.MaterialProgressBar
+    <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/top_progress_bar"
         style="@style/FirebaseUI.TopProgressBar"
         tools:visibility="visible" />

--- a/auth/src/main/res/values/styles.xml
+++ b/auth/src/main/res/values/styles.xml
@@ -275,13 +275,11 @@
         <item name="android:textColor">#FFFFFFFF</item>
     </style>
 
-    <style name="FirebaseUI.TopProgressBar" parent="@style/Widget.MaterialProgressBar.ProgressBar.Horizontal">
+    <style name="FirebaseUI.TopProgressBar" parent="@style/Widget.MaterialComponents.LinearProgressIndicator">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">4dp</item>
         <item name="android:indeterminate">true</item>
         <item name="android:visibility">invisible</item>
-        <item name="mpb_progressStyle">horizontal</item>
-        <item name="mpb_useIntrinsicPadding">false</item>
     </style>
 
     <style name="FirebaseUI.PrivacyFooter">

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -75,7 +75,6 @@ object Config {
             const val butterKnifeCompiler = "com.jakewharton:butterknife-compiler:$butterVersion"
 
             const val permissions = "pub.devrel:easypermissions:3.0.0"
-            const val materialProgress = "me.zhanghai.android.materialprogressbar:library:1.6.1"
         }
 
         object Test {

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -38,7 +38,7 @@ object Config {
             const val paging = "androidx.paging:paging-runtime:2.1.2"
             const val recyclerView = "androidx.recyclerview:recyclerview:1.1.0"
 
-            const val design = "com.google.android.material:material:1.2.1"
+            const val materialDesign = "com.google.android.material:material:1.3.0"
         }
 
         object Firebase {


### PR DESCRIPTION
A continuation of the migration to Material Components

Material lib updated, third party lib for progress bar removed (#1907), and Dialogs updated.

I've tried this head on various brands and android version from 5 to 10 (I have no android 4), and I can no longer find any theme related problems that I can't override in my own extension of FirebaseUI theme.

I'm unsure about my `Merge pull request`commit in this PR, maybe that should be removed?
