### PR TITLE
upgrade to AGP7

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: set up JDK 1.8
+    - name: set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Build with Gradle
       run: ./scripts/build.sh
     - name: Print Logs

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion(Config.SdkVersions.compile)
+    compileSdk = Config.SdkVersions.compile
 
     defaultConfig {
-        minSdkVersion(Config.SdkVersions.min)
-        targetSdkVersion(Config.SdkVersions.target)
+        minSdk = Config.SdkVersions.min
+        targetSdk = Config.SdkVersions.target
 
         versionName = Config.version
         versionCode = 1
@@ -37,7 +37,7 @@ android {
         }
     }
 
-    lintOptions {
+    lint {
         // Common lint options across all modules
         disable(
             "IconExpectedSize",

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,7 +43,9 @@ android {
             "IconExpectedSize",
             "InvalidPackage", // Firestore uses GRPC which makes lint mad
             "NewerVersionAvailable", "GradleDependency", // For reproducible builds
-            "SelectableText", "SyntheticAccessor" // We almost never care about this
+            "SelectableText", "SyntheticAccessor", // We almost never care about this
+            "UnusedIds", "MediaCapabilities" // TODO(rosariopfernandes): remove this once we confirm
+            // it builds successfully
         )
 
         // Module-specific

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
         tools:ignore="GoogleAppIndexingWarning,UnusedAttribute"
         android:usesCleartextTraffic="true">
 
-        <activity android:name=".ChooserActivity">
+        <activity android:name=".ChooserActivity"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,5 @@
 <resources>
     <color name="colorPrimary">#039BE5</color>
-    <color name="colorPrimaryDark">#0288D1</color>
     <color name="colorPrimaryVariant">#0288D1</color>
     <color name="colorSecondary">#FFA000</color>
 
@@ -14,7 +13,6 @@
     <color name="material_gray_300">#E0E0E0</color>
     <color name="material_gray_500">#9e9e9e</color>
 
-    <color name="material_lime_a700">#AEEA00</color>
     <color name="material_red_a200">#FF5252</color>
 
 </resources>

--- a/auth/build.gradle.kts
+++ b/auth/build.gradle.kts
@@ -6,14 +6,13 @@ plugins {
 }
 
 android {
-    compileSdkVersion(Config.SdkVersions.compile)
+    compileSdk = Config.SdkVersions.compile
 
     defaultConfig {
-        minSdkVersion(Config.SdkVersions.min)
-        targetSdkVersion(Config.SdkVersions.target)
+        minSdk = Config.SdkVersions.min
+        targetSdk =Config.SdkVersions.target
 
-        versionName = Config.version
-        versionCode = 1
+        buildConfigField("String", "VERSION_NAME", "\"${Config.version}\"")
 
         resourcePrefix("fui_")
         vectorDrawables.useSupportLibrary = true
@@ -31,7 +30,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    lintOptions {
+    lint {
         // Common lint options across all modules
         disable(
             "IconExpectedSize",
@@ -59,9 +58,9 @@ android {
     }
 
     testOptions {
-        unitTests(closureOf<TestOptions.UnitTestOptions> {
+        unitTests {
             isIncludeAndroidResources = true
-        })
+        }
     }
 }
 

--- a/auth/src/main/java/com/firebase/ui/auth/IdpResponse.java
+++ b/auth/src/main/java/com/firebase/ui/auth/IdpResponse.java
@@ -14,6 +14,7 @@
 
 package com.firebase.ui.auth;
 
+import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -123,7 +124,9 @@ public class IdpResponse implements Parcelable {
         } else if (e instanceof FirebaseUiUserCollisionException) {
             FirebaseUiUserCollisionException collisionException
                     = (FirebaseUiUserCollisionException) e;
-            User user = new User.Builder(
+            // Lint complains about providerId not being
+            // in the pre-defined set of constants
+            @SuppressLint("WrongConstant") User user = new User.Builder(
                     collisionException.getProviderId(),
                     collisionException.getEmail())
                     .build();

--- a/auth/src/main/res/layout/fui_check_email_layout.xml
+++ b/auth/src/main/res/layout/fui_check_email_layout.xml
@@ -18,7 +18,6 @@
 
         <LinearLayout
             style="@style/FirebaseUI.WrapperStyle"
-            android:id="@+id/email_top_layout"
             android:layout_height="wrap_content"
             android:orientation="vertical">
 

--- a/auth/src/main/res/layout/fui_email_link_sign_in_layout.xml
+++ b/auth/src/main/res/layout/fui_email_link_sign_in_layout.xml
@@ -24,7 +24,6 @@
             android:orientation="vertical">
 
             <TextView
-                android:id="@+id/sign_in_email_sent_header_text"
                 style="@style/FirebaseUI.Text.Heading"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/auth/src/main/res/layout/fui_email_link_trouble_signing_in_layout.xml
+++ b/auth/src/main/res/layout/fui_email_link_trouble_signing_in_layout.xml
@@ -30,7 +30,6 @@
                 android:text="@string/fui_email_link_trouble_getting_email_header" />
 
             <TextView
-                android:id="@+id/trouble_signing_in_possible_fixes"
                 style="@style/FirebaseUI.Text.BodyText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/auth/src/main/res/layout/fui_idp_button_apple.xml
+++ b/auth/src/main/res/layout/fui_idp_button_apple.xml
@@ -1,4 +1,3 @@
 <com.google.android.material.button.MaterialButton xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/apple_signin_button"
     style="@style/FirebaseUI.Button.AccountChooser.AppleButton"
     android:text="@string/fui_sign_in_with_apple"/>

--- a/auth/src/main/res/layout/fui_idp_button_microsoft.xml
+++ b/auth/src/main/res/layout/fui_idp_button_microsoft.xml
@@ -1,4 +1,3 @@
 <com.google.android.material.button.MaterialButton xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/microsoft_signin_button"
     style="@style/FirebaseUI.Button.AccountChooser.MicrosoftButton"
     android:text="@string/fui_sign_in_with_microsoft"/>

--- a/auth/src/main/res/layout/fui_idp_button_yahoo.xml
+++ b/auth/src/main/res/layout/fui_idp_button_yahoo.xml
@@ -1,4 +1,3 @@
 <com.google.android.material.button.MaterialButton xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/yahoo_signin_button"
     style="@style/FirebaseUI.Button.AccountChooser.YahooButton"
     android:text="@string/fui_sign_in_with_yahoo" />

--- a/auth/src/main/res/layout/fui_provider_button_anonymous.xml
+++ b/auth/src/main/res/layout/fui_provider_button_anonymous.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.button.MaterialButton
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/anonymous_button"
     style="@style/FirebaseUI.Button.AccountChooser.AnonymousButton"
     android:text="@string/fui_sign_in_anonymously" />

--- a/auth/src/main/res/values-ar/strings.xml
+++ b/auth/src/main/res/values-ar/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">جارٍ التحميل…</string>
     <string name="fui_sign_in_default">تسجيل الدخول</string>
-    <string name="fui_cancel">إلغاء</string>
     <string name="fui_continue">متابعة</string>
     <string name="fui_tos_and_pp">تشير المتابعة إلى موافقتك على %1$s و%2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">تمّ إرسال رسالة إلكترونية لتسجيل الدخول تتضمّن تعليمات إضافية إلى %1$s. يُرجى التحقق من بريدك الإلكتروني لإكمال عملية تسجيل الدخول.</string>
     <string name="fui_email_link_trouble_getting_email_header">هل تواجه مشكلة في استلام الرسالة الإلكترونية؟</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">يمكنك تجربة الحلول الشائعة التالية:\n\u2022 التأكّد ممّا إذا تمّ وضع علامة على الرسالة الإلكترونية بأنّها \"غير مرغوب فيها\" أو إذا تمّ نقلها تلقائيًا إلى مجلّد آخر\n\u2022 التحقّق من الاتصال بالإنترنت\n\u2022 التأكّد من كتابة عنوان البريد الإلكتروني بالشكل الصحيح\n\u2022 التحقق من عدم نفاد مساحة البريد الوارد أو من عدم وجود مشاكل أخرى في إعداده\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">إذا لم تنجح الخطوات أعلاه، يمكنك إعادة إرسال الرسالة الإلكترونية إلّا أنّ ذلك سيُلغي الرابط المضمّن في الرسالة السابقة.</string>
     <string name="fui_email_link_resend">إعادة الإرسال</string>
     <string name="fui_email_link_wrong_device_header">تمّ رصد جهاز أو متصفّح جديد</string>
     <string name="fui_email_link_wrong_device_message">يُرجى محاولة فتح الرابط باستخدام الجهاز أو المتصفّح نفسه الذي استخدمته عند بدء عملية تسجيل الدخول.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">تأكيد عنوان البريد الإلكتروني لمتابعة تسجيل الدخول</string>
     <string name="fui_email_link_dismiss_button">رفض</string>
     <string name="fui_email_link_cross_device_linking_text">لقد بدأت هذه العملية بهدف ربط %1$s ببريدك الإلكتروني إلّا أنك فتحت الرابط على جهاز آخر لم يتمّ تسجيل الدخول عليه.\n\nلربط حسابك على %1$s، يجب فتح الرابط على الجهاز نفسه حيث سجّلت الدخول في البداية. ولإلغاء عملية الربط، يُرجى النقر على \"متابعة\" لتسجيل الدخول على هذا الجهاز.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">تسجيل الدخول باستخدام %1$s</string>
     <string name="fui_verify_phone_number_title">أدخل رقم هاتفك</string>
     <string name="fui_invalid_phone_number">يُرجى إدخال رقم هاتف صالح</string>
     <string name="fui_enter_confirmation_code">أدخل الرمز المكوّن من 6 أرقام الذي أرسلناه إلى</string>

--- a/auth/src/main/res/values-b+es+419/strings.xml
+++ b/auth/src/main/res/values-b+es+419/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-bg/strings.xml
+++ b/auth/src/main/res/values-bg/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Зарежда се…</string>
     <string name="fui_sign_in_default">Вход</string>
-    <string name="fui_cancel">Отказ</string>
     <string name="fui_continue">Напред</string>
     <string name="fui_tos_and_pp">Продължавайки, приемате нашите %1$s и %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Изпратихме имейл до %1$s за вход в профила с допълнителни инструкции. Проверете входящата си поща, за да завършите процеса.</string>
     <string name="fui_email_link_trouble_getting_email_header">Имате проблеми с получаването на имейла?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Изпробвайте следните често използвани решения:\n\u2022 Проверете дали имейлът не е обозначен и филтриран като спам.\n\u2022 Проверете връзката си с интернет.\n\u2022 Проверете дали имейлът е изписан правилно.\n\u2022 Проверете дали в пощенската ви кутия има достатъчно пространство, или не е налице друг проблем с настройките й.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Ако стъпките по-горе не проработят, можете да изпратите отново имейла. Имайте предвид, че това ще деактивира връзката в предходното съобщение.</string>
     <string name="fui_email_link_resend">Повторно изпращане</string>
     <string name="fui_email_link_wrong_device_header">Открито е ново устройство или браузър.</string>
     <string name="fui_email_link_wrong_device_message">Опитайте да отворите връзката от същото устройство или браузър, където е започнат процесът на влизане в профила.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Потвърдете имейл адреса, за да продължите с влизането в профила</string>
     <string name="fui_email_link_dismiss_button">Отхвърляне</string>
     <string name="fui_email_link_cross_device_linking_text">Първоначално искахте да свържете %1$s с имейла на профила си, но отворихте връзката на различно устройство без вход в профила.\n\nАко все още искате да свържете профила си в(ъв) %1$s, отворете връзката на същото устройство, на което започнахте влизането в профила. В противен случай докоснете „Напред“, за да влезете на това устройство.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Вход в профила с(ъс) %1$s</string>
     <string name="fui_verify_phone_number_title">Въвеждане на телефонния ви номер</string>
     <string name="fui_invalid_phone_number">Въведете валиден телефонен номер</string>
     <string name="fui_enter_confirmation_code">Въведете 6-цифрения код, който изпратихме до</string>

--- a/auth/src/main/res/values-bn/strings.xml
+++ b/auth/src/main/res/values-bn/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">লোড হচ্ছে…</string>
     <string name="fui_sign_in_default">সাইন-ইন করুন</string>
-    <string name="fui_cancel">বাতিল করুন</string>
     <string name="fui_continue">চালিয়ে যান</string>
     <string name="fui_tos_and_pp">চালিয়ে যাওয়ার অর্থ, আপনি আমাদের %1$s এবং %2$s-এর সাথে সম্মত।</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">অতিরিক্ত নির্দেশাবলী সহ সাইন-ইন করার একটি ইমেল %1$s-এ পাঠানো হয়েছে। সাইন-ইন করার জন্য আপনার ইমেল দেখুন।</string>
     <string name="fui_email_link_trouble_getting_email_header">ইমেল পেতে সমস্যা হচ্ছে?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">সাধারণ সমাধানগুলি ব্যবহার করে দেখুন:\n\u2022 ইমেলটি স্প্যাম হিসেবে চিহ্নিত করে স্প্যাম ফোল্ডারে পাঠানো হয়েছে কিনা তা দেখুন।\n\u2022 আপনার ইন্টারনেট কানেকশন যাচাই করুন।\n\u2022 আপনার ইমেল আইডিতে কোনও ভুল বানান লিখেছেন কিনা দেখে নিন।\n\u2022 আপনার ইনবক্সের স্পেস শেষ হয়ে গেছে কিনা এবং ইনবক্স সংক্রান্ত অন্যান্য সমস্যাগুলি একবার দেখে নিন।\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">তারপরেও ইমেলটি না পেলে, আপনি তা আবার পাঠাতে পারেন। তবে, প্রথমে যে ইমেলটি পাঠানো হয়েছিল তাতে থাকা লিঙ্কটি আর কাজ করবে না।</string>
     <string name="fui_email_link_resend">আবার পাঠান</string>
     <string name="fui_email_link_wrong_device_header">এই ডিভাইস বা ব্রাউজারটি আলাদা।</string>
     <string name="fui_email_link_wrong_device_message">যে ডিভাইস অথবা ব্রাউজারে আপনি সাইন-ইন প্রসেস শুরু করেছেন সেই একই ডিভাইস অথবা ব্রাউজার ব্যবহার করে লিঙ্কটি খোলার চেষ্টা করুন।</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">সাইন-ইন করতে ইমেল আইডি কনফার্ম করুন</string>
     <string name="fui_email_link_dismiss_button">খারিজ করুন</string>
     <string name="fui_email_link_cross_device_linking_text">আপনি %1$s অ্যাকাউন্ট ইমেল অ্যাকাউন্টের সাথে কানেক্ট করতে চেয়েছিলেন কিন্তু এমন একটি ডিভাইসে লিঙ্কটি খুলেছেন যেখানে সাইন-ইন করেননি।\n\nআপনি যদি এখনও %1$s অ্যাকাউন্টটি কানেক্ট করতে চান, যে ডিভাইসে সাইন-ইন করেছিলেন সেখানেই লিঙ্কটি খুলুন। নাহলে, ডিভাইসের সাইন-ইন বিকল্পে ট্যাপ করুন।</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">%1$s দিয়ে সাইন-ইন করুন</string>
     <string name="fui_verify_phone_number_title">আপনার ফোন নম্বর লিখুন</string>
     <string name="fui_invalid_phone_number">একটি সঠিক ফোন নম্বর লিখুন</string>
     <string name="fui_enter_confirmation_code">আমাদের পাঠানো ৬-সংখ্যার কোডটি লিখুন</string>

--- a/auth/src/main/res/values-ca/strings.xml
+++ b/auth/src/main/res/values-ca/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">S\'està carregant…</string>
     <string name="fui_sign_in_default">Inicia la sessió</string>
-    <string name="fui_cancel">Cancel·la</string>
     <string name="fui_continue">Continua</string>
     <string name="fui_tos_and_pp">En continuar, acceptes les nostres %1$s i la nostra %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">S\'ha enviat un correu electrònic d\'inici de sessió amb més instruccions a %1$s. Comprova si l\'has rebut per completar l\'inici de sessió.</string>
     <string name="fui_email_link_trouble_getting_email_header">Tens problemes per rebre el correu electrònic?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prova aquestes solucions habituals:\n\u2022 Comprova que el correu electrònic no s\'hagi marcat com a correu brossa ni s\'hagi filtrat.\n\u2022 Comprova la connexió a Internet.\n\u2022 Comprova que hagis escrit correctament la teva adreça electrònica.\n\u2022 Comprova que tinguis espai a la safata d\'entrada o qualsevol altre problema relacionat amb la configuració de la safata d\'entrada.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si els passos anteriors no t\'han servit d\'ajuda, pots tornar a enviar el correu electrònic. Tingues en compte que l\'enllaç del correu anterior es desactivarà.</string>
     <string name="fui_email_link_resend">Torna a enviar</string>
     <string name="fui_email_link_wrong_device_header">S\'ha detectat un dispositiu o navegador nou.</string>
     <string name="fui_email_link_wrong_device_message">Prova d\'obrir l\'enllaç amb el mateix dispositiu o navegador on has començat el procés d\'inici de sessió.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma l\'adreça electrònica per continuar amb l\'inici de sessió</string>
     <string name="fui_email_link_dismiss_button">Ignora</string>
     <string name="fui_email_link_cross_device_linking_text">Inicialment has intentat connectar %1$s amb el teu compte de correu electrònic, però has obert l\'enllaç amb un dispositiu diferent en què no has iniciat la sessió.\n\nSi encara vols connectar el compte que tens a %1$s, obre l\'enllaç al mateix dispositiu en què has començat a iniciar la sessió. Si no, toca Continua per iniciar la sessió en aquest dispositiu.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Inicia la sessió amb %1$s</string>
     <string name="fui_verify_phone_number_title">Introdueix el número de telèfon</string>
     <string name="fui_invalid_phone_number">Introdueix un número de telèfon vàlid</string>
     <string name="fui_enter_confirmation_code">Introdueix el codi de 6 dígits que s\'ha enviat al número</string>

--- a/auth/src/main/res/values-cs/strings.xml
+++ b/auth/src/main/res/values-cs/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Načítání…</string>
     <string name="fui_sign_in_default">Přihlásit se</string>
-    <string name="fui_cancel">Zrušit</string>
     <string name="fui_continue">Pokračovat</string>
     <string name="fui_tos_and_pp">Budete-li pokračovat, vyjadřujete svůj souhlas s dokumenty %1$s a %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Na adresu %1$s byl odeslán přihlašovací e-mail s dalšími pokyny. Dokončete přihlášení podle instrukcí v e-mailu.</string>
     <string name="fui_email_link_trouble_getting_email_header">Nepřišel vám e-mail?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Vyzkoušejte tyto běžné opravy:\n\u2022 Zkontrolujte, jestli nebyl e-mail označen jako spam nebo vyfiltrován.\n\u2022 Zkontrolujte své připojení k internetu.\n\u2022 Zkontrolujte, že jste napsali e-mailovou adresu správně.\n\u2022 Zkontrolujte, že ve vaší e-mailové schránce máte dostatek úložného prostoru nebo jiné problémy týkající se nastavení schránky.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Pokud žádné z uvedených řešení nepomohlo, můžete si e-mail nechat zaslat znovu. Odkaz v prvním e-mailu pak bude deaktivován.</string>
     <string name="fui_email_link_resend">Odeslat znovu</string>
     <string name="fui_email_link_wrong_device_header">Bylo rozpoznáno nové zařízení nebo prohlížeč</string>
     <string name="fui_email_link_wrong_device_message">Otevřete odkaz na stejném zařízení nebo ve stejném prohlížeči, kde jste proces přihlášení započali.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Pokud chcete pokračovat v přihlášení, potvrďte e-mailovou adresu.</string>
     <string name="fui_email_link_dismiss_button">Zavřít</string>
     <string name="fui_email_link_cross_device_linking_text">Původně jste chtěli propojit %1$s se svým e-mailovým účtem, ale otevřeli jste odkaz na jiném zařízení, na kterém nejste přihlášení.\n\nPokud stále chcete propojit svůj účet %1$s, otevřete odkaz na stejném zařízení, na kterém jste se začali přihlašovat. V opačném případě klepněte na možnost Pokračovat a přihlaste se na tomto zařízení.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Přihlásit se prostřednictvím %1$s</string>
     <string name="fui_verify_phone_number_title">Zadejte své telefonní číslo</string>
     <string name="fui_invalid_phone_number">Zadejte platné telefonní číslo</string>
     <string name="fui_enter_confirmation_code">Zadejte šestimístný kód, který jsme vám zaslali</string>

--- a/auth/src/main/res/values-da/strings.xml
+++ b/auth/src/main/res/values-da/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Indlæser…</string>
     <string name="fui_sign_in_default">Log ind</string>
-    <string name="fui_cancel">Annuller</string>
     <string name="fui_continue">Fortsæt</string>
     <string name="fui_tos_and_pp">Ved at fortsætte indikerer du, at du accepterer vores %1$s og %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">En loginmail med yderligere vejledning er sendt til %1$s. Tjek din mail for at fuldføre loginprocessen.</string>
     <string name="fui_email_link_trouble_getting_email_header">Har du problemer med at modtage mailen?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prøv disse almindelige løsninger:\n\u2022 Tjek, om mailen er blevet markeret som spam eller filtreret fra.\n\u2022 Tjek din internetforbindelse.\n\u2022 Tjek, at du ikke har stavet din mailadresse forkert.\n\u2022 Tjek, at din indbakke ikke er løbet tør for plads, og at du ikke har andre problemer med indbakken.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Hvis ovenstående trin ikke løste problemet, kan du prøve at sende mailen igen. Bemærk, at dette vil deaktivere linket i den gamle mail.</string>
     <string name="fui_email_link_resend">Send igen</string>
     <string name="fui_email_link_wrong_device_header">Der er registreret en ny enhed eller browser</string>
     <string name="fui_email_link_wrong_device_message">Prøv at åbne linket med samme enhed eller samme browser, som du brugte til at starte loginprocessen.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Bekræft mailadresse for at fortsætte loginprocessen</string>
     <string name="fui_email_link_dismiss_button">Afvis</string>
     <string name="fui_email_link_cross_device_linking_text">Du ville egentlig knytte %1$s til din mailkonto, men du har åbnet linket på en anden enhed, som du ikke er logget ind på.\n\nHvis du stadig vil tilknytte din %1$s-konto, skal du åbne linket på den enhed, hvor du startede loginprocessen. Ellers kan du klikke på Fortsæt for at fortsætte med at logge ind på denne enhed.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Log ind med %1$s</string>
     <string name="fui_verify_phone_number_title">Angiv dit telefonnummer</string>
     <string name="fui_invalid_phone_number">Angiv et gyldigt telefonnummer</string>
     <string name="fui_enter_confirmation_code">Angiv den 6-cifrede kode, vi sendte til</string>

--- a/auth/src/main/res/values-de-rAT/strings.xml
+++ b/auth/src/main/res/values-de-rAT/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Wird geladen…</string>
     <string name="fui_sign_in_default">Anmelden</string>
-    <string name="fui_cancel">Abbrechen</string>
     <string name="fui_continue">Weiter</string>
     <string name="fui_tos_and_pp">Indem Sie fortfahren, stimmen Sie unseren %1$s und unserer %2$s zu.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Wir haben eine Anmelde-E-Mail mit zusätzlichen Informationen an %1$s gesendet. Bitte öffnen Sie die E-Mail, um die Anmeldung abzuschließen.</string>
     <string name="fui_email_link_trouble_getting_email_header">Probleme beim Empfangen von E-Mails?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Versuchen Sie es mit diesen gängigen Korrekturen:\n\u2022 Prüfen Sie, ob die E-Mail als Spam markiert oder gefiltert wurde.\n\u2022 Prüfen Sie Ihre Internetverbindung.\n\u2022 Prüfen Sie, ob Sie die E-Mail-Adresse korrekt geschrieben haben.\n\u2022 Prüfen Sie, ob Ihr Posteingang über genügend Speicherplatz verfügt oder ob es Probleme mit den Einstellungen gibt.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Sollte das Problem auch nach Ausführung der obigen Schritte weiterhin bestehen, können Sie sich die Anmelde-E-Mail noch einmal zusenden lassen. Hinweis: Der Link in der vorhergehenden E-Mail ist dann nicht mehr gültig.</string>
     <string name="fui_email_link_resend">Erneut senden</string>
     <string name="fui_email_link_wrong_device_header">Neues Gerät oder neuer Browser erkannt.</string>
     <string name="fui_email_link_wrong_device_message">Öffnen Sie den Link mit demselben Gerät oder Browser, mit dem Sie die Anmeldung begonnen haben.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">E-Mail-Adresse bestätigen, um Anmeldung fortzusetzen</string>
     <string name="fui_email_link_dismiss_button">Ablehnen</string>
     <string name="fui_email_link_cross_device_linking_text">Sie haben versucht, %1$s auf einem Gerät, auf dem Sie nicht angemeldet sind, mit Ihrem E-Mail-Konto zu verbinden.\n\nWenn Sie Ihr %1$s-Konto weiterhin verbinden möchten, öffnen Sie den Link bitte auf dem Gerät, auf dem Sie den Anmeldevorgang gestartet haben. Andernfalls tippen Sie auf \"Weiter\", um sich auf diesem Gerät anzumelden.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Mit %1$s anmelden</string>
     <string name="fui_verify_phone_number_title">Telefonnummer eingeben</string>
     <string name="fui_invalid_phone_number">Geben Sie eine gültige Telefonnummer ein</string>
     <string name="fui_enter_confirmation_code">Geben Sie den 6-stelligen Code ein, der gesendet wurde an</string>

--- a/auth/src/main/res/values-de-rCH/strings.xml
+++ b/auth/src/main/res/values-de-rCH/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Wird geladen…</string>
     <string name="fui_sign_in_default">Anmelden</string>
-    <string name="fui_cancel">Abbrechen</string>
     <string name="fui_continue">Weiter</string>
     <string name="fui_tos_and_pp">Indem Sie fortfahren, stimmen Sie unseren %1$s und unserer %2$s zu.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Wir haben eine Anmelde-E-Mail mit zusätzlichen Informationen an %1$s gesendet. Bitte öffnen Sie die E-Mail, um die Anmeldung abzuschließen.</string>
     <string name="fui_email_link_trouble_getting_email_header">Probleme beim Empfangen von E-Mails?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Versuchen Sie es mit diesen gängigen Korrekturen:\n\u2022 Prüfen Sie, ob die E-Mail als Spam markiert oder gefiltert wurde.\n\u2022 Prüfen Sie Ihre Internetverbindung.\n\u2022 Prüfen Sie, ob Sie die E-Mail-Adresse korrekt geschrieben haben.\n\u2022 Prüfen Sie, ob Ihr Posteingang über genügend Speicherplatz verfügt oder ob es Probleme mit den Einstellungen gibt.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Sollte das Problem auch nach Ausführung der obigen Schritte weiterhin bestehen, können Sie sich die Anmelde-E-Mail noch einmal zusenden lassen. Hinweis: Der Link in der vorhergehenden E-Mail ist dann nicht mehr gültig.</string>
     <string name="fui_email_link_resend">Erneut senden</string>
     <string name="fui_email_link_wrong_device_header">Neues Gerät oder neuer Browser erkannt.</string>
     <string name="fui_email_link_wrong_device_message">Öffnen Sie den Link mit demselben Gerät oder Browser, mit dem Sie die Anmeldung begonnen haben.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">E-Mail-Adresse bestätigen, um Anmeldung fortzusetzen</string>
     <string name="fui_email_link_dismiss_button">Ablehnen</string>
     <string name="fui_email_link_cross_device_linking_text">Sie haben versucht, %1$s auf einem Gerät, auf dem Sie nicht angemeldet sind, mit Ihrem E-Mail-Konto zu verbinden.\n\nWenn Sie Ihr %1$s-Konto weiterhin verbinden möchten, öffnen Sie den Link bitte auf dem Gerät, auf dem Sie den Anmeldevorgang gestartet haben. Andernfalls tippen Sie auf \"Weiter\", um sich auf diesem Gerät anzumelden.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Mit %1$s anmelden</string>
     <string name="fui_verify_phone_number_title">Telefonnummer eingeben</string>
     <string name="fui_invalid_phone_number">Geben Sie eine gültige Telefonnummer ein</string>
     <string name="fui_enter_confirmation_code">Geben Sie den 6-stelligen Code ein, der gesendet wurde an</string>

--- a/auth/src/main/res/values-de/strings.xml
+++ b/auth/src/main/res/values-de/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Wird geladen…</string>
     <string name="fui_sign_in_default">Anmelden</string>
-    <string name="fui_cancel">Abbrechen</string>
     <string name="fui_continue">Weiter</string>
     <string name="fui_tos_and_pp">Indem Sie fortfahren, stimmen Sie unseren %1$s und unserer %2$s zu.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Wir haben eine Anmelde-E-Mail mit zusätzlichen Informationen an %1$s gesendet. Bitte öffnen Sie die E-Mail, um die Anmeldung abzuschließen.</string>
     <string name="fui_email_link_trouble_getting_email_header">Probleme beim Empfangen von E-Mails?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Versuchen Sie es mit diesen gängigen Korrekturen:\n\u2022 Prüfen Sie, ob die E-Mail als Spam markiert oder gefiltert wurde.\n\u2022 Prüfen Sie Ihre Internetverbindung.\n\u2022 Prüfen Sie, ob Sie die E-Mail-Adresse korrekt geschrieben haben.\n\u2022 Prüfen Sie, ob Ihr Posteingang über genügend Speicherplatz verfügt oder ob es Probleme mit den Einstellungen gibt.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Sollte das Problem auch nach Ausführung der obigen Schritte weiterhin bestehen, können Sie sich die Anmelde-E-Mail noch einmal zusenden lassen. Hinweis: Der Link in der vorhergehenden E-Mail ist dann nicht mehr gültig.</string>
     <string name="fui_email_link_resend">Erneut senden</string>
     <string name="fui_email_link_wrong_device_header">Neues Gerät oder neuer Browser erkannt.</string>
     <string name="fui_email_link_wrong_device_message">Öffnen Sie den Link mit demselben Gerät oder Browser, mit dem Sie die Anmeldung begonnen haben.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">E-Mail-Adresse bestätigen, um Anmeldung fortzusetzen</string>
     <string name="fui_email_link_dismiss_button">Ablehnen</string>
     <string name="fui_email_link_cross_device_linking_text">Sie haben versucht, %1$s auf einem Gerät, auf dem Sie nicht angemeldet sind, mit Ihrem E-Mail-Konto zu verbinden.\n\nWenn Sie Ihr %1$s-Konto weiterhin verbinden möchten, öffnen Sie den Link bitte auf dem Gerät, auf dem Sie den Anmeldevorgang gestartet haben. Andernfalls tippen Sie auf \"Weiter\", um sich auf diesem Gerät anzumelden.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Mit %1$s anmelden</string>
     <string name="fui_verify_phone_number_title">Telefonnummer eingeben</string>
     <string name="fui_invalid_phone_number">Geben Sie eine gültige Telefonnummer ein</string>
     <string name="fui_enter_confirmation_code">Geben Sie den 6-stelligen Code ein, der gesendet wurde an</string>

--- a/auth/src/main/res/values-el/strings.xml
+++ b/auth/src/main/res/values-el/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Γίνεται φόρτωση…</string>
     <string name="fui_sign_in_default">Σύνδεση</string>
-    <string name="fui_cancel">Ακύρωση</string>
     <string name="fui_continue">Συνέχεια</string>
     <string name="fui_tos_and_pp">Αν συνεχίσετε, δηλώνετε ότι αποδέχεστε τους %1$s και την %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Ένα μήνυμα ηλεκτρονικού ταχυδρομείου σύνδεσης με πρόσθετες οδηγίες στάλθηκε στη διεύθυνση %1$s. Ελέγξτε τη διεύθυνση ηλεκτρονικού ταχυδρομείου για να ολοκληρώσετε τη σύνδεση.</string>
     <string name="fui_email_link_trouble_getting_email_header">Αντιμετωπίζετε πρόβλημα με τη λήψη του μηνύματος ηλεκτρονικού ταχυδρομείου;</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Δοκιμάστε αυτές τις συνήθεις διορθώσεις:\n\u2022 Ελέγξτε αν το μήνυμα ηλεκτρονικού ταχυδρομείου επισημάνθηκε ως ανεπιθύμητο ή φιλτραρισμένο.\n\u2022 Ελέγξτε τη σύνδεσή σας στο διαδίκτυο.\n\u2022 Βεβαιωθείτε ότι δεν έχετε γράψει λάθος το μήνυμα ηλεκτρονικού ταχυδρομείου.\n\u2022 Βεβαιωθείτε ότι δεν έχει γεμίσει ο χώρος εισερχομένων ή ότι δεν υπάρχουν άλλα προβλήματα που σχετίζονται με τις ρυθμίσεις εισερχομένων.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Αν τα παραπάνω βήματα δεν λειτούργησαν, μπορείτε να στείλετε ξανά το μήνυμα ηλεκτρονικού ταχυδρομείου. Έχετε υπόψη ότι με αυτήν την ενέργεια, ο σύνδεσμος στο παλιότερο μήνυμα ηλεκτρονικού ταχυδρομείου θα απενεργοποιηθεί.</string>
     <string name="fui_email_link_resend">Επανάληψη αποστολής</string>
     <string name="fui_email_link_wrong_device_header">Εντοπίστηκε νέα συσκευή ή πρόγραμμα περιήγησης.</string>
     <string name="fui_email_link_wrong_device_message">Δοκιμάστε να ανοίξετε τον σύνδεσμο χρησιμοποιώντας την ίδια συσκευή ή το ίδιο πρόγραμμα περιήγησης από όπου ξεκινήσατε τη διαδικασία σύνδεσης.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Επιβεβαιώστε τη διεύθυνση ηλεκτρονικού ταχυδρομείου για να συνεχίσετε τη σύνδεση</string>
     <string name="fui_email_link_dismiss_button">Παράβλεψη</string>
     <string name="fui_email_link_cross_device_linking_text">Αρχικά, σκοπεύατε να συνδέσετε το %1$s με τον λογαριασμό ηλεκτρονικού ταχυδρομείου, αλλά, για το άνοιγμα του συνδέσμου, χρησιμοποιήσατε άλλη συσκευή στην οποία δεν είστε συνδεδεμένοι.\n\nΑν θέλετε να συνεχίσετε τη σύνδεση του λογαριασμού %1$s, ανοίξτε τον σύνδεσμο στην ίδια συσκευή από την οποία ξεκινήσατε τη σύνδεση. Διαφορετικά, πατήστε Συνέχεια για να συνδεθείτε σε αυτήν τη συσκευή.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Συνδεθείτε μέσω %1$s</string>
     <string name="fui_verify_phone_number_title">Εισαγάγετε τον αριθμό τηλεφώνου σας</string>
     <string name="fui_invalid_phone_number">Καταχωρίστε έναν έγκυρο αριθμό τηλεφώνου</string>
     <string name="fui_enter_confirmation_code">Εισαγάγετε τον 6ψήφιο κωδικό που σας στείλαμε στο</string>

--- a/auth/src/main/res/values-en-rAU/strings.xml
+++ b/auth/src/main/res/values-en-rAU/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Loading…</string>
     <string name="fui_sign_in_default">Sign in</string>
-    <string name="fui_cancel">Cancel</string>
     <string name="fui_continue">Continue</string>
     <string name="fui_tos_and_pp">By continuing, you are indicating that you accept our %1$s and %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">A sign-in email with additional instructions was sent to %1$s. Check your email to complete sign-in.</string>
     <string name="fui_email_link_trouble_getting_email_header">Trouble getting email?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Try these common fixes:\n\u2022 Check if the email was marked as spam or filtered.\n\u2022 Check your Internet connection.\n\u2022 Check that you did not misspell your email.\n\u2022 Check that your inbox space is not running out or other inbox settings related issues.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">If the steps above didn\'t work, you can resend the email. Note that this will deactivate the link in the older email.</string>
     <string name="fui_email_link_resend">Resend</string>
     <string name="fui_email_link_wrong_device_header">New device or browser detected.</string>
     <string name="fui_email_link_wrong_device_message">Try opening the link using the same device or browser where you started the sign-in process.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirm email to continue sign in</string>
     <string name="fui_email_link_dismiss_button">Dismiss</string>
     <string name="fui_email_link_cross_device_linking_text">You originally intended to connect %1$s to your email account, but have opened the link on a different device where you are not signed in.\n\nIf you still want to connect your %1$s account, open the link on the same device on which you started sign-in. Otherwise, tap \'Continue\' to sign in on this device.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Sign in with %1$s</string>
     <string name="fui_verify_phone_number_title">Enter your phone number</string>
     <string name="fui_invalid_phone_number">Enter a valid phone number</string>
     <string name="fui_enter_confirmation_code">Enter the 6-digit code that we sent to</string>

--- a/auth/src/main/res/values-en-rCA/strings.xml
+++ b/auth/src/main/res/values-en-rCA/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Loading…</string>
     <string name="fui_sign_in_default">Sign in</string>
-    <string name="fui_cancel">Cancel</string>
     <string name="fui_continue">Continue</string>
     <string name="fui_tos_and_pp">By continuing, you are indicating that you accept our %1$s and %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">A sign-in email with additional instructions was sent to %1$s. Check your email to complete sign-in.</string>
     <string name="fui_email_link_trouble_getting_email_header">Trouble getting email?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Try these common fixes:\n\u2022 Check if the email was marked as spam or filtered.\n\u2022 Check your Internet connection.\n\u2022 Check that you did not misspell your email.\n\u2022 Check that your inbox space is not running out or other inbox settings related issues.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">If the steps above didn\'t work, you can resend the email. Note that this will deactivate the link in the older email.</string>
     <string name="fui_email_link_resend">Resend</string>
     <string name="fui_email_link_wrong_device_header">New device or browser detected.</string>
     <string name="fui_email_link_wrong_device_message">Try opening the link using the same device or browser where you started the sign-in process.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirm email to continue sign in</string>
     <string name="fui_email_link_dismiss_button">Dismiss</string>
     <string name="fui_email_link_cross_device_linking_text">You originally intended to connect %1$s to your email account, but have opened the link on a different device where you are not signed in.\n\nIf you still want to connect your %1$s account, open the link on the same device on which you started sign-in. Otherwise, tap \'Continue\' to sign in on this device.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Sign in with %1$s</string>
     <string name="fui_verify_phone_number_title">Enter your phone number</string>
     <string name="fui_invalid_phone_number">Enter a valid phone number</string>
     <string name="fui_enter_confirmation_code">Enter the 6-digit code that we sent to</string>

--- a/auth/src/main/res/values-en-rGB/strings.xml
+++ b/auth/src/main/res/values-en-rGB/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Loading…</string>
     <string name="fui_sign_in_default">Sign in</string>
-    <string name="fui_cancel">Cancel</string>
     <string name="fui_continue">Continue</string>
     <string name="fui_tos_and_pp">By continuing, you are indicating that you accept our %1$s and %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">A sign-in email with additional instructions was sent to %1$s. Check your email to complete sign-in.</string>
     <string name="fui_email_link_trouble_getting_email_header">Trouble getting email?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Try these common fixes:\n\u2022 Check if the email was marked as spam or filtered.\n\u2022 Check your Internet connection.\n\u2022 Check that you did not misspell your email.\n\u2022 Check that your inbox space is not running out or other inbox settings related issues.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">If the steps above didn\'t work, you can resend the email. Note that this will deactivate the link in the older email.</string>
     <string name="fui_email_link_resend">Resend</string>
     <string name="fui_email_link_wrong_device_header">New device or browser detected.</string>
     <string name="fui_email_link_wrong_device_message">Try opening the link using the same device or browser where you started the sign-in process.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirm email to continue sign in</string>
     <string name="fui_email_link_dismiss_button">Dismiss</string>
     <string name="fui_email_link_cross_device_linking_text">You originally intended to connect %1$s to your email account, but have opened the link on a different device where you are not signed in.\n\nIf you still want to connect your %1$s account, open the link on the same device on which you started sign-in. Otherwise, tap \'Continue\' to sign in on this device.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Sign in with %1$s</string>
     <string name="fui_verify_phone_number_title">Enter your phone number</string>
     <string name="fui_invalid_phone_number">Enter a valid phone number</string>
     <string name="fui_enter_confirmation_code">Enter the 6-digit code that we sent to</string>

--- a/auth/src/main/res/values-en-rIE/strings.xml
+++ b/auth/src/main/res/values-en-rIE/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Loading…</string>
     <string name="fui_sign_in_default">Sign in</string>
-    <string name="fui_cancel">Cancel</string>
     <string name="fui_continue">Continue</string>
     <string name="fui_tos_and_pp">By continuing, you are indicating that you accept our %1$s and %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">A sign-in email with additional instructions was sent to %1$s. Check your email to complete sign-in.</string>
     <string name="fui_email_link_trouble_getting_email_header">Trouble getting email?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Try these common fixes:\n\u2022 Check if the email was marked as spam or filtered.\n\u2022 Check your Internet connection.\n\u2022 Check that you did not misspell your email.\n\u2022 Check that your inbox space is not running out or other inbox settings related issues.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">If the steps above didn\'t work, you can resend the email. Note that this will deactivate the link in the older email.</string>
     <string name="fui_email_link_resend">Resend</string>
     <string name="fui_email_link_wrong_device_header">New device or browser detected.</string>
     <string name="fui_email_link_wrong_device_message">Try opening the link using the same device or browser where you started the sign-in process.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirm email to continue sign in</string>
     <string name="fui_email_link_dismiss_button">Dismiss</string>
     <string name="fui_email_link_cross_device_linking_text">You originally intended to connect %1$s to your email account, but have opened the link on a different device where you are not signed in.\n\nIf you still want to connect your %1$s account, open the link on the same device on which you started sign-in. Otherwise, tap \'Continue\' to sign in on this device.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Sign in with %1$s</string>
     <string name="fui_verify_phone_number_title">Enter your phone number</string>
     <string name="fui_invalid_phone_number">Enter a valid phone number</string>
     <string name="fui_enter_confirmation_code">Enter the 6-digit code that we sent to</string>

--- a/auth/src/main/res/values-en-rIN/strings.xml
+++ b/auth/src/main/res/values-en-rIN/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Loading…</string>
     <string name="fui_sign_in_default">Sign in</string>
-    <string name="fui_cancel">Cancel</string>
     <string name="fui_continue">Continue</string>
     <string name="fui_tos_and_pp">By continuing, you are indicating that you accept our %1$s and %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">A sign-in email with additional instructions was sent to %1$s. Check your email to complete sign-in.</string>
     <string name="fui_email_link_trouble_getting_email_header">Trouble getting email?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Try these common fixes:\n\u2022 Check if the email was marked as spam or filtered.\n\u2022 Check your Internet connection.\n\u2022 Check that you did not misspell your email.\n\u2022 Check that your inbox space is not running out or other inbox settings related issues.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">If the steps above didn\'t work, you can resend the email. Note that this will deactivate the link in the older email.</string>
     <string name="fui_email_link_resend">Resend</string>
     <string name="fui_email_link_wrong_device_header">New device or browser detected.</string>
     <string name="fui_email_link_wrong_device_message">Try opening the link using the same device or browser where you started the sign-in process.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirm email to continue sign in</string>
     <string name="fui_email_link_dismiss_button">Dismiss</string>
     <string name="fui_email_link_cross_device_linking_text">You originally intended to connect %1$s to your email account, but have opened the link on a different device where you are not signed in.\n\nIf you still want to connect your %1$s account, open the link on the same device on which you started sign-in. Otherwise, tap \'Continue\' to sign in on this device.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Sign in with %1$s</string>
     <string name="fui_verify_phone_number_title">Enter your phone number</string>
     <string name="fui_invalid_phone_number">Enter a valid phone number</string>
     <string name="fui_enter_confirmation_code">Enter the 6-digit code that we sent to</string>

--- a/auth/src/main/res/values-en-rSG/strings.xml
+++ b/auth/src/main/res/values-en-rSG/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Loading…</string>
     <string name="fui_sign_in_default">Sign in</string>
-    <string name="fui_cancel">Cancel</string>
     <string name="fui_continue">Continue</string>
     <string name="fui_tos_and_pp">By continuing, you are indicating that you accept our %1$s and %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">A sign-in email with additional instructions was sent to %1$s. Check your email to complete sign-in.</string>
     <string name="fui_email_link_trouble_getting_email_header">Trouble getting email?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Try these common fixes:\n\u2022 Check if the email was marked as spam or filtered.\n\u2022 Check your Internet connection.\n\u2022 Check that you did not misspell your email.\n\u2022 Check that your inbox space is not running out or other inbox settings related issues.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">If the steps above didn\'t work, you can resend the email. Note that this will deactivate the link in the older email.</string>
     <string name="fui_email_link_resend">Resend</string>
     <string name="fui_email_link_wrong_device_header">New device or browser detected.</string>
     <string name="fui_email_link_wrong_device_message">Try opening the link using the same device or browser where you started the sign-in process.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirm email to continue sign in</string>
     <string name="fui_email_link_dismiss_button">Dismiss</string>
     <string name="fui_email_link_cross_device_linking_text">You originally intended to connect %1$s to your email account, but have opened the link on a different device where you are not signed in.\n\nIf you still want to connect your %1$s account, open the link on the same device on which you started sign-in. Otherwise, tap \'Continue\' to sign in on this device.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Sign in with %1$s</string>
     <string name="fui_verify_phone_number_title">Enter your phone number</string>
     <string name="fui_invalid_phone_number">Enter a valid phone number</string>
     <string name="fui_enter_confirmation_code">Enter the 6-digit code that we sent to</string>

--- a/auth/src/main/res/values-en-rZA/strings.xml
+++ b/auth/src/main/res/values-en-rZA/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Loading…</string>
     <string name="fui_sign_in_default">Sign in</string>
-    <string name="fui_cancel">Cancel</string>
     <string name="fui_continue">Continue</string>
     <string name="fui_tos_and_pp">By continuing, you are indicating that you accept our %1$s and %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">A sign-in email with additional instructions was sent to %1$s. Check your email to complete sign-in.</string>
     <string name="fui_email_link_trouble_getting_email_header">Trouble getting email?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Try these common fixes:\n\u2022 Check if the email was marked as spam or filtered.\n\u2022 Check your Internet connection.\n\u2022 Check that you did not misspell your email.\n\u2022 Check that your inbox space is not running out or other inbox settings related issues.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">If the steps above didn\'t work, you can resend the email. Note that this will deactivate the link in the older email.</string>
     <string name="fui_email_link_resend">Resend</string>
     <string name="fui_email_link_wrong_device_header">New device or browser detected.</string>
     <string name="fui_email_link_wrong_device_message">Try opening the link using the same device or browser where you started the sign-in process.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirm email to continue sign in</string>
     <string name="fui_email_link_dismiss_button">Dismiss</string>
     <string name="fui_email_link_cross_device_linking_text">You originally intended to connect %1$s to your email account, but have opened the link on a different device where you are not signed in.\n\nIf you still want to connect your %1$s account, open the link on the same device on which you started sign-in. Otherwise, tap \'Continue\' to sign in on this device.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Sign in with %1$s</string>
     <string name="fui_verify_phone_number_title">Enter your phone number</string>
     <string name="fui_invalid_phone_number">Enter a valid phone number</string>
     <string name="fui_enter_confirmation_code">Enter the 6-digit code that we sent to</string>

--- a/auth/src/main/res/values-es-rAR/strings.xml
+++ b/auth/src/main/res/values-es-rAR/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rBO/strings.xml
+++ b/auth/src/main/res/values-es-rBO/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rCL/strings.xml
+++ b/auth/src/main/res/values-es-rCL/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rCO/strings.xml
+++ b/auth/src/main/res/values-es-rCO/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rCR/strings.xml
+++ b/auth/src/main/res/values-es-rCR/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rDO/strings.xml
+++ b/auth/src/main/res/values-es-rDO/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rEC/strings.xml
+++ b/auth/src/main/res/values-es-rEC/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rGT/strings.xml
+++ b/auth/src/main/res/values-es-rGT/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rHN/strings.xml
+++ b/auth/src/main/res/values-es-rHN/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rMX/strings.xml
+++ b/auth/src/main/res/values-es-rMX/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rNI/strings.xml
+++ b/auth/src/main/res/values-es-rNI/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rPA/strings.xml
+++ b/auth/src/main/res/values-es-rPA/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rPE/strings.xml
+++ b/auth/src/main/res/values-es-rPE/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rPR/strings.xml
+++ b/auth/src/main/res/values-es-rPR/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rPY/strings.xml
+++ b/auth/src/main/res/values-es-rPY/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rSV/strings.xml
+++ b/auth/src/main/res/values-es-rSV/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rUS/strings.xml
+++ b/auth/src/main/res/values-es-rUS/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rUY/strings.xml
+++ b/auth/src/main/res/values-es-rUY/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rVE/strings.xml
+++ b/auth/src/main/res/values-es-rVE/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Acceder</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, indicas que aceptas nuestras %1$s y %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se envió un correo electrónico de acceso con instrucciones adicionales a %1$s. Revisa tu bandeja de entrada para completar el proceso.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿Tienes problemas para recibir correos electrónicos?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba estas soluciones comunes:\n\u2022 Revisa si el correo electrónico se marcó como spam o se filtró.\n\u2022 Comprueba tu conexión a Internet.\n\u2022 Verifica que hayas escrito correctamente el correo electrónico.\n\u2022 Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si los pasos anteriores no funcionaron, puedes reenviar el correo electrónico. Ten en cuenta que esta acción desactivará el vínculo en el correo electrónico más antiguo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se detectó un dispositivo o navegador nuevo</string>
     <string name="fui_email_link_wrong_device_message">Intenta abrir el vínculo con el mismo dispositivo o navegador en el que comenzaste el proceso de acceso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el acceso</string>
     <string name="fui_email_link_dismiss_button">Descartar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Acceder con %1$s</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es/strings.xml
+++ b/auth/src/main/res/values-es/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Cargando…</string>
     <string name="fui_sign_in_default">Iniciar sesión</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Si continúas, confirmas que aceptas nuestras %1$s y nuestra %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Se ha enviado un correo electrónico de inicio de sesión con más instrucciones a %1$s. Consulta tu bandeja de entrada para completar el inicio de sesión.</string>
     <string name="fui_email_link_trouble_getting_email_header">¿No puedes recibir el correo?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prueba las soluciones más habituales:\n\u2022 Comprueba si el mensaje de correo electrónico se ha filtrado o marcado como spam.\n\u2022 Verifica que tienes conexión a Internet.\n\u2022 Asegúrate de haber escrito correctamente tu dirección de correo electrónico.\n\u2022 Comprueba que no te estás quedando sin espacio en la bandeja de entrada y que no hay ningún problema con su configuración.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si no se ha resuelto el problema con los pasos mencionados, puedes volver a enviar el correo electrónico (se desactivará el enlace del correo electrónico anterior).</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Se ha detectado un nuevo dispositivo o navegador.</string>
     <string name="fui_email_link_wrong_device_message">Prueba a abrir el enlace con el mismo dispositivo o navegador en los que empezaste el proceso de inicio de sesión.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirma el correo electrónico para continuar con el inicio de sesión</string>
     <string name="fui_email_link_dismiss_button">Cerrar</string>
     <string name="fui_email_link_cross_device_linking_text">En un principio intentaste conectar %1$s a tu cuenta de correo electrónico, pero has abierto el enlace en un dispositivo diferente en el que no has iniciado sesión.\n\nSi sigues queriendo vincular tu cuenta de %1$s, abre el enlace en el mismo dispositivo en el que empezaste el inicio de sesión. De lo contrario, toca Continuar para iniciar sesión en este dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Iniciar sesión con %1$s</string>
     <string name="fui_verify_phone_number_title">Introduce tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Introduce un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Introduce el código de seis dígitos que hemos enviado a</string>

--- a/auth/src/main/res/values-fa/strings.xml
+++ b/auth/src/main/res/values-fa/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">درحال بارگیری…</string>
     <string name="fui_sign_in_default">ورود به سیستم</string>
-    <string name="fui_cancel">لغو</string>
     <string name="fui_continue">ادامه</string>
     <string name="fui_tos_and_pp">درصورت ادامه‌دادن، موافقتتان را با %1$s و %2$s اعلام می‌کنید.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">ایمیل ورود به سیستم، حاوی دستورالعمل‌های بیشتر، به %1$s ارسال شد. برای تکمیل ورود به سیستم، ایمیلتان را بررسی کنید.</string>
     <string name="fui_email_link_trouble_getting_email_header">در دریافت ایمیل مشکل دارید؟</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">این رفع اشکال‌های معمول را امتحان کنید:\n\u2022 ببینید ایمیل به‌عنوان هرزنامه یا فیلترشده مشخص نشده باشد.\n\u2022 اتصال اینترنتتان را بررسی کنید.\n\u2022 مطمئن شوید املای ایمیلتان را درست وارد کرده باشید.\n\u2022 مطمئن شوید فضای صندوق ورودی‌تان روبه‌اتمام نباشد یا مشکل دیگری در تنظیمات صندوق ورودی وجود نداشته باشد.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">اگر اقدامات بالا به رفع مشکل کمک نکرد، می‌توانید ایمیل را مجدداً ارسال کنید. توجه کنید که با این کار، پیوند موجود در ایمیل قبلی غیرفعال می‌شود.</string>
     <string name="fui_email_link_resend">ارسال مجدد</string>
     <string name="fui_email_link_wrong_device_header">دستگاه یا مرورگر جدید شناسایی شد.</string>
     <string name="fui_email_link_wrong_device_message">با همان دستگاه یا مرورگری که فرایند ورود به سیستم را آغاز کردید، پیوند را باز کنید.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">برای ادامه ورود به سیستم، ایمیل را به‌تأیید برسانید</string>
     <string name="fui_email_link_dismiss_button">نپذیرفتن</string>
     <string name="fui_email_link_cross_device_linking_text">ابتدا قصد داشتید %1$s را به حساب ایمیلتان متصل کنید، اما پیوند را در دستگاه دیگری باز کردید که در آن وارد سیستم نشده‌اید.\n\nاگر همچنان می‌خواهید حساب %1$s را متصل کنید، پیوند را در همان دستگاهی باز کنید که ورود به سیستم را با آن شروع کرده‌اید. درغیراین‌صورت، برای ورود به سیستم با این دستگاه، روی «ادامه» ضربه بزنید.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">ورود به سیستم با %1$s</string>
     <string name="fui_verify_phone_number_title">شماره تلفن خود را وارد کنید</string>
     <string name="fui_invalid_phone_number">شماره تلفن معتبری وارد کنید</string>
     <string name="fui_enter_confirmation_code">وارد کردن کد ۶ رقمی ارسال‌شده به</string>

--- a/auth/src/main/res/values-fi/strings.xml
+++ b/auth/src/main/res/values-fi/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Ladataan…</string>
     <string name="fui_sign_in_default">Kirjaudu sisään</string>
-    <string name="fui_cancel">Peru</string>
     <string name="fui_continue">Jatka</string>
     <string name="fui_tos_and_pp">Jatkamalla vahvistat, että hyväksyt seuraavat: %1$s ja %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Lisäohjeita sisältävä kirjautumisviesti lähetettiin osoitteeseen %1$s. Tarkista sähköpostisi kirjautumisen suorittamiseksi loppuun.</string>
     <string name="fui_email_link_trouble_getting_email_header">Ongelmia sähköpostiviestin saamisessa?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Kokeile näitä yleisiä ratkaisuja:\n\u2022 Tarkista merkittiinkö viesti roskapostiksi tai suodatettiinko se.\n\u2022 Tarkista internetyhteytesi.\n\u2022 Tarkista että kirjoitit sähköpostiosoitteesi oikein.\n\u2022 Tarkista ettei postilaatikkosi tila ole loppumassa tai ettei postilaatikon asetuksissa ole muita ongelmia.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Jos edellä olevista ratkaisuista ei ollut apua, voit lähettää viestin uudelleen. Huomaa että tällöin aiemmassa viestissä oleva linkki poistetaan käytöstä.</string>
     <string name="fui_email_link_resend">Lähetä uudelleen</string>
     <string name="fui_email_link_wrong_device_header">Uusi laite tai selain havaittu.</string>
     <string name="fui_email_link_wrong_device_message">Kokeile avata linkki käyttäen samaa laitetta tai selainta, jolla aloitit kirjautumisen.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Vahvista sähköposti jatkaaksesi kirjautumista</string>
     <string name="fui_email_link_dismiss_button">Hylkää</string>
     <string name="fui_email_link_cross_device_linking_text">Tarkoituksesi oli yhdistää palvelu %1$s sähköpostiosoitteeseesi, mutta avasit linkin eri laitteella, johon et ollut kirjautunut.\n\Jos haluat edelleen yhdistää palvelun %1$s tilisi, avaa linkki samalla laitteella, jolla aloitit kirjautumisen. Jos haluat jatkaa kirjautumista tällä laitteella, napauta Jatka.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Kirjaudu palvelun %1$s kautta</string>
     <string name="fui_verify_phone_number_title">Anna puhelinnumerosi</string>
     <string name="fui_invalid_phone_number">Anna voimassa oleva puhelinnumero.</string>
     <string name="fui_enter_confirmation_code">Anna 6 merkin pituinen koodi, jonka lähetimme numeroon</string>

--- a/auth/src/main/res/values-fil/strings.xml
+++ b/auth/src/main/res/values-fil/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Naglo-load…</string>
     <string name="fui_sign_in_default">Mag-sign in</string>
-    <string name="fui_cancel">Kanselahin</string>
     <string name="fui_continue">Magpatuloy</string>
     <string name="fui_tos_and_pp">Sa pagpapatuloy, ipinababatid mo na tinatanggap mo ang aming %1$s at %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Nagpadala ng email sa pag-sign in na may mga karagdagang tagubilin sa %1$s. Tingnan ang iyong email para makumpleto ang pag-sign in.</string>
     <string name="fui_email_link_trouble_getting_email_header">Nagkakaproblema sa pagtanggap ng email?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Subukan ang mga karaniwang pag-aayos na ito:\n\u2022 Tingnan kung namarkahan na spam o na-filter ang email.\n\u2022 Tingnan ang iyong koneksyon sa internet.\n\u2022 Tiyakin na hindi ka nagkamali sa pagbaybay sa iyong email.\n\u2022 Tiyakin na hindi nauubusan ng espasyo ang iyong inbox o may iba pang isyu na may kinalaman sa setting ng inbox.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Kung hindi gumagana ang mga hakbang sa itaas, maaari mong ipadala muli ang email. Tandaan na ide-deactivate nito ang link sa mas lumang email.</string>
     <string name="fui_email_link_resend">Muling ipadala</string>
     <string name="fui_email_link_wrong_device_header">May nakitang bagong device o browser.</string>
     <string name="fui_email_link_wrong_device_message">Subukang buksan ang link gamit ang parehong device o browser kung saan mo sinimulan ang proseso ng pag-sign in.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Kumpirmahin ang email para magpatuloy sa pag-sign in</string>
     <string name="fui_email_link_dismiss_button">I-dismiss</string>
     <string name="fui_email_link_cross_device_linking_text">Orihinal na sinadya mong ikonekta ang %1$s sa iyong email account pero nabuksan ang link sa ibang device kung saan hindi ka naka-sign in.\n\nKung gusto mo pa ring ikonekta ang iyong %1$s account, buksan ang link sa parehong device kung saan ka nagsimulang mag-sign in. Kung hindi, i-tap ang Magpatuloy para makapag-sign in sa device na ito.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Mag-sign in gamit ang %1$s</string>
     <string name="fui_verify_phone_number_title">Ilagay ang numero ng iyong telepono</string>
     <string name="fui_invalid_phone_number">Maglagay ng wastong numero ng telepono</string>
     <string name="fui_enter_confirmation_code">Ilagay ang 6-digit na code na ipinadala namin sa</string>

--- a/auth/src/main/res/values-fr-rCH/strings.xml
+++ b/auth/src/main/res/values-fr-rCH/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Chargement…</string>
     <string name="fui_sign_in_default">Se connecter</string>
-    <string name="fui_cancel">Annuler</string>
     <string name="fui_continue">Continuer</string>
     <string name="fui_tos_and_pp">En continuant, vous acceptez les %1$s et les %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s   %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Un e-mail de connexion avec des instructions supplémentaires a été envoyé à %1$s. Consultez cet e-mail pour vous connecter.</string>
     <string name="fui_email_link_trouble_getting_email_header">Vous n\'avez pas reçu l\'e-mail ?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Essayez les solutions courantes suivantes :\n\u2022 Vérifiez que l\'e-mail n\'a ni été marqué comme spam ni été filtré.\n\u2022 Vérifiez votre connexion Internet.\n\u2022 Vérifiez que votre adresse e-mail est correcte.\n\u2022 Vérifiez que votre boîte de réception n\'est pas pleine et que les paramètres sont correctement définis.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si les étapes décrites plus haut n\'ont pas résolu le problème, vous pouvez renvoyer l\'e-mail. Sachez que le lien du premier e-mail sera alors désactivé.</string>
     <string name="fui_email_link_resend">Renvoyer</string>
     <string name="fui_email_link_wrong_device_header">Nouveau navigateur ou nouvel appareil détecté</string>
     <string name="fui_email_link_wrong_device_message">Essayez d\'ouvrir le lien en utilisant le même appareil ou navigateur que celui sur lequel vous avez commencé le processus de connexion.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirmez votre adresse e-mail pour vous connecter</string>
     <string name="fui_email_link_dismiss_button">Ignorer</string>
     <string name="fui_email_link_cross_device_linking_text">Vous aviez décidé d\'associer votre compte %1$s à votre adresse e-mail, mais vous avez ouvert le lien sur un appareil différent de celui avec lequel vous vous êtes connecté.\n\nSi vous souhaitez toujours associer votre compte %1$s, ouvrez le lien sur l\'appareil avec lequel vous avez commencé à vous connecter. Sinon, appuyez sur \"Continuer\" pour vous connecter depuis un autre appareil.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Se connecter avec %1$s</string>
     <string name="fui_verify_phone_number_title">Saisissez votre numéro de téléphone</string>
     <string name="fui_invalid_phone_number">Saisissez un numéro de téléphone valide</string>
     <string name="fui_enter_confirmation_code">Saisissez le code à six chiffres envoyé au</string>

--- a/auth/src/main/res/values-fr/strings.xml
+++ b/auth/src/main/res/values-fr/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Chargement…</string>
     <string name="fui_sign_in_default">Se connecter</string>
-    <string name="fui_cancel">Annuler</string>
     <string name="fui_continue">Continuer</string>
     <string name="fui_tos_and_pp">En continuant, vous acceptez les %1$s et les %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s   %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Un e-mail de connexion avec des instructions supplémentaires a été envoyé à %1$s. Consultez cet e-mail pour vous connecter.</string>
     <string name="fui_email_link_trouble_getting_email_header">Vous n\'avez pas reçu l\'e-mail ?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Essayez les solutions courantes suivantes :\n\u2022 Vérifiez que l\'e-mail n\'a ni été marqué comme spam ni été filtré.\n\u2022 Vérifiez votre connexion Internet.\n\u2022 Vérifiez que votre adresse e-mail est correcte.\n\u2022 Vérifiez que votre boîte de réception n\'est pas pleine et que les paramètres sont correctement définis.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si les étapes décrites plus haut n\'ont pas résolu le problème, vous pouvez renvoyer l\'e-mail. Sachez que le lien du premier e-mail sera alors désactivé.</string>
     <string name="fui_email_link_resend">Renvoyer</string>
     <string name="fui_email_link_wrong_device_header">Nouveau navigateur ou nouvel appareil détecté</string>
     <string name="fui_email_link_wrong_device_message">Essayez d\'ouvrir le lien en utilisant le même appareil ou navigateur que celui sur lequel vous avez commencé le processus de connexion.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirmez votre adresse e-mail pour vous connecter</string>
     <string name="fui_email_link_dismiss_button">Ignorer</string>
     <string name="fui_email_link_cross_device_linking_text">Vous aviez décidé d\'associer votre compte %1$s à votre adresse e-mail, mais vous avez ouvert le lien sur un appareil différent de celui avec lequel vous vous êtes connecté.\n\nSi vous souhaitez toujours associer votre compte %1$s, ouvrez le lien sur l\'appareil avec lequel vous avez commencé à vous connecter. Sinon, appuyez sur \"Continuer\" pour vous connecter depuis un autre appareil.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Se connecter avec %1$s</string>
     <string name="fui_verify_phone_number_title">Saisissez votre numéro de téléphone</string>
     <string name="fui_invalid_phone_number">Saisissez un numéro de téléphone valide</string>
     <string name="fui_enter_confirmation_code">Saisissez le code à six chiffres envoyé au</string>

--- a/auth/src/main/res/values-gsw/strings.xml
+++ b/auth/src/main/res/values-gsw/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Wird geladen…</string>
     <string name="fui_sign_in_default">Anmelden</string>
-    <string name="fui_cancel">Abbrechen</string>
     <string name="fui_continue">Weiter</string>
     <string name="fui_tos_and_pp">Indem Sie fortfahren, stimmen Sie unseren %1$s und unserer %2$s zu.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Wir haben eine Anmelde-E-Mail mit zusätzlichen Informationen an %1$s gesendet. Bitte öffnen Sie die E-Mail, um die Anmeldung abzuschließen.</string>
     <string name="fui_email_link_trouble_getting_email_header">Probleme beim Empfangen von E-Mails?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Versuchen Sie es mit diesen gängigen Korrekturen:\n\u2022 Prüfen Sie, ob die E-Mail als Spam markiert oder gefiltert wurde.\n\u2022 Prüfen Sie Ihre Internetverbindung.\n\u2022 Prüfen Sie, ob Sie die E-Mail-Adresse korrekt geschrieben haben.\n\u2022 Prüfen Sie, ob Ihr Posteingang über genügend Speicherplatz verfügt oder ob es Probleme mit den Einstellungen gibt.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Sollte das Problem auch nach Ausführung der obigen Schritte weiterhin bestehen, können Sie sich die Anmelde-E-Mail noch einmal zusenden lassen. Hinweis: Der Link in der vorhergehenden E-Mail ist dann nicht mehr gültig.</string>
     <string name="fui_email_link_resend">Erneut senden</string>
     <string name="fui_email_link_wrong_device_header">Neues Gerät oder neuer Browser erkannt.</string>
     <string name="fui_email_link_wrong_device_message">Öffnen Sie den Link mit demselben Gerät oder Browser, mit dem Sie die Anmeldung begonnen haben.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">E-Mail-Adresse bestätigen, um Anmeldung fortzusetzen</string>
     <string name="fui_email_link_dismiss_button">Ablehnen</string>
     <string name="fui_email_link_cross_device_linking_text">Sie haben versucht, %1$s auf einem Gerät, auf dem Sie nicht angemeldet sind, mit Ihrem E-Mail-Konto zu verbinden.\n\nWenn Sie Ihr %1$s-Konto weiterhin verbinden möchten, öffnen Sie den Link bitte auf dem Gerät, auf dem Sie den Anmeldevorgang gestartet haben. Andernfalls tippen Sie auf \"Weiter\", um sich auf diesem Gerät anzumelden.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Mit %1$s anmelden</string>
     <string name="fui_verify_phone_number_title">Telefonnummer eingeben</string>
     <string name="fui_invalid_phone_number">Geben Sie eine gültige Telefonnummer ein</string>
     <string name="fui_enter_confirmation_code">Geben Sie den 6-stelligen Code ein, der gesendet wurde an</string>

--- a/auth/src/main/res/values-gu/strings.xml
+++ b/auth/src/main/res/values-gu/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">લોડ કરી રહ્યું છે…</string>
     <string name="fui_sign_in_default">સાઇન ઇન કરો</string>
-    <string name="fui_cancel">રદ કરો</string>
     <string name="fui_continue">આગળ વધો</string>
     <string name="fui_tos_and_pp">ચાલુ રાખીને, તમે સૂચવી રહ્યાં છો કે તમે અમારી %1$s અને %2$sને સ્વીકારો છો.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">વધારાની સૂચનાઓ ધરાવતો સાઇન-ઇન ઇમેઇલ %1$s પર મોકલ્યો હતો. સાઇન-ઇન પૂર્ણ કરવા માટે તમારું ઇમેઇલ ઍડ્રેસ ચેક કરો.</string>
     <string name="fui_email_link_trouble_getting_email_header">ઇમેઇલ મેળવવામાં મુશ્કેલી આવે છે?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">આ સામાન્ય ઉકેલોને અજમાવી જુઓ:\n\u2022 ચેક કરો કે તે ઇમેઇલને સ્પામ કે ફિલ્ટર કરેલ તરીકે ચિહ્નિત કર્યો હતો કે કેમ.\n\u2022 તમારું ઇન્ટરનેટ કનેક્શન ચેક કરો.\n\u2022 ચેક કરો કે તમારા ઇમેઇલની જોડણી ખોટી તો નથી.\n\u2022 ચેક કરો કે તમારા ઇનબૉક્સમાં જગ્યા ભરાઈ ગઈ છે કે કેમ અથવા ઇનબૉક્સ સેટિંગથી સંબંધિત અન્ય સમસ્યા નથી.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">જો ઉપરોક્ત પગલાં કામ ન કરે, તો તમે ઇમેઇલ ફરીથી મોકલી શકો છો. નોંધ લેશો કે આ જૂના ઇમેઇલમાં રહેલી લિંકને નિષ્ક્રિય કરશે.</string>
     <string name="fui_email_link_resend">ફરીથી મોકલો</string>
     <string name="fui_email_link_wrong_device_header">નવું ડિવાઇસ અથવા બ્રાઉઝર મળ્યું.</string>
     <string name="fui_email_link_wrong_device_message">લિંકને તે જ ડિવાઇસ અથવા બ્રાઉઝરમાંથી ખોલવાનો પ્રયાસ કરો કે જેનાથી તમે સાઇન ઇન પ્રક્રિયા શરૂ કરી હતી.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">સાઇન ઇન ચાલુ રાખવા માટે ઇમેઇલ કન્ફર્મ કરો</string>
     <string name="fui_email_link_dismiss_button">છોડી દો</string>
     <string name="fui_email_link_cross_device_linking_text">તમે ઑરિજિનલ રીતે %1$sને તમારા ઇમેઇલ એકાઉન્ટ જોડે કનેક્ટ કરવા માગતા હતા પણ તમે લિંકને કોઈ અલગ ડિવાઇસ પરથી ખોલી છે, જેમાં તમે સાઇન ઇન થયા નથી.\n\nજો તમે હજી પણ તમારા %1$s એકાઉન્ટને કનેક્ટ કરવા માગતા હો, તો તમે જે ડિવાઇસ પરથી સાઇન-ઇન કરવાની પ્રક્રિયા શરૂ કરી હોય એના પરથી જ લિંક ખોલો. અન્યથા, આ ડિવાઇસ પરથી સાઇન-ઇન કરવા માટે આગળ વધો પર ટૅપ કરો.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">%1$s વડે સાઇન ઇન કરો</string>
     <string name="fui_verify_phone_number_title">તમારો ફોન નંબર દાખલ કરો</string>
     <string name="fui_invalid_phone_number">એક માન્ય ફોન નંબર દાખલ કરો</string>
     <string name="fui_enter_confirmation_code">અમે આ ફોન નંબર પર મોકલેલ 6-અંકનો કોડ દાખલ કરો</string>

--- a/auth/src/main/res/values-hi/strings.xml
+++ b/auth/src/main/res/values-hi/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">लोड हो रहा है…</string>
     <string name="fui_sign_in_default">प्रवेश करें</string>
-    <string name="fui_cancel">रद्द करें</string>
     <string name="fui_continue">जारी रखें</string>
     <string name="fui_tos_and_pp">जारी रखकर, आप यह बताते हैं कि आप हमारी %1$s और %2$s को मंज़ूर करते हैं.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">ज़्यादा निर्देशों वाला एक ईमेल %1$s पर भेजा गया है. साइन-इन पूरा करने के लिए अपना ईमेल देखें.</string>
     <string name="fui_email_link_trouble_getting_email_header">क्या ईमेल मिलने में दिक्कत हो रही है?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">समाधान के इन सामान्य तरीकों को आज़माएं:\n\u2022 देख लें कि ईमेल स्पैम फ़ोल्डर में तो नहीं चला गया या फिर फ़िल्टर तो नहीं हो गया है.\n\u2022 अपने इंटरनेट कनेक्शन की जाँच करें.\n\u2022 देख लें कि आपने अपने ईमेल पते की वर्तनी गलत तो नहीं लिखी है.\n\u2022 देख लें कि आपके इनबॉक्स में नए ईमेल आने के लिए जगह है या नहीं या इनबॉक्स सेटिंग से जुड़ी दूसरी समस्याएं तो नहीं हैं.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">अगर ऊपर दिए गए सुझावों से काम नहीं बनता है, तो आप फिर से ईमेल भेज सकते हैं. ध्यान दें कि ऐसा करने से पुराने ईमेल का लिंक बंद हो जाएगा.</string>
     <string name="fui_email_link_resend">फिर से भेजें</string>
     <string name="fui_email_link_wrong_device_header">नए डिवाइस या ब्राउज़र का पता चला है.</string>
     <string name="fui_email_link_wrong_device_message">उसी डिवाइस या ब्राउज़र का इस्तेमाल करके लिंक खोलने की कोशिश करें जिससे आपने साइन-इन करना शुरू किया था.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">साइन इन जारी रखने के लिए ईमेल की पुष्टि करें</string>
     <string name="fui_email_link_dismiss_button">खारिज करें</string>
     <string name="fui_email_link_cross_device_linking_text">आप पहले %1$s को अपने ईमेल खाते से जोड़ना चाहते थे, लेकिन आपने ऐसे किसी अलग डिवाइस से लिंक खोला है, जहां आप साइन-इन नहीं हैं.\n\nअगर आप अब भी अपने %1$s खाते को जोड़ना चाहते हैं, तो उसी डिवाइस पर लिंक खोलें जिस पर आपने साइन-इन करना शुरू किया था. या फिर, इस डिवाइस से साइन इन करने के लिए \'जारी रखें\' पर टैप करें.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">%1$s के साथ साइन इन करें</string>
     <string name="fui_verify_phone_number_title">अपना फ़ोन नंबर डालें</string>
     <string name="fui_invalid_phone_number">कोई मान्य फ़ोन नंबर डालें</string>
     <string name="fui_enter_confirmation_code">हमारी ओर से भेजा गया 6-अंकों वाला कोड डालें</string>

--- a/auth/src/main/res/values-hr/strings.xml
+++ b/auth/src/main/res/values-hr/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Učitavanje…</string>
     <string name="fui_sign_in_default">Prijava</string>
-    <string name="fui_cancel">Odustani</string>
     <string name="fui_continue">Nastavi</string>
     <string name="fui_tos_and_pp">Ako nastavite, potvrđujete da prihvaćate odredbe koje sadrže %1$s i %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">E-poruka za prijavu s dodatnim uputama poslana je na adresu %1$s. Provjerite e-poštu da biste dovršili prijavu.</string>
     <string name="fui_email_link_trouble_getting_email_header">Imate poteškoće s primanjem e-poruke?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Isprobajte ova uobičajena rješenja:\n\u2022 Provjerite je li e-poruka filtrirana ili označena kao neželjena pošta.\n\u2022 Provjerite internetsku vezu.\n\u2022 Provjerite jeste li točno napisali e-adresu.\n\u2022 Provjerite ima li dovoljno prostora u vašem pretincu pristigle pošte ili je došlo do drugih problema povezanih s postavkama pretinca pristigle pošte.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Ako se problem ne riješi pomoću koraka iznad, možete ponovo poslati e-poruku. Time će se deaktivirati veza u ranijoj e-poruci.</string>
     <string name="fui_email_link_resend">Pošalji ponovo</string>
     <string name="fui_email_link_wrong_device_header">Pronađen je novi uređaj ili preglednik.</string>
     <string name="fui_email_link_wrong_device_message">Pokušajte otvoriti vezu s onog uređaja ili preglednika u kojem ste započeli postupak prijave.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Za nastavak prijave potvrdite e-adresu</string>
     <string name="fui_email_link_dismiss_button">Odbaci</string>
     <string name="fui_email_link_cross_device_linking_text">Izvorno ste namjeravali povezati %1$s račun sa svojim računom e-pošte, no otvorili ste vezu na drugom uređaju na kojem niste prijavljeni.\n\nAko i dalje želite povezati svoj %1$s račun, otvorite vezu na uređaju na kojem ste pokrenuli postupak prijave. U suprotnom dodirnite Nastavi da biste se prijavili na ovom uređaju.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Prijava putem adrese %1$s</string>
     <string name="fui_verify_phone_number_title">Unesite telefonski broj</string>
     <string name="fui_invalid_phone_number">Unesite važeći telefonski broj</string>
     <string name="fui_enter_confirmation_code">Unesite 6-znamenkasti kôd koji smo poslali na broj</string>

--- a/auth/src/main/res/values-hu/strings.xml
+++ b/auth/src/main/res/values-hu/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Betöltés…</string>
     <string name="fui_sign_in_default">Bejelentkezés</string>
-    <string name="fui_cancel">Mégse</string>
     <string name="fui_continue">Tovább</string>
     <string name="fui_tos_and_pp">A folytatással elfogadja a következő dokumentumokat: %1$s és %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">A további utasításokat tartalmazó bejelentkezési e-mailt elküldtük ide: %1$s. A bejelentkezés befejezéséhez keresse meg az e-mailjei között.</string>
     <string name="fui_email_link_trouble_getting_email_header">Az e-mail-fogadással kapcsolatos problémát észlel?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Próbálja ki ezeket az általános problémamegoldó lépéseket:\n\u2022 Ellenőrizze, hogy az e-mail nem lett-e spamként megjelölve, vagy kiszűrve.\n\u2022 Ellenőrizze az internetkapcsolatát.\n\u2022 Ellenőrizze, hogy nem tévesen írta-e le az e-mail-címét.\n\u2022 Ellenőrizze, hogy a beérkező levelek számára van-e tárhely, illetve nincs-e gond a beérkező levelek beállításaival.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Ha a fenti lépések végrehajtása nem járt eredménnyel, küldje el újra az e-mailt. Ne feledje, hogy ezzel deaktiválja az előző e-mailben szereplő linket.</string>
     <string name="fui_email_link_resend">Újraküldés</string>
     <string name="fui_email_link_wrong_device_header">A rendszer új eszközt vagy böngészőt észlelt.</string>
     <string name="fui_email_link_wrong_device_message">Ugyanazzal az eszközzel vagy böngészővel nyissa meg a linket, amellyel elkezdte a bejelentkezési műveletet.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">A bejelentkezés folytatásához erősítse meg az e-mail-címet</string>
     <string name="fui_email_link_dismiss_button">Elvetés</string>
     <string name="fui_email_link_cross_device_linking_text">Eredetileg össze szerette volna kapcsolni %1$s-fiókját az e-mail-fiókjával, a linket azonban olyan eszközön nyitotta meg, amelyen nem jelentkezett be.\n\nHa továbbra is össze kívánja kapcsolni %1$s-fiókját, akkor azon az eszközön nyissa meg a linket, amelyen megkezdte a bejelentkezést. Ha ezen az eszközön kíván bejelentkezni, akkor koppintson a Tovább gombra.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Bejelentkezés a következővel: %1$s</string>
     <string name="fui_verify_phone_number_title">Adja meg telefonszámát</string>
     <string name="fui_invalid_phone_number">Érvényes telefonszámot adjon meg.</string>
     <string name="fui_enter_confirmation_code">Adja meg a telefonszámra elküldött 6 számjegyű kódot</string>

--- a/auth/src/main/res/values-in/strings.xml
+++ b/auth/src/main/res/values-in/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Memuat…</string>
     <string name="fui_sign_in_default">Login</string>
-    <string name="fui_cancel">Batal</string>
     <string name="fui_continue">Lanjutkan</string>
     <string name="fui_tos_and_pp">Dengan melanjutkan, Anda menyatakan bahwa Anda menyetujui %1$s dan %2$s kami.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Email login dengan petunjuk tambahan telah dikirim ke %1$s. Buka email Anda untuk menyelesaikan proses login.</string>
     <string name="fui_email_link_trouble_getting_email_header">Ada masalah saat mendapatkan email?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Cobalah perbaikan umum ini:\n\u2022 Periksa apakah email tersebut ditandai sebagai spam atau difilter.\n\u2022 Periksa koneksi internet Anda.\n\u2022 Periksa bahwa Anda tidak salah mengeja email Anda.\n\u2022 Periksa apakah masih ada ruang di kotak masuk email Anda atau tidak, atau apakah ada masalah terkait setelan kotak masuk lainnya atau tidak.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Jika langkah-langkah di atas tidak berfungsi, Anda dapat mengirim ulang email tersebut. Perlu diperhatikan bahwa tindakan ini akan menonaktifkan link di email lama.</string>
     <string name="fui_email_link_resend">Kirim ulang</string>
     <string name="fui_email_link_wrong_device_header">Perangkat atau browser baru terdeteksi.</string>
     <string name="fui_email_link_wrong_device_message">Coba buka link menggunakan perangkat atau browser yang sama tempat Anda memulai proses login.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Konfirmasi email untuk melanjutkan login</string>
     <string name="fui_email_link_dismiss_button">Tutup</string>
     <string name="fui_email_link_cross_device_linking_text">Anda sebelumnya ingin menghubungkan %1$s ke akun email Anda, tapi telah membuka link di perangkat berbeda yang tidak digunakan untuk login.\n\nJika Anda masih ingin menghubungkan ke akun %1$s, buka link di perangkat yang sama yang digunakan untuk login. Jika tidak, ketuk Lanjutkan untuk login di perangkat ini.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Login dengan %1$s</string>
     <string name="fui_verify_phone_number_title">Masukkan nomor telepon Anda</string>
     <string name="fui_invalid_phone_number">Masukkan nomor telepon yang valid</string>
     <string name="fui_enter_confirmation_code">Masukkan kode 6 digit yang kami kirimkan ke</string>

--- a/auth/src/main/res/values-it/strings.xml
+++ b/auth/src/main/res/values-it/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Caricamento in corso…</string>
     <string name="fui_sign_in_default">Accedi</string>
-    <string name="fui_cancel">Annulla</string>
     <string name="fui_continue">Continua</string>
     <string name="fui_tos_and_pp">Se continui, accetti i nostri %1$s e le nostre %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Un\'email di accesso con ulteriori istruzioni è stata inviata all\'indirizzo %1$s. Controlla la tua casella di posta per completare l\'accesso.</string>
     <string name="fui_email_link_trouble_getting_email_header">Non hai ricevuto l\'email?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prova le seguenti soluzioni comuni:\n\u2022 Verifica se l\'email è stata contrassegnata come spam o filtrata.\n\u2022 Verifica la connessione a Internet.\n\u2022 Verifica di aver digitato correttamente l\'indirizzo email.\n\u2022 Verifica di avere spazio sufficiente nella casella di posta in arrivo o che non vi siano altri problemi relativi alle impostazioni della casella di posta in arrivo.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Se le procedure descritte sopra non hanno risolto il problema, puoi inviare nuovamente l\'email. Tieni presente che questo disattiverà il link contenuto nell\'email precedente.</string>
     <string name="fui_email_link_resend">Invia di nuovo</string>
     <string name="fui_email_link_wrong_device_header">Rilevato nuovo dispositivo o browser</string>
     <string name="fui_email_link_wrong_device_message">Prova ad aprire il link utilizzando lo stesso dispositivo o browser dal quale hai iniziato la procedura di accesso.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Conferma l\'indirizzo email per proseguire con l\'accesso</string>
     <string name="fui_email_link_dismiss_button">Ignora</string>
     <string name="fui_email_link_cross_device_linking_text">Inizialmente intendevi collegare %1$s al tuo account email, ma hai aperto il link su un altro dispositivo, sul quale non hai eseguito l\'accesso.\n\nSe vuoi continuare a collegare l\'account su %1$s, apri il link sullo stesso dispositivo su cui hai iniziato la procedura di accesso. Altrimenti, tocca Continua per accedere su questo dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Accedi con %1$s</string>
     <string name="fui_verify_phone_number_title">Inserisci il numero di telefono</string>
     <string name="fui_invalid_phone_number">Inserisci un numero di telefono valido</string>
     <string name="fui_enter_confirmation_code">Inserisci il codice a 6 cifre che abbiamo inviato al numero</string>

--- a/auth/src/main/res/values-iw/strings.xml
+++ b/auth/src/main/res/values-iw/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">טוען…</string>
     <string name="fui_sign_in_default">כניסה</string>
-    <string name="fui_cancel">ביטול</string>
     <string name="fui_continue">המשך</string>
     <string name="fui_tos_and_pp">המשך התהליך יפורש כהסכמתך ל%1$s ול%2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">אימייל לכניסה לחשבון עם הוראות נוספות נשלח אל %1$s. יש לבדוק את תיבת הדואר הנכנס כדי להשלים את תהליך הכניסה.</string>
     <string name="fui_email_link_trouble_getting_email_header">נתקלת בבעיה בקבלת האימייל?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">כדי לנסות לפתור את הבעיה, מומלץ:‎\n\u2022 לבדוק אם האימייל סומן כספאם או סונן.‎\n\u2022 לבדוק את החיבור לאינטרנט.‎\n\u2022 לוודא שכתובת האימייל אויתה בצורה תקינה.‎\n\u2022 לוודא שהשטח הפנוי בתיבת הדואר הנכנס אינו עומד להסתיים, או לבדוק בעיות אחרות שקשורות להגדרות של תיבת הדואר הנכנס.‎\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">אם השלבים המפורטים למעלה לא פותרים את הבעיה, אפשר לשלוח מחדש את האימייל. לתשומת ליבך: שליחת האימייל מחדש תשבית את הקישור באימייל הקודם.</string>
     <string name="fui_email_link_resend">שליחה מחדש</string>
     <string name="fui_email_link_wrong_device_header">זוהו מכשיר או דפדפן חדשים.</string>
     <string name="fui_email_link_wrong_device_message">מומלץ לפתוח את הקישור באמצעות אותו מכשיר או דפדפן שבהם התחלת את תהליך הכניסה.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">יש לאשר את כתובת האימייל כדי להמשיך בתהליך הכניסה</string>
     <string name="fui_email_link_dismiss_button">סגירה</string>
     <string name="fui_email_link_cross_device_linking_text">כוונתך המקורית הייתה לקשר את חשבון %1$s לחשבון שלך, אבל פתחת את הקישור במכשיר אחר שממנו לא נכנסת לחשבון.\n\nבכל זאת רוצה לקשר את חשבון %1$s לחשבון שלך? אם כן, יש לפתוח את הקישור באותו מכשיר שבו התחלת את תהליך הכניסה. אם לא, יש להקיש על \'המשך\' כדי להיכנס לחשבון במכשיר הזה.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">כניסה באמצעות %1$s</string>
     <string name="fui_verify_phone_number_title">הזן את מספר הטלפון שלך</string>
     <string name="fui_invalid_phone_number">מספר הטלפון שהזנת לא תקין</string>
     <string name="fui_enter_confirmation_code">הזן את הקוד בן 6 הספרות ששלחנו אל</string>

--- a/auth/src/main/res/values-ja/strings.xml
+++ b/auth/src/main/res/values-ja/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">読み込んでいます…</string>
     <string name="fui_sign_in_default">ログイン</string>
-    <string name="fui_cancel">キャンセル</string>
     <string name="fui_continue">続行</string>
     <string name="fui_tos_and_pp">続行すると、%1$s と %2$s に同意したことになります。</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">詳細な説明を記載したログインメールを %1$s に送信しました。メールを確認してログインを完了してください。</string>
     <string name="fui_email_link_trouble_getting_email_header">メールが受信できない場合</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">以下の一般的な解決方法をお試しください。\n\u2022 メールがスパムに分類されたりフィルタされたりしていないか確認する。\n\u2022 インターネットの接続を確認する。\n\u2022 メールアドレスのスペルに誤りがないか確認する。\n\u2022 受信トレイの容量不足や、設定関連のその他の問題がないか確認する。\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">上記の手順で解決しなかった場合はメールを再送信できます。メールを再送信すると、前回のメールに記載されたリンクは無効になります。</string>
     <string name="fui_email_link_resend">再送信</string>
     <string name="fui_email_link_wrong_device_header">新しいデバイスまたはブラウザが検出されました。</string>
     <string name="fui_email_link_wrong_device_message">ログイン プロセスを開始したときと同じデバイスまたはブラウザを使用してリンクを開いてみてください。</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">ログインを続行するにはメールを確認してください</string>
     <string name="fui_email_link_dismiss_button">閉じる</string>
     <string name="fui_email_link_cross_device_linking_text">元々は %1$s をメール アカウントに接続しようとしましたが、ログインしていないデバイスでリンクが開かれました。%1$s アカウントの接続を続行する場合は、ログインを開始したデバイスでリンクを開いてください。接続しない場合は、[続行] をタップしてこのデバイスでログインします。</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">%1$s でログイン</string>
     <string name="fui_verify_phone_number_title">電話番号を入力してください</string>
     <string name="fui_invalid_phone_number">有効な電話番号を入力してください</string>
     <string name="fui_enter_confirmation_code">送信された 6 桁のコードを入力してください</string>

--- a/auth/src/main/res/values-kn/strings.xml
+++ b/auth/src/main/res/values-kn/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">ಲೋಡ್‌ ಮಾಡಲಾಗುತ್ತಿದೆ…</string>
     <string name="fui_sign_in_default">ಸೈನ್ ಇನ್‌</string>
-    <string name="fui_cancel">ರದ್ದುಮಾಡಿ</string>
     <string name="fui_continue">ಮುಂದುವರಿಸಿ</string>
     <string name="fui_tos_and_pp">ಮುಂದುವರಿಸುವ ಮೂಲಕ, ನೀವು ನಮ್ಮ %1$s ಮತ್ತು %2$s ಸ್ವೀಕರಿಸುತ್ತೀರಿ ಎಂದು ನೀವು ಸೂಚಿಸುತ್ತಿರುವಿರಿ</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">%1$s ಇಮೇಲ್‌ಗೆ ಹೆಚ್ಚುವರಿ ಸೂಚನೆಗಳನ್ನು ಹೊಂದಿರುವ ಸೈನ್-ಇನ್ ಇಮೇಲ್ ಅನ್ನು ಕಳುಹಿಸಲಾಗಿದೆ. ಸೈನ್-ಇನ್ ಪೂರ್ಣಗೊಳಿಸಲು ನಿಮ್ಮ ಇಮೇಲ್ ಅನ್ನು ಪರಿಶೀಲಿಸಿ.</string>
     <string name="fui_email_link_trouble_getting_email_header">ಇಮೇಲ್ ಪಡೆಯುವಲ್ಲಿ ಸಮಸ್ಯೆ ಉಂಟಾಗುತ್ತಿದೆಯೇ?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">ಈ ಸಾಮಾನ್ಯ ಪರಿಹಾರಗಳನ್ನು ಪ್ರಯತ್ನಿಸಿ:\n\u2022 ಇಮೇಲ್ ಅನ್ನು ಸ್ಪ್ಯಾಮ್ ಎಂದು ಗುರುತು ಮಾಡಲಾಗಿದೆಯೇ ಅಥವಾ ಫಿಲ್ಟರ್ ಮಾಡಲಾಗಿದೆಯೇ ಎಂದು ಪರಿಶೀಲಿಸಿ.\n\u2022 ನಿಮ್ಮ ಇಂಟರ್ನೆಟ್ ಸಂಪರ್ಕವನ್ನು ಪರಿಶೀಲಿಸಿ.\n\u2022 ನಿಮ್ಮ ಇಮೇಲ್‌ನ ಕಾಗುಣಿತವನ್ನು ಸರಿಯಾಗಿ ನಮೂದಿಸಿರುವಿರಾ ಎಂಬುದನ್ನು ಪರಿಶೀಲಿಸಿ.\n\u2022 ನಿಮ್ಮ ಇನ್‌ಬಾಕ್ಸ್ ಸಂಗ್ರಹಣೆಯು ಭರ್ತಿಯಾಗದಿರುವುದನ್ನು ಅಥವಾ ಇತರ ಇನ್‌ಬಾಕ್ಸ್ ಸೆಟ್ಟಿಂಗ್‌ಗಳಿಗೆ ಸಂಬಂಧಿಸಿದ ಸಮಸ್ಯೆಗಳನ್ನು ಪರಿಶೀಲಿಸಿ.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">ಮೇಲಿನ ಹಂತಗಳು ಕಾರ್ಯನಿರ್ವಹಿಸದಿದ್ದಲ್ಲಿ, ನೀವು ಇಮೇಲ್ ಅನ್ನು ಪುನಃ ಕಳುಹಿಸಬಹುದು. ಇದು ಹಳೆಯ ಇಮೇಲ್‌ನಲ್ಲಿರುವ ಲಿಂಕ್ ಅನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸುತ್ತದೆ ಎಂಬುದನ್ನು ಗಮನಿಸಿ.</string>
     <string name="fui_email_link_resend">ಪುನಃ ಕಳುಹಿಸಿ</string>
     <string name="fui_email_link_wrong_device_header">ಹೊಸ ಸಾಧನ ಅಥವಾ ಬ್ರೌಸರ್ ಪತ್ತೆಯಾಗಿದೆ.</string>
     <string name="fui_email_link_wrong_device_message">ನೀವು ಸೈನ್ ಇನ್ ಪ್ರಕ್ರಿಯೆಯನ್ನು ಪ್ರಾರಂಭಿಸಿದ ಸಾಧನ ಅಥವಾ ಬ್ರೌಸರ್ ಅನ್ನು ಬಳಸಿಕೊಂಡು ಲಿಂಕ್ ತೆರೆಯಲು ಪ್ರಯತ್ನಿಸಿ.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">ಸೈನ್ ಇನ್ ಮುಂದುವರಿಸಲು ಇಮೇಲ್ ದೃಢೀಕರಿಸಿ</string>
     <string name="fui_email_link_dismiss_button">ವಜಾಗೊಳಿಸಿ</string>
     <string name="fui_email_link_cross_device_linking_text">ನೀವು ಮೂಲತಃ %1$s ಅನ್ನು ನಿಮ್ಮ ಇಮೇಲ್ ಜೊತೆಗೆ ಸಂಪರ್ಕಿಸಲು ಬಯಸಿದ್ದೀರಿ ಆದರೆ ನೀವು ಸೈನ್ ಇನ್ ಮಾಡದಿರುವ ಬೇರೆ ಸಾಧನದಲ್ಲಿ ಲಿಂಕ್ ಅನ್ನು ತೆರೆದಿದ್ದೀರಿ.n\nನಿಮ್ಮ %1$s ಖಾತೆಯನ್ನು ಇನ್ನೂ ನೀವು ಸಂಪರ್ಕಿಸಲು ಬಯಸಿದರೆ, ನೀವು ಸೈನ್ ಇನ್ ಮಾಡದೇ ಇರುವ ಅದೇ ಸಾಧನದಲ್ಲಿ ಲಿಂಕ್ ತೆರೆಯಿರಿ. ಇಲ್ಲದಿದ್ದರೆ ಈ ಸಾಧನದಲ್ಲಿ ಸೈನ್ ಇನ್ ಮಾಡಲು ಮುಂದುವರಿಸಿ ಟ್ಯಾಪ್ ಮಾಡಿ.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">%1$s ಸಹಾಯದೊಂದಿಗೆ ಸೈನ್ ಇನ್ ಮಾಡಿ</string>
     <string name="fui_verify_phone_number_title">ನಿಮ್ಮ ಫೋನ್‌ ಸಂಖ್ಯೆಯನ್ನು ನಮೂದಿಸಿ</string>
     <string name="fui_invalid_phone_number">ಮಾನ್ಯವಾದ ಫೋನ್ ಸಂಖ್ಯೆಯನ್ನು ನಮೂದಿಸಿ</string>
     <string name="fui_enter_confirmation_code">ನಾವು ಕಳುಹಿಸಿರುವ 6 ಅಂಕಿಯ ಕೋಡ್‌ ನಮೂದಿಸಿ</string>

--- a/auth/src/main/res/values-ko/strings.xml
+++ b/auth/src/main/res/values-ko/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">로드 중…</string>
     <string name="fui_sign_in_default">로그인</string>
-    <string name="fui_cancel">취소</string>
     <string name="fui_continue">계속</string>
     <string name="fui_tos_and_pp">계속 진행하면 %1$s 및 %2$s에 동의하는 것으로 간주됩니다.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">추가 안내가 포함된 로그인 이메일이 %1$s(으)로 전송되었습니다. 이메일을 확인하여 로그인을 완료하세요.</string>
     <string name="fui_email_link_trouble_getting_email_header">이메일을 받는 데 문제가 있나요?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">다음의 일반적인 해결방법을 시도해 보세요.\n\u2022 이메일이 스팸으로 표시되었거나 필터링되었는지 확인합니다.\n\u2022 인터넷 연결을 확인합니다.\n\u2022 이메일을 잘못 입력하지 않았는지 확인합니다.\n\u2022 받은편지함 용량이 다 찼거나 받은편지함 설정과 관련된 문제가 있는 것이 아닌지 확인합니다.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">위의 단계로 문제가 해결되지 않으면 이메일을 다시 전송하실 수 있습니다. 이 경우 이전 이메일의 링크는 비활성화됩니다.</string>
     <string name="fui_email_link_resend">재전송</string>
     <string name="fui_email_link_wrong_device_header">새 기기 또는 브라우저 감지됨</string>
     <string name="fui_email_link_wrong_device_message">로그인 절차를 시작하는 데 사용한 것과 동일한 기기나 브라우저로 링크를 열어 보세요.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">계속해서 로그인하려면 이메일을 확인하세요.</string>
     <string name="fui_email_link_dismiss_button">닫기</string>
     <string name="fui_email_link_cross_device_linking_text">원래 이메일 계정에 %1$s을(를) 연결하려고 했지만 로그인되지 않은 다른 기기에서 링크를 열었습니다.\n\n%1$s 계정에 연결하려는 경우 로그인을 시작한 것과 동일한 기기에서 링크를 여세요. 또는 \'계속\'을 탭하여 이 기기에서 로그인하세요.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">%1$s(으)로 로그인</string>
     <string name="fui_verify_phone_number_title">전화번호 입력</string>
     <string name="fui_invalid_phone_number">올바른 전화번호를 입력하세요.</string>
     <string name="fui_enter_confirmation_code">전송된 6자리 코드를 입력하세요.</string>

--- a/auth/src/main/res/values-ln/strings.xml
+++ b/auth/src/main/res/values-ln/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Chargement…</string>
     <string name="fui_sign_in_default">Se connecter</string>
-    <string name="fui_cancel">Annuler</string>
     <string name="fui_continue">Continuer</string>
     <string name="fui_tos_and_pp">En continuant, vous acceptez les %1$s et les %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s   %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Un e-mail de connexion avec des instructions supplémentaires a été envoyé à %1$s. Consultez cet e-mail pour vous connecter.</string>
     <string name="fui_email_link_trouble_getting_email_header">Vous n\'avez pas reçu l\'e-mail ?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Essayez les solutions courantes suivantes :\n\u2022 Vérifiez que l\'e-mail n\'a ni été marqué comme spam ni été filtré.\n\u2022 Vérifiez votre connexion Internet.\n\u2022 Vérifiez que votre adresse e-mail est correcte.\n\u2022 Vérifiez que votre boîte de réception n\'est pas pleine et que les paramètres sont correctement définis.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Si les étapes décrites plus haut n\'ont pas résolu le problème, vous pouvez renvoyer l\'e-mail. Sachez que le lien du premier e-mail sera alors désactivé.</string>
     <string name="fui_email_link_resend">Renvoyer</string>
     <string name="fui_email_link_wrong_device_header">Nouveau navigateur ou nouvel appareil détecté</string>
     <string name="fui_email_link_wrong_device_message">Essayez d\'ouvrir le lien en utilisant le même appareil ou navigateur que celui sur lequel vous avez commencé le processus de connexion.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirmez votre adresse e-mail pour vous connecter</string>
     <string name="fui_email_link_dismiss_button">Ignorer</string>
     <string name="fui_email_link_cross_device_linking_text">Vous aviez décidé d\'associer votre compte %1$s à votre adresse e-mail, mais vous avez ouvert le lien sur un appareil différent de celui avec lequel vous vous êtes connecté.\n\nSi vous souhaitez toujours associer votre compte %1$s, ouvrez le lien sur l\'appareil avec lequel vous avez commencé à vous connecter. Sinon, appuyez sur \"Continuer\" pour vous connecter depuis un autre appareil.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Se connecter avec %1$s</string>
     <string name="fui_verify_phone_number_title">Saisissez votre numéro de téléphone</string>
     <string name="fui_invalid_phone_number">Saisissez un numéro de téléphone valide</string>
     <string name="fui_enter_confirmation_code">Saisissez le code à six chiffres envoyé au</string>

--- a/auth/src/main/res/values-lt/strings.xml
+++ b/auth/src/main/res/values-lt/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Įkeliama…</string>
     <string name="fui_sign_in_default">Prisijungti</string>
-    <string name="fui_cancel">Atšaukti</string>
     <string name="fui_continue">Tęsti</string>
     <string name="fui_tos_and_pp">Tęsdami nurodote, kad sutinkate su %1$s ir %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Prisijungimo el. laiškas su papildomomis instrukcijomis išsiųstas adresu %1$s. Patikrinkite el. paštą, kad užbaigtumėte prisijungimą.</string>
     <string name="fui_email_link_trouble_getting_email_header">Negaunate el. laiško?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Išbandykite šiuos dažnai kylančių problemų sprendimo būdus:\n\u2022 patikrinkite, ar el. laiškas nebuvo pažymėtas kaip šlamštas arba filtruotas;\n\u2022 patikrinkite interneto ryšį;\n\u2022 patikrinkite, ar nurodėte tikslų el. pašto adresą;\n\u2022 patikrinkite, ar nepasibaigė gautiesiems skirta saugyklos vieta arba kitas su gautųjų nustatymais susijusias problemas.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Jei ankstesni veiksmai nebuvo naudingi, galite iš naujo išsiųsti el. laišką. Atkreipkite dėmesį, kad šiuo veiksmu bus išaktyvinta ankstesniame el. laiške pateikta nuoroda.</string>
     <string name="fui_email_link_resend">Siųsti iš naujo</string>
     <string name="fui_email_link_wrong_device_header">Aptiktas naujas įrenginys arba naršyklė.</string>
     <string name="fui_email_link_wrong_device_message">Bandykite atidaryti nuorodą naudodami tą patį įrenginį ar naršyklę, kur pradėjote prisijungimo procesą.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Patvirtinkite el. paštą, kad galėtumėte tęsti prisijungimą</string>
     <string name="fui_email_link_dismiss_button">Atsisakyti</string>
     <string name="fui_email_link_cross_device_linking_text">Iš pradžių ketinote susieti %1$s ir el. pašto paskyras, bet atidarėte nuorodą kitame įrenginyje, kuriame nesate prisijungę.\n\nJei vis tiek norite susieti %1$s paskyrą, atidarykite nuorodą tame pačiame įrenginyje, kuriame pradėjote prisijungimo procesą. Jei nenorite, palieskite „Tęsti“ ir prisijunkite šiame įrenginyje.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Prisijungti per „%1$s“</string>
     <string name="fui_verify_phone_number_title">Įveskite telefono numerį</string>
     <string name="fui_invalid_phone_number">Įveskite tinkamą telefono numerį</string>
     <string name="fui_enter_confirmation_code">Įveskite 6 skaitmenų kodą, kurį išsiuntėme</string>

--- a/auth/src/main/res/values-lv/strings.xml
+++ b/auth/src/main/res/values-lv/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Notiek ielāde…</string>
     <string name="fui_sign_in_default">Pierakstīties</string>
-    <string name="fui_cancel">Atcelt</string>
     <string name="fui_continue">Tālāk</string>
     <string name="fui_tos_and_pp">Turpinot jūs norādāt, ka piekrītat šādiem dokumentiem: %1$s un %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Pierakstīšanās e-pasta ziņojums ar papildu norādījumiem tika nosūtīts uz e-pasta adresi %1$s. Pārbaudiet savu e-pastu, lai pabeigtu pierakstīšanos.</string>
     <string name="fui_email_link_trouble_getting_email_header">Vai jums ir problēmas ar e-pasta ziņojuma saņemšanu?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Izmēģiniet tālāk norādītās tipiskās problēmu novēršanas iespējas.\n\u2022 Pārbaudiet, vai e-pasta ziņojums nav atzīmēts kā mēstule vai nav filtrēts.\n\u2022 Pārbaudiet interneta savienojumu.\n\u2022 Pārbaudiet, vai e-pasta adrese ir pareizi uzrakstīta.\n\u2022 Pārbaudiet, vai jūsu iesūtnes krātuve nav beigusies vai nav citu ar iesūtnes iestatījumiem saistītu problēmu.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Ja iepriekš minētās darbības nepalīdzēja, varat atkārtoti nosūtīt e-pasta ziņojumu. Ņemiet vērā: tiks deaktivizēta saite no iepriekšējā e-pasta ziņojuma.</string>
     <string name="fui_email_link_resend">Sūtīt vēlreiz</string>
     <string name="fui_email_link_wrong_device_header">Konstatēta jauna ierīce vai pārlūkprogramma.</string>
     <string name="fui_email_link_wrong_device_message">Mēģiniet atvērt saiti, izmantot to pašu ierīci vai pārlūkprogrammu, kur sākāt pierakstīšanās procesu.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Lai turpinātu pierakstīšanos, apstipriniet e-pasta adresi.</string>
     <string name="fui_email_link_dismiss_button">Nerādīt</string>
     <string name="fui_email_link_cross_device_linking_text">Sākotnēji vēlējāties saistīt %1$s ar savu e-pasta kontu, tomēr saiti atvērāt citā ierīcē, kurā neesat pierakstījies.\n\nJa joprojām vēlaties saistīt savu %1$s kontu, atveriet saiti tajā pašā ierīcē, kurā sākāt pierakstīšanos. Pretējā gadījumā pieskarieties vienumam Turpināt, lai pierakstītos šajā ierīcē.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Pierakstieties ar %1$s</string>
     <string name="fui_verify_phone_number_title">Ievadiet savu tālruņa numuru</string>
     <string name="fui_invalid_phone_number">Ievadiet derīgu tālruņa numuru</string>
     <string name="fui_enter_confirmation_code">Ievadiet 6 ciparu kodu, ko nosūtījām</string>

--- a/auth/src/main/res/values-mo/strings.xml
+++ b/auth/src/main/res/values-mo/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Se încarcă…</string>
     <string name="fui_sign_in_default">Conectați-vă</string>
-    <string name="fui_cancel">Anulați</string>
     <string name="fui_continue">Continuați</string>
     <string name="fui_tos_and_pp">Dacă alegeți să continuați, sunteți de acord cu %1$s și cu %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Un e-mail de conectare cu instrucțiuni suplimentare a fost trimis la %1$s. Verificați-vă căsuța de e-mail pentru a finaliza conectarea.</string>
     <string name="fui_email_link_trouble_getting_email_header">Nu primiți e-mailuri?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Încercați aceste soluții folosite frecvent:\n\u2022 verificați dacă e-mailul a fost marcat ca spam sau filtrat;\n\u2022 verificați conexiunea la internet;\n\u2022 verificați dacă ați scris corect adresa de e-mail;\n\u2022 verificați dacă aveți spațiu în căsuța de e-mail sau dacă există alte probleme legate de setările căsuței de e-mail.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Dacă pașii de mai sus nu funcționează, puteți să trimiteți din nou e-mailul. Rețineți că va fi dezactivat linkul din e-mailul anterior.</string>
     <string name="fui_email_link_resend">Retrimiteți</string>
     <string name="fui_email_link_wrong_device_header">A fost detectat un nou dispozitiv sau browser.</string>
     <string name="fui_email_link_wrong_device_message">Încercați să accesați linkul folosind același dispozitiv sau browser pe care ați început procesul de conectare.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirmați adresa de e-mail pentru a continua conectarea</string>
     <string name="fui_email_link_dismiss_button">Închideți</string>
     <string name="fui_email_link_cross_device_linking_text">Inițial ați intenționat să conectați %1$s la contul de e-mail, dar ați deschis linkul pe un dispozitiv pe care nu sunteți conectat(ă).\n\nDacă doriți să continuați conectarea contului %1$s, deschideți linkul pe același dispozitiv pe care ați început conectarea. În caz contrar, atingeți Continuați pentru a vă conecta pe acest dispozitiv.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Conectați-vă cu %1$s</string>
     <string name="fui_verify_phone_number_title">Introduceți numărul de telefon</string>
     <string name="fui_invalid_phone_number">Introduceți un număr valid de telefon</string>
     <string name="fui_enter_confirmation_code">Introduceți codul din 6 cifre pe care l-am trimis la</string>

--- a/auth/src/main/res/values-mr/strings.xml
+++ b/auth/src/main/res/values-mr/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">लोड करत आहे…</string>
     <string name="fui_sign_in_default">साइन इन करा</string>
-    <string name="fui_cancel">रद्द करा</string>
     <string name="fui_continue">सुरू ठेवा</string>
     <string name="fui_tos_and_pp">पुढे सुरू ठेवून, तुम्ही सूचित करता की तुम्ही आमचे %1$s आणि %2$s स्वीकारता.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">तिरिक्त सूचना असलेला साइन इन ईमेल %1$s ला पाठवला होता. साइन इन पूर्ण करण्यासाठी तुमचा ईमेल तपासा.</string>
     <string name="fui_email_link_trouble_getting_email_header">ईमेल मिळवण्यात समस्या येत आहे?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">या सामान्य निराकरणासाठी प्रयत्न करा:\n\u2022 ईमेल स्पॅम म्हणून चिन्हांकित केले गेले आहे किंवा फिल्टर केलेले आहे का ते तपासा. \n\u2022 तुमचे इंटरनेट कनेक्शन तपासा.\n\u2022 तुम्ही तुमच्या ईमेलचे चुकीचे शब्दलेखन केले नाही हे तपासा.\n\u2022 तुमच्या इनबॉक्सची जागा तपासा, ती संपत नाही किंवा इतर इनबॉक्स सेटिंग संबंधित समस्या नाहीत ना हे तपसा.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">वरील पायरी करून उपयोग झाला नसल्यास, तुम्ही ईमेल पुन्हा पाठवू शकता. लक्षात ठेवा की, यामुळे जुन्या ईमेलमधील लिंक निष्क्रिय केली जाईल.</string>
     <string name="fui_email_link_resend">पुन्हा पाठवा</string>
     <string name="fui_email_link_wrong_device_header">नवीन डिव्हाइस किंवा ब्राउझर आढळला.</string>
     <string name="fui_email_link_wrong_device_message">समान डिव्हाइस किंवा तुम्ही साइन इन प्रक्रिया सुरू केलेला ब्राउझर वापरून लिंक उघडण्याचा प्रयत्न करा.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">साइन इन करणे सुरू ठेवण्यासाठी ईमेलची खात्री करा</string>
     <string name="fui_email_link_dismiss_button">डिसमिस करा</string>
     <string name="fui_email_link_cross_device_linking_text">तुमचे ईमेल खाते %1$s सह कनेक्ट करणे हा तुमचा मूळ उद्देश होता पण तुम्ही साइन इन न केलेल्या वेगळ्या डिव्हाइसवर लिंक उघडली आहे. \n\nतुम्हाला तरीही तुमचे %1$s खाते कनेक्ट करायचे असल्यास, तुम्ही साइन इन सुरू केले त्याच डिव्हाइसवर लिंक उघडा. नाहीतर, या डिव्हाइसवर साइन इन करण्यासाठी सुरू ठेवा वर टॅप करा.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">%1$s सह साइन इन करा</string>
     <string name="fui_verify_phone_number_title">तुमचा फोन नंबर टाका</string>
     <string name="fui_invalid_phone_number">कृपया वैध फोन नंबर टाका</string>
     <string name="fui_enter_confirmation_code">वर आम्ही पाठवलेला 6 अंकी कोड टाका</string>

--- a/auth/src/main/res/values-ms/strings.xml
+++ b/auth/src/main/res/values-ms/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Memuatkan…</string>
     <string name="fui_sign_in_default">Log masuk</string>
-    <string name="fui_cancel">Batal</string>
     <string name="fui_continue">Teruskan</string>
     <string name="fui_tos_and_pp">Dengan meneruskan, anda menyatakan bahawa anda menerima %1$s dan %2$s kami.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">E-mel log masuk dengan arahan tambahan telah dihantar ke %1$s. Semak e-mel anda untuk melengkapkan log masuk.</string>
     <string name="fui_email_link_trouble_getting_email_header">Tidak menerima e-mel?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Cuba pembetulan lazim berikut:\n\u2022 Pastikan e-mel tidak ditandakan sebagai spam atau ditapis.\n\u2022 Semak sambungan Internet anda.\n\u2022 Pastikan e-mel anda dieja dengan betul.\n\u2022 Pastikan peti masuk anda tidak kehabisan ruang atau tiada isu berkaitan tetapan peti masuk yang lain.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Jika langkah di atas tidak boleh digunakan, anda boleh menghantar semula e-mel. Sila ambil perhatian bahawa tindakan ini akan menyahaktifkan pautan dalam e-mel sebelumnya.</string>
     <string name="fui_email_link_resend">Hantar semula</string>
     <string name="fui_email_link_wrong_device_header">Peranti atau penyemak imbas baharu telah dikesan.</string>
     <string name="fui_email_link_wrong_device_message">Cuba buka pautan menggunakan peranti atau penyemak imbas sama yang anda gunakan untuk memulakan proses log masuk.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Sahkan e-mel untuk meneruskan log masuk</string>
     <string name="fui_email_link_dismiss_button">Ketepikan</string>
     <string name="fui_email_link_cross_device_linking_text">Pada asalnya, anda mahu menyambungkan %1$s kepada akaun e-mel anda tetapi telah membuka pautan pada peranti berbeza yang tidak dilog masuk.\n\nJika anda masih mahu memautkan akaun %1$s anda, buka pautan pada peranti yang anda gunakan untuk log masuk. Jika tidak, ketik Teruskan untuk log masuk pada peranti ini.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Log masuk dengan %1$s</string>
     <string name="fui_verify_phone_number_title">Masukkan nombor telefon anda</string>
     <string name="fui_invalid_phone_number">Masukkan nombor telefon yang sah</string>
     <string name="fui_enter_confirmation_code">Masukkan kod 6 digit yang kami hantar ke</string>

--- a/auth/src/main/res/values-nb/strings.xml
+++ b/auth/src/main/res/values-nb/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Laster inn…</string>
     <string name="fui_sign_in_default">Logg på</string>
-    <string name="fui_cancel">Avbryt</string>
     <string name="fui_continue">Fortsett</string>
     <string name="fui_tos_and_pp">Ved å fortsette godtar du %1$s og %2$s våre.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">En påloggings-e-post med ytterligere veiledning er sendt til %1$s. Sjekk e-posten din for å fullføre påloggingen.</string>
     <string name="fui_email_link_trouble_getting_email_header">Problemer med å motta e-posten?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prøv disse vanlige løsningene:\n\u2022 Sjekk om e-posten ble merket som søppelpost eller filtrert bort.\n\u2022 Sjekk internettilkoblingen din.\n\u2022 Sjekk at du ikke har skrevet e-postadressen din feil.\n\u2022 Sjekk at innboksen din ikke er full, og se etter andre problemer knyttet til innboksinnstillingene.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Hvis trinnene ovenfor ikke bidro til å løse problemet, kan du sende e-posten på nytt. Merk at denne handlingen deaktiverer linken i den forrige e-posten.</string>
     <string name="fui_email_link_resend">Send på nytt</string>
     <string name="fui_email_link_wrong_device_header">Ny enhet eller nettleser er registrert.</string>
     <string name="fui_email_link_wrong_device_message">Prøv å åpne linken med den samme enheten eller nettleseren som du brukte til å starte påloggingsprosessen.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Bekreft e-postadressen for å fortsette med påloggingen</string>
     <string name="fui_email_link_dismiss_button">Lukk</string>
     <string name="fui_email_link_cross_device_linking_text">Du forsøkte opprinnelig å koble %1$s til e-postkontoen din, men du åpnet linken på en annen enhet enn den du er pålogget med.\n\nHvis du fortsatt ønsker å koble til %1$s-kontoen din, åpner du linken på enheten du er pålogget med. Hvis ikke trykker du på Fortsett for å logge på med denne enheten.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Logg på med %1$s</string>
     <string name="fui_verify_phone_number_title">Oppgi telefonnummeret ditt</string>
     <string name="fui_invalid_phone_number">Oppgi et gyldig telefonnummer</string>
     <string name="fui_enter_confirmation_code">Oppgi den 6-sifrede koden vi sendte til</string>

--- a/auth/src/main/res/values-nl/strings.xml
+++ b/auth/src/main/res/values-nl/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Laden…</string>
     <string name="fui_sign_in_default">Inloggen</string>
-    <string name="fui_cancel">Annuleren</string>
     <string name="fui_continue">Doorgaan</string>
     <string name="fui_tos_and_pp">Als u doorgaat, geeft u aan dat u onze %1$s en ons %2$s accepteert.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Er is een inlogmail met aanvullende instructies verzonden naar %1$s. Controleer uw inbox om het inlogproces te voltooien.</string>
     <string name="fui_email_link_trouble_getting_email_header">E-mail niet ontvangen?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Probeer deze algemene oplossingen:\n\u2022 Controleer of de e-mail als spam is gemarkeerd of is weggefilterd.\n\u2022 Controleer uw internetverbinding.\n\u2022 Controleer of u uw e-mailadres juist heeft gespeld.\n\u2022 Controleer of er voldoende ruimte in uw inbox is en of er geen andere problemen met inboxinstellingen zijn.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Als de bovenstaande stappen geen uitkomst bieden, kunt u de e-mail opnieuw verzenden. Hiermee wordt de link in de eerdere e-mail gedeactiveerd.</string>
     <string name="fui_email_link_resend">Opnieuw verzenden</string>
     <string name="fui_email_link_wrong_device_header">Nieuw apparaat of nieuwe browser gedetecteerd.</string>
     <string name="fui_email_link_wrong_device_message">Probeer de link te openen op het apparaat of in de browser waarmee u het inlogproces bent gestart.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Bevestig uw e-mailadres om door te gaan met inloggen</string>
     <string name="fui_email_link_dismiss_button">Afwijzen</string>
     <string name="fui_email_link_cross_device_linking_text">U wilde aanvankelijk %1$s aan uw e-mailaccount koppelen, maar u heeft de link geopend op een andere apparaat, waarop u niet ingelogd bent.\n\nAls u nog steeds verbinding wilt maken met uw %1$s-account, opent u de link op het apparaat waarop u het inlogproces bent gestart. Tik anders op Doorgaan om in te loggen op dit apparaat.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Inloggen met %1$s</string>
     <string name="fui_verify_phone_number_title">Voer uw telefoonnummer in</string>
     <string name="fui_invalid_phone_number">Voer een geldig telefoonnummer in</string>
     <string name="fui_enter_confirmation_code">Voer de zescijferige code in die we hebben verzonden naar</string>

--- a/auth/src/main/res/values-no/strings.xml
+++ b/auth/src/main/res/values-no/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Laster inn…</string>
     <string name="fui_sign_in_default">Logg på</string>
-    <string name="fui_cancel">Avbryt</string>
     <string name="fui_continue">Fortsett</string>
     <string name="fui_tos_and_pp">Ved å fortsette godtar du %1$s og %2$s våre.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">En påloggings-e-post med ytterligere veiledning er sendt til %1$s. Sjekk e-posten din for å fullføre påloggingen.</string>
     <string name="fui_email_link_trouble_getting_email_header">Problemer med å motta e-posten?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prøv disse vanlige løsningene:\n\u2022 Sjekk om e-posten ble merket som søppelpost eller filtrert bort.\n\u2022 Sjekk internettilkoblingen din.\n\u2022 Sjekk at du ikke har skrevet e-postadressen din feil.\n\u2022 Sjekk at innboksen din ikke er full, og se etter andre problemer knyttet til innboksinnstillingene.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Hvis trinnene ovenfor ikke bidro til å løse problemet, kan du sende e-posten på nytt. Merk at denne handlingen deaktiverer linken i den forrige e-posten.</string>
     <string name="fui_email_link_resend">Send på nytt</string>
     <string name="fui_email_link_wrong_device_header">Ny enhet eller nettleser er registrert.</string>
     <string name="fui_email_link_wrong_device_message">Prøv å åpne linken med den samme enheten eller nettleseren som du brukte til å starte påloggingsprosessen.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Bekreft e-postadressen for å fortsette med påloggingen</string>
     <string name="fui_email_link_dismiss_button">Lukk</string>
     <string name="fui_email_link_cross_device_linking_text">Du forsøkte opprinnelig å koble %1$s til e-postkontoen din, men du åpnet linken på en annen enhet enn den du er pålogget med.\n\nHvis du fortsatt ønsker å koble til %1$s-kontoen din, åpner du linken på enheten du er pålogget med. Hvis ikke trykker du på Fortsett for å logge på med denne enheten.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Logg på med %1$s</string>
     <string name="fui_verify_phone_number_title">Oppgi telefonnummeret ditt</string>
     <string name="fui_invalid_phone_number">Oppgi et gyldig telefonnummer</string>
     <string name="fui_enter_confirmation_code">Oppgi den 6-sifrede koden vi sendte til</string>

--- a/auth/src/main/res/values-pl/strings.xml
+++ b/auth/src/main/res/values-pl/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Wczytuję…</string>
     <string name="fui_sign_in_default">Zaloguj się</string>
-    <string name="fui_cancel">Anuluj</string>
     <string name="fui_continue">Dalej</string>
     <string name="fui_tos_and_pp">Kontynuując, potwierdzasz, że akceptujesz te dokumenty: %1$s i %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Na adres %1$s wysłaliśmy wiadomość umożliwiającą zalogowanie się i dodatkowe instrukcje. Sprawdź pocztę, by się zalogować.</string>
     <string name="fui_email_link_trouble_getting_email_header">E-mail nie dotarł?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Typowe rozwiązania tego problemu:\n\u2022 Sprawdź, czy e-mail nie został oznaczony jako spam lub objęty którymś z filtrów.\n\u2022 Sprawdź połączenie z internetem.\n\u2022 Sprawdź, czy został wpisany poprawny adres e-mail.\n\u2022 Sprawdź, czy nie kończy się miejsce w skrzynce odbiorczej oraz czy nie ma innych problemów z jej ustawieniami.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Jeżeli wykonanie powyższych czynności nie dało żadnych rezultatów, możesz wysłać e-mail jeszcze raz. Link wysłany w poprzedniej wiadomości przestanie być aktywny.</string>
     <string name="fui_email_link_resend">Wyślij ponownie</string>
     <string name="fui_email_link_wrong_device_header">Wykryto nowe urządzenie lub nową przeglądarkę</string>
     <string name="fui_email_link_wrong_device_message">Otwórz link na tym samym urządzeniu, na którym rozpoczęto proces logowania i w tej samej przeglądarce.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Potwierdź adres e-mail, aby kontynuować logowanie się</string>
     <string name="fui_email_link_dismiss_button">Odrzuć</string>
     <string name="fui_email_link_cross_device_linking_text">Podjęto próbę połączenia konta %1$s z kontem, na którym używasz podanego adresu e-mail, ale link został otwarty na innym urządzeniu, na którym użytkownik nie był zalogowany.\n\nJeśli nadal chcesz połączyć konto w serwisie %1$s, otwórz link na urządzeniu, na którym rozpoczęto logowanie. W przeciwnym razie wybierz Dalej, by zalogować się na tym urządzeniu.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Zaloguj się przez: %1$s</string>
     <string name="fui_verify_phone_number_title">Wpisz numer telefonu</string>
     <string name="fui_invalid_phone_number">Wpisz prawidłowy numer telefonu</string>
     <string name="fui_enter_confirmation_code">Wpisz sześciocyfrowy kod, który wysłaliśmy na numer</string>

--- a/auth/src/main/res/values-pt-rBR/strings.xml
+++ b/auth/src/main/res/values-pt-rBR/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Carregando…</string>
     <string name="fui_sign_in_default">Fazer login</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Ao continuar, você concorda com nossos %1$s e a %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Um e-mail de login com mais instruções foi enviado para %1$s. Verifique sua caixa de entrada para concluir o login.</string>
     <string name="fui_email_link_trouble_getting_email_header">Problemas para receber e-mails?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Utilize estas soluções comuns:\n\u2022 Verifique se o e-mail foi filtrado ou marcado como spam\n\u2022 Verifique sua conexão com a Internet.\n\u2022 Verifique se você digitou seu e-mail corretamente.\n\u2022 Verifique se a sua caixa de entrada está cheia ou se ela está com outro tipo de problema.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Se as etapas acima não funcionarem, envie o e-mail novamente. Observação: isso desativará o link do e-mail anterior.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Novo dispositivo ou navegador detectado.</string>
     <string name="fui_email_link_wrong_device_message">Tente abrir o link usando o mesmo dispositivo ou navegador que você usou para iniciar o processo de login.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirme o e-mail para continuar o login</string>
     <string name="fui_email_link_dismiss_button">Dispensar</string>
     <string name="fui_email_link_cross_device_linking_text">Inicialmente, você quis conectar %1$s à sua conta de e-mail, mas abriu o link em outro dispositivo no qual você não está conectado.\n\nSe você ainda quiser conectar sua conta de %1$s, abra o link no mesmo dispositivo em que fez login. Se preferir, toque em \"Continuar\" para fazer login neste dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Fazer login com %1$s</string>
     <string name="fui_verify_phone_number_title">Insira o número do seu telefone</string>
     <string name="fui_invalid_phone_number">Insira um número de telefone válido</string>
     <string name="fui_enter_confirmation_code">Insira o código de 6 dígitos enviado para</string>

--- a/auth/src/main/res/values-pt-rPT/strings.xml
+++ b/auth/src/main/res/values-pt-rPT/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">A carregar…</string>
     <string name="fui_sign_in_default">Iniciar sessão</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Ao continuar, indica que aceita os %1$s e a %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s     %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Enviámos um email de início de sessão com instruções adicionais para %1$s. Consulte o seu email para concluir o início de sessão.</string>
     <string name="fui_email_link_trouble_getting_email_header">Está com problemas para receber emails?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Experimente estas correções comuns:\n\u2022 Verifique se o email foi assinalado como spam ou filtrado.\n\u2022 Verifique a ligação à Internet.\n\u2022 Certifique-se de que não introduziu o seu email incorretamente.\n\u2022 Certifique-se de que a sua caixa de entrada não está a ficar sem espaço disponível nem está com outros problemas relacionados com as definições da caixa de entrada.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Se os passos acima não resolverem o problema, pode reenviar o email. Tenha em atenção que esta ação desativa o link no email mais antigo.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Novo dispositivo ou navegador detetado.</string>
     <string name="fui_email_link_wrong_device_message">Experimente abrir o link através do mesmo dispositivo ou navegador no qual iniciou o processo de início de sessão.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirme o email para iniciar sessão.</string>
     <string name="fui_email_link_dismiss_button">Ignorar</string>
     <string name="fui_email_link_cross_device_linking_text">Originalmente, pretendia associar %1$s à sua conta de email, mas abriu o link num dispositivo diferente no qual não tem sessão iniciada.\n\nSe ainda pretender associar a sua conta do %1$s, abra o link no mesmo dispositivo em que iniciou sessão. Caso contrário, toque em Continuar para iniciar sessão neste dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Iniciar sessão com %1$s</string>
     <string name="fui_verify_phone_number_title">Introduza o seu número de telefone</string>
     <string name="fui_invalid_phone_number">Introduza um número de telefone válido</string>
     <string name="fui_enter_confirmation_code">Introduza o código de 6 dígitos que enviámos para</string>

--- a/auth/src/main/res/values-pt/strings.xml
+++ b/auth/src/main/res/values-pt/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Carregando…</string>
     <string name="fui_sign_in_default">Fazer login</string>
-    <string name="fui_cancel">Cancelar</string>
     <string name="fui_continue">Continuar</string>
     <string name="fui_tos_and_pp">Ao continuar, você concorda com nossos %1$s e a %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Um e-mail de login com mais instruções foi enviado para %1$s. Verifique sua caixa de entrada para concluir o login.</string>
     <string name="fui_email_link_trouble_getting_email_header">Problemas para receber e-mails?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Utilize estas soluções comuns:\n\u2022 Verifique se o e-mail foi filtrado ou marcado como spam\n\u2022 Verifique sua conexão com a Internet.\n\u2022 Verifique se você digitou seu e-mail corretamente.\n\u2022 Verifique se a sua caixa de entrada está cheia ou se ela está com outro tipo de problema.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Se as etapas acima não funcionarem, envie o e-mail novamente. Observação: isso desativará o link do e-mail anterior.</string>
     <string name="fui_email_link_resend">Reenviar</string>
     <string name="fui_email_link_wrong_device_header">Novo dispositivo ou navegador detectado.</string>
     <string name="fui_email_link_wrong_device_message">Tente abrir o link usando o mesmo dispositivo ou navegador que você usou para iniciar o processo de login.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirme o e-mail para continuar o login</string>
     <string name="fui_email_link_dismiss_button">Dispensar</string>
     <string name="fui_email_link_cross_device_linking_text">Inicialmente, você quis conectar %1$s à sua conta de e-mail, mas abriu o link em outro dispositivo no qual você não está conectado.\n\nSe você ainda quiser conectar sua conta de %1$s, abra o link no mesmo dispositivo em que fez login. Se preferir, toque em \"Continuar\" para fazer login neste dispositivo.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Fazer login com %1$s</string>
     <string name="fui_verify_phone_number_title">Insira o número do seu telefone</string>
     <string name="fui_invalid_phone_number">Insira um número de telefone válido</string>
     <string name="fui_enter_confirmation_code">Insira o código de 6 dígitos enviado para</string>

--- a/auth/src/main/res/values-ro/strings.xml
+++ b/auth/src/main/res/values-ro/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Se încarcă…</string>
     <string name="fui_sign_in_default">Conectați-vă</string>
-    <string name="fui_cancel">Anulați</string>
     <string name="fui_continue">Continuați</string>
     <string name="fui_tos_and_pp">Dacă alegeți să continuați, sunteți de acord cu %1$s și cu %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Un e-mail de conectare cu instrucțiuni suplimentare a fost trimis la %1$s. Verificați-vă căsuța de e-mail pentru a finaliza conectarea.</string>
     <string name="fui_email_link_trouble_getting_email_header">Nu primiți e-mailuri?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Încercați aceste soluții folosite frecvent:\n\u2022 verificați dacă e-mailul a fost marcat ca spam sau filtrat;\n\u2022 verificați conexiunea la internet;\n\u2022 verificați dacă ați scris corect adresa de e-mail;\n\u2022 verificați dacă aveți spațiu în căsuța de e-mail sau dacă există alte probleme legate de setările căsuței de e-mail.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Dacă pașii de mai sus nu funcționează, puteți să trimiteți din nou e-mailul. Rețineți că va fi dezactivat linkul din e-mailul anterior.</string>
     <string name="fui_email_link_resend">Retrimiteți</string>
     <string name="fui_email_link_wrong_device_header">A fost detectat un nou dispozitiv sau browser.</string>
     <string name="fui_email_link_wrong_device_message">Încercați să accesați linkul folosind același dispozitiv sau browser pe care ați început procesul de conectare.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Confirmați adresa de e-mail pentru a continua conectarea</string>
     <string name="fui_email_link_dismiss_button">Închideți</string>
     <string name="fui_email_link_cross_device_linking_text">Inițial ați intenționat să conectați %1$s la contul de e-mail, dar ați deschis linkul pe un dispozitiv pe care nu sunteți conectat(ă).\n\nDacă doriți să continuați conectarea contului %1$s, deschideți linkul pe același dispozitiv pe care ați început conectarea. În caz contrar, atingeți Continuați pentru a vă conecta pe acest dispozitiv.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Conectați-vă cu %1$s</string>
     <string name="fui_verify_phone_number_title">Introduceți numărul de telefon</string>
     <string name="fui_invalid_phone_number">Introduceți un număr valid de telefon</string>
     <string name="fui_enter_confirmation_code">Introduceți codul din 6 cifre pe care l-am trimis la</string>

--- a/auth/src/main/res/values-ru/strings.xml
+++ b/auth/src/main/res/values-ru/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Загрузка…</string>
     <string name="fui_sign_in_default">Войти</string>
-    <string name="fui_cancel">Отмена</string>
     <string name="fui_continue">Продолжить</string>
     <string name="fui_tos_and_pp">Продолжая, вы принимаете %1$s и %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">На адрес электронной почты %1$s отправлено письмо с информацией о том, как войти в аккаунт. Изучите его и выполните инструкции.</string>
     <string name="fui_email_link_trouble_getting_email_header">Не получили письмо?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Выполните действия, описанные ниже.\n\u2022 Поищите письмо в папке со спамом или отфильтрованными сообщениями.\n\u2022 Проверьте подключение к Интернету.\n\u2022 Убедитесь, что правильно указали свой адрес электронной почты.\n\u2022 Проверьте настройки папки со входящими сообщениям и посмотрите, достаточно ли в ней места.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Если найти письмо не удалось, мы можем отправить его ещё раз. В таком случае ссылка из предыдущего сообщения станет недействительна.</string>
     <string name="fui_email_link_resend">Отправить ещё раз</string>
     <string name="fui_email_link_wrong_device_header">Зарегистрирован вход с нового устройства или из нового браузера</string>
     <string name="fui_email_link_wrong_device_message">Попробуйте открыть ссылку в браузере или на устройстве, которые вы использовали, чтобы начать процесс входа.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Чтобы продолжить вход, подтвердите адрес электронной почты.</string>
     <string name="fui_email_link_dismiss_button">ОК</string>
     <string name="fui_email_link_cross_device_linking_text">Вы пытались связать аккаунт сервиса %1$s со своим адресом электронной почты, однако перешли по ссылке на устройстве, на котором у вас не выполнен вход.\n\nЧтобы пройти авторизацию на текущем компьютере, телефоне или планшете, нажмите \"Продолжить\". Если вы все-таки хотите связать аккаунт сервиса %1$s со своим адресом электронной почты, откройте ссылку на устройстве, на котором начали процесс входа.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Войти через аккаунт %1$s</string>
     <string name="fui_verify_phone_number_title">Введите номер телефона</string>
     <string name="fui_invalid_phone_number">Введите действительный номер телефона.</string>
     <string name="fui_enter_confirmation_code">Введите 6-значный код, отправленный на номер</string>

--- a/auth/src/main/res/values-sk/strings.xml
+++ b/auth/src/main/res/values-sk/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Načítava sa…</string>
     <string name="fui_sign_in_default">Prihlásiť sa</string>
-    <string name="fui_cancel">Zrušiť</string>
     <string name="fui_continue">Pokračovať</string>
     <string name="fui_tos_and_pp">Pokračovaním vyjadrujete súhlas s dokumentmi %1$s a %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Prihlasovací e‑mail s ďalšími pokynmi bol odoslaný na adresu %1$s. Na dokončenie prihlásenia skontrolujte svoj e‑mail.</string>
     <string name="fui_email_link_trouble_getting_email_header">Máte problémy s dostávaním e‑mailov?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Vyskúšajte tieto bežné opravy:\n\u2022 Skontrolujte, či e‑mail nebol označený ako spam alebo či nebol odfiltrovaný.\n\u2022 Skontrolujte internetové pripojenie.\n\u2022 Skontrolujte, či ste správne napísali svoju e‑mailovú adresu.\n\u2022 Skontrolujte, či máte dostatok miesta v doručenej pošte alebo či nemáte iné problémy súvisiace s nastaveniami doručenej pošty.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Ak sa uvedenými krokmi problém nevyriešil, e‑mail môžete znovu odoslať. Upozorňujeme, že opätovné odoslanie deaktivuje odkaz v staršom e‑maile.</string>
     <string name="fui_email_link_resend">Odoslať znova</string>
     <string name="fui_email_link_wrong_device_header">Bolo rozpoznané nové zariadenie alebo prehliadač.</string>
     <string name="fui_email_link_wrong_device_message">Skúste otvoriť odkaz pomocou toho istého zariadenia, v ktorom ste začali proces prihlásenia.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Ak chcete pokračovať v prihlasovaní, potvrďte e‑mailovú adresu</string>
     <string name="fui_email_link_dismiss_button">Odmietnuť</string>
     <string name="fui_email_link_cross_device_linking_text">Pôvodne ste chceli prepojiť svoj účet v službe %1$s so svojím e‑mailovým účtom, ale odkaz ste otvorili v inom zariadení, v ktorom ste sa neprihlásili.\n\nAk stále chcete prepojiť svoj účet v službe %1$s, otvorte odkaz v rovnakom zariadení, v ktorom ste sa začali prihlasovať. V opačnom prípade klepnite na tlačidlo Pokračovať a prihláste sa v tomto zariadení.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Prihláste sa cez %1$s</string>
     <string name="fui_verify_phone_number_title">Zadajte svoje telefónne číslo</string>
     <string name="fui_invalid_phone_number">Zadajte platné telefónne číslo</string>
     <string name="fui_enter_confirmation_code">Zadajte 6-ciferný kód, ktorý sme odoslali na adresu</string>

--- a/auth/src/main/res/values-sl/strings.xml
+++ b/auth/src/main/res/values-sl/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Nalaganje…</string>
     <string name="fui_sign_in_default">Prijava</string>
-    <string name="fui_cancel">Prekliči</string>
     <string name="fui_continue">Naprej</string>
     <string name="fui_tos_and_pp">Z nadaljevanjem potrjujete, da se strinjate z dokumentoma %1$s in %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">E-poštno sporočilo za prijavo z dodatnimi navodili je bilo poslano na %1$s. Preverite e-pošto in dokončajte prijavo.</string>
     <string name="fui_email_link_trouble_getting_email_header">Niste prejeli e-poštnega sporočila?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Poskusite te splošne rešitve:\n\u2022 Preverite, ali je bilo e-poštno sporočilo označeno kot vsiljena pošta ali filtrirano.\n\u2022 Preverite internetno povezavo.\n\u2022 Preverite, ali je e-poštni naslov pravilno zapisan.\n\u2022 Zagotovite, da imate v mapi »Prejeto« dovolj prostora oziroma da ni prišlo do drugih težav, povezanih z nastavitvami mape »Prejeto«.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Če z zgornjimi koraki ne odpravite težave, lahko znova pošljete e-poštno sporočilo. Upoštevajte, da boste s tem onemogočili povezavo v prejšnjem e-poštnem sporočilu.</string>
     <string name="fui_email_link_resend">Pošlji znova</string>
     <string name="fui_email_link_wrong_device_header">Zaznana je bila nova naprava ali brskalnik.</string>
     <string name="fui_email_link_wrong_device_message">Povezavo poskusite odpreti v isti napravi ali brskalniku, kjer ste začeli postopek prijave.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Če želite nadaljevati s prijavo, potrdite e-poštni naslov</string>
     <string name="fui_email_link_dismiss_button">Opusti</string>
     <string name="fui_email_link_cross_device_linking_text">Najprej ste želeli račun %1$s povezati z e-poštnim računom, vendar ste povezavo odprli v drugi napravi, kjer niste prijavljeni.\n\nČe želite še vedno povezati račun %1$s, odprite povezavo v napravi, v kateri ste začeli s prijavo. V nasprotnem primeru se dotaknite možnosti »Nadaljuj«, da se prijavite v tej napravi.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Prijava z računom %1$s</string>
     <string name="fui_verify_phone_number_title">Vnesite telefonsko številko</string>
     <string name="fui_invalid_phone_number">Vnesite veljavno telefonsko številko</string>
     <string name="fui_enter_confirmation_code">Vnesite 6-mestno kodo, ki smo jo poslali na številko</string>

--- a/auth/src/main/res/values-sr/strings.xml
+++ b/auth/src/main/res/values-sr/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Учитава се…</string>
     <string name="fui_sign_in_default">Пријави ме</string>
-    <string name="fui_cancel">Откажи</string>
     <string name="fui_continue">Настави</string>
     <string name="fui_tos_and_pp">Ако наставите, потврђујете да прихватате документе %1$s и %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Имејл за пријављивање са додатним упутствима је послат на %1$s. Проверите имејл да бисте довршили пријављивање.</string>
     <string name="fui_email_link_trouble_getting_email_header">Имате проблема са пријемом имејла?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Пробајте ова честа решења:\n\u2022 Проверите да ли је имејл означен као непожељан или је филтриран.\n\u2022 Проверите интернет везу.\n\u2022 Проверите да ли сте унели тачан имејл.\n\u2022 Проверите да нисте остали без простора у пријемном сандучету или да немате други проблем са подешавањима пријемног сандучета.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Ако наведене мере не уроде плодом, можете поново да пошаљете имејл. Имајте у виду да ћете тиме деактивирати линк у старијем имејлу.</string>
     <string name="fui_email_link_resend">Поново пошаљи</string>
     <string name="fui_email_link_wrong_device_header">Открили смо нови уређај или прегледач.</string>
     <string name="fui_email_link_wrong_device_message">Отворите линк са истог уређаја или из истог прегледача из ког сте покренули поступак пријављивања.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Потврдите имејл адресу да бисте наставили са пријављивањем</string>
     <string name="fui_email_link_dismiss_button">Одбаци</string>
     <string name="fui_email_link_cross_device_linking_text">Првобитна намера вам је била да повежете %1$s налог са имејл налогом, али сте отворили линк на другом уређају, на ком нисте пријављени.\n\nАко и даље желите да повежете %1$s налог, отворите линк на истом уређају на ком сте почели пријављивање. У супротном, додирните Настави да бисте се пријавили на овом уређају.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Пријавите се уз %1$s</string>
     <string name="fui_verify_phone_number_title">Унесите број телефона</string>
     <string name="fui_invalid_phone_number">Унесите важећи број телефона</string>
     <string name="fui_enter_confirmation_code">Унесите 6-цифрени кôд који смо послали на</string>

--- a/auth/src/main/res/values-sv/strings.xml
+++ b/auth/src/main/res/values-sv/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Läser in…</string>
     <string name="fui_sign_in_default">Logga in</string>
-    <string name="fui_cancel">Avbryt</string>
     <string name="fui_continue">Fortsätt</string>
     <string name="fui_tos_and_pp">Genom att fortsätta godkänner du våra %1$s och vår %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Ett inloggningsmeddelande med instruktioner skickades till %1$s. Kontrollera din e-post för att slutföra inloggningen.</string>
     <string name="fui_email_link_trouble_getting_email_header">Fick du inget e-postmeddelande?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Prova dessa vanliga lösningar:\n\u2022 Kontrollera om meddelandet hamnade bland skräpposten eller filtrerades.\n\u2022 Kontrollera internetanslutningen.\n\u2022 Kontrollera att du inte stavade e-postadressen fel.\n\u2022 Kontrollera att du inte har ont om utrymme i inkorgen samt andra inkorgsrelaterade problem.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Om ovanstående lösningar inte fungerar kan du testa att skicka meddelandet igen. Länken i det gamla meddelandet inaktiveras.</string>
     <string name="fui_email_link_resend">Skicka igen</string>
     <string name="fui_email_link_wrong_device_header">Ny enhet eller webbläsare identifierad.</string>
     <string name="fui_email_link_wrong_device_message">Testa att öppna länken med samma enhet eller webbläsare som du använde när du påbörjade inloggningen.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Bekräfta e-postadressen om du vill fortsätta med inloggningen</string>
     <string name="fui_email_link_dismiss_button">Stäng</string>
     <string name="fui_email_link_cross_device_linking_text">Du skulle ansluta %1$s till ditt e-postkonto men har öppnat länken på en annan enhet där du inte är inloggad.\n\nOm du fortfarande vill ansluta ditt %1$s-konto ska du öppna länken på den enhet där du påbörjade inloggningen. Annars kan du klicka på Fortsätt för att logga in på den här enheten.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Logga in med %1$s</string>
     <string name="fui_verify_phone_number_title">Ange ditt telefonnummer</string>
     <string name="fui_invalid_phone_number">Ange ett giltigt telefonnummer</string>
     <string name="fui_enter_confirmation_code">Ange den sexsiffriga koden vi skickade till</string>

--- a/auth/src/main/res/values-ta/strings.xml
+++ b/auth/src/main/res/values-ta/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">ஏற்றுகிறது…</string>
     <string name="fui_sign_in_default">உள்நுழைக</string>
-    <string name="fui_cancel">ரத்துசெய்</string>
     <string name="fui_continue">தொடர்க</string>
     <string name="fui_tos_and_pp">தொடர்வதன் மூலம், எங்கள் %1$s மற்றும் %2$sஐ ஏற்பதாகக் குறிப்பிடுகிறீர்கள்.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">கூடுதல் வழிமுறைகளுடன் கூடிய உள்நுழைவு மின்னஞ்சல் %1$sக்கு அனுப்பப்பட்டது. உள்நுழைவை நிறைவு செய்ய, உங்கள் மின்னஞ்சலைப் பார்க்கவும்.</string>
     <string name="fui_email_link_trouble_getting_email_header">மின்னஞ்சலைப் பெறுவதில் சிக்கல் உள்ளதா?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">இந்த வழக்கமான பிழைத்திருத்த முறைகளை முயலவும்:\n\u2022 மின்னஞ்சல் ஸ்பேமாகக் குறிக்கப்பட்டுள்ளதா அல்லது வடிகட்டப்பட்டுள்ளதா எனப் பார்க்கவும்.\n\u2022 உங்கள் இணைய இணைப்பைச் சரிபார்க்கவும்.\n\u2022 உங்கள் மின்னஞ்சல் முகவரி சரியாக இருக்கிறதா எனப் பார்க்கவும்.\n\u2022 இன்பாக்ஸில் போதுமான இடமுள்ளதா என்பதையும், மற்ற இன்பாக்ஸ் அமைப்புகளுடன் தொடர்புடைய சிக்கல்களையும் சரிபார்க்கவும்.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">மேலேயுள்ளவற்றை முயன்றும் பலனளிக்கவில்லை எனில், நீங்கள் மீண்டும் மின்னஞ்சல் அனுப்பலாம். இது முந்தைய மின்னஞ்சலில் உள்ள இணைப்பை முடக்கிவிடும் என்பதை நினைவில் கொள்ளவும்.</string>
     <string name="fui_email_link_resend">மீண்டும் அனுப்பு</string>
     <string name="fui_email_link_wrong_device_header">புதிய சாதனம் அல்லது உலாவி கண்டறியப்பட்டுள்ளது.</string>
     <string name="fui_email_link_wrong_device_message">நீங்கள் உள்நுழைவுச் செயல்முறையைத் தொடங்கிய அதே சாதனம் அல்லது உலாவியைப் பயன்படுத்தி இணைப்பைத் திறக்கவும்.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">உள்நுழைவைத் தொடர, மின்னஞ்சலை உறுதிப்படுத்தவும்</string>
     <string name="fui_email_link_dismiss_button">மூடு</string>
     <string name="fui_email_link_cross_device_linking_text">முதலில் %1$sஐ உங்கள் மின்னஞ்சல் கணக்குடன் இணைப்பதற்காக முயற்சித்தீர்கள், ஆனால் உள்நுழைந்திராத வேறொரு சாதனத்தில் இணைப்பைத் திறந்துள்ளீர்கள்.\n\nஉங்கள் %1$s கணக்கை இணைக்க விரும்பினால், நீங்கள் உள்நுழைய தொடங்கிய அதே சாதனத்தில் இணைப்பைத் திறக்கவும். இல்லையெனில் இந்தச் சாதனத்தில் உள்நுழைய தொடர்க என்பதைத் தட்டவும்.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">%1$s மூலம் உள்நுழையவும்</string>
     <string name="fui_verify_phone_number_title">ஃபோன் எண்ணை உள்ளிடவும்</string>
     <string name="fui_invalid_phone_number">சரியான ஃபோன் எண்ணை உள்ளிடவும்</string>
     <string name="fui_enter_confirmation_code">இந்த எண்ணுக்கு நாங்கள் அனுப்பிய 6 இலக்கக் குறியீட்டை உள்ளிடவும்:</string>

--- a/auth/src/main/res/values-th/strings.xml
+++ b/auth/src/main/res/values-th/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">กำลังโหลด…</string>
     <string name="fui_sign_in_default">ลงชื่อเข้าใช้</string>
-    <string name="fui_cancel">ยกเลิก</string>
     <string name="fui_continue">ต่อไป</string>
     <string name="fui_tos_and_pp">การดำเนินการต่อแสดงว่าคุณยอมรับ %1$s และ %2$s</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">ระบบได้ส่งอีเมลลงชื่อเข้าใช้พร้อมวิธีการเพิ่มเติมไปยัง %1$s แล้ว โปรดตรวจสอบอีเมลเพื่อลงชื่อเข้าใช้</string>
     <string name="fui_email_link_trouble_getting_email_header">มีปัญหาในการรับอีเมลใช่ไหม</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">ลองใช้วิธีแก้ไขทั่วไปเหล่านี้:\n\u2022 ตรวจสอบว่าอีเมลดังกล่าวมีการทำเครื่องหมายว่าเป็นสแปมหรือผ่านการกรอง\n\u2022 ตรวจสอบการเชื่อมต่ออินเทอร์เน็ต\n\u2022 ตรวจสอบว่าสะกดชื่ออีเมลถูกต้องแล้ว\n\u2022 ตรวจสอบว่ายังมีพื้นที่เหลือในกล่องจดหมายหรือไม่มีปัญหาอื่นๆ ที่เกี่ยวกับการตั้งค่ากล่องจดหมาย\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">คุณอาจส่งอีเมลอีกครั้งได้ หากขั้นตอนข้างต้นไม่ช่วยแก้ไขปัญหา โปรดทราบว่าการกระทำดังกล่าวจะเป็นการปิดใช้งานลิงก์ในอีเมลเก่า</string>
     <string name="fui_email_link_resend">ส่งซ้ำ</string>
     <string name="fui_email_link_wrong_device_header">พบการใช้อุปกรณ์หรือเบราว์เซอร์ใหม่</string>
     <string name="fui_email_link_wrong_device_message">ลองเปิดลิงก์โดยใช้อุปกรณ์หรือเบราว์เซอร์เดียวกันกับที่คุณใช้ในขั้นตอนการลงชื่อเข้าใช้</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">ยืนยันอีเมลเพื่อลงชื่อเข้าใช้ต่อ</string>
     <string name="fui_email_link_dismiss_button">ปิด</string>
     <string name="fui_email_link_cross_device_linking_text">แต่เดิมคุณตั้งใจที่จะเชื่อม %1$s เข้ากับบัญชีอีเมลแต่ได้เปิดลิงก์บนอุปกรณ์อื่นที่ไม่ได้ลงชื่อเข้าใช้\n\nหากยังต้องการเชื่อมบัญชี %1$s ให้เปิดลิงก์บนอุปกรณ์เดียวกันกับที่เริ่มลงชื่อเข้าใช้ หรือแตะ \"ต่อไป\" เพื่อลงชื่อเข้าใช้บนอุปกรณ์นี้</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">ลงชื่อเข้าใช้ด้วย %1$s</string>
     <string name="fui_verify_phone_number_title">ป้อนหมายเลขโทรศัพท์ของคุณ</string>
     <string name="fui_invalid_phone_number">ป้อนหมายเลขโทรศัพท์ที่ถูกต้อง</string>
     <string name="fui_enter_confirmation_code">ป้อนรหัส 6 หลักที่เราส่งไปยัง</string>

--- a/auth/src/main/res/values-tl/strings.xml
+++ b/auth/src/main/res/values-tl/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Naglo-load…</string>
     <string name="fui_sign_in_default">Mag-sign in</string>
-    <string name="fui_cancel">Kanselahin</string>
     <string name="fui_continue">Magpatuloy</string>
     <string name="fui_tos_and_pp">Sa pagpapatuloy, ipinababatid mo na tinatanggap mo ang aming %1$s at %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Nagpadala ng email sa pag-sign in na may mga karagdagang tagubilin sa %1$s. Tingnan ang iyong email para makumpleto ang pag-sign in.</string>
     <string name="fui_email_link_trouble_getting_email_header">Nagkakaproblema sa pagtanggap ng email?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Subukan ang mga karaniwang pag-aayos na ito:\n\u2022 Tingnan kung namarkahan na spam o na-filter ang email.\n\u2022 Tingnan ang iyong koneksyon sa internet.\n\u2022 Tiyakin na hindi ka nagkamali sa pagbaybay sa iyong email.\n\u2022 Tiyakin na hindi nauubusan ng espasyo ang iyong inbox o may iba pang isyu na may kinalaman sa setting ng inbox.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Kung hindi gumagana ang mga hakbang sa itaas, maaari mong ipadala muli ang email. Tandaan na ide-deactivate nito ang link sa mas lumang email.</string>
     <string name="fui_email_link_resend">Muling ipadala</string>
     <string name="fui_email_link_wrong_device_header">May nakitang bagong device o browser.</string>
     <string name="fui_email_link_wrong_device_message">Subukang buksan ang link gamit ang parehong device o browser kung saan mo sinimulan ang proseso ng pag-sign in.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Kumpirmahin ang email para magpatuloy sa pag-sign in</string>
     <string name="fui_email_link_dismiss_button">I-dismiss</string>
     <string name="fui_email_link_cross_device_linking_text">Orihinal na sinadya mong ikonekta ang %1$s sa iyong email account pero nabuksan ang link sa ibang device kung saan hindi ka naka-sign in.\n\nKung gusto mo pa ring ikonekta ang iyong %1$s account, buksan ang link sa parehong device kung saan ka nagsimulang mag-sign in. Kung hindi, i-tap ang Magpatuloy para makapag-sign in sa device na ito.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Mag-sign in gamit ang %1$s</string>
     <string name="fui_verify_phone_number_title">Ilagay ang numero ng iyong telepono</string>
     <string name="fui_invalid_phone_number">Maglagay ng wastong numero ng telepono</string>
     <string name="fui_enter_confirmation_code">Ilagay ang 6-digit na code na ipinadala namin sa</string>

--- a/auth/src/main/res/values-tr/strings.xml
+++ b/auth/src/main/res/values-tr/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Yükleniyor…</string>
     <string name="fui_sign_in_default">Oturum aç</string>
-    <string name="fui_cancel">İptal</string>
     <string name="fui_continue">Devam</string>
     <string name="fui_tos_and_pp">Devam ederek %1$s ve %2$s hükümlerimizi kabul ettiğinizi bildirirsiniz.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Ek talimatlar içeren bir oturum açma e-postası %1$s adresine gönderildi. Oturum açma işlemini tamamlamak için e-postanızı kontrol edin.</string>
     <string name="fui_email_link_trouble_getting_email_header">E-posta almayla ilgili sorun mu yaşıyorsunuz?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Şu sık başvurulan düzeltme yöntemlerini deneyin:\n\u2022 E-postanın spam olarak işaretlenme veya filtrelenme durumunu kontrol edin.\n\u2022 İnternet bağlantınızı kontrol edin.\n\u2022 E-postanızda yazım hatası bulunmadığından emin olun.\n\u2022 Gelen kutunuzdaki boş alanın azalıp azalmadığını ve gelen kutusu ayarlarıyla ilgili başka bir sorun olup olmadığını kontrol edin.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Yukarıdaki adımların işe yaramadığı durumlarda e-postayı yeniden gönderebilirsiniz. Bu işlemin eski e-postadaki bağlantıyı devre dışı bırakacağını unutmayın.</string>
     <string name="fui_email_link_resend">Tekrar gönder</string>
     <string name="fui_email_link_wrong_device_header">Yeni bir cihaz veya tarayıcı algılandı.</string>
     <string name="fui_email_link_wrong_device_message">Bağlantıyı, oturum açma işlemini başlattığınız cihazda veya tarayıcıda açmayı deneyin.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Oturum açma işlemine devam etmek için e-posta adresini onaylayın</string>
     <string name="fui_email_link_dismiss_button">Kapat</string>
     <string name="fui_email_link_cross_device_linking_text">Aslında %1$s adlı sağlayıcıyı e-posta hesabınıza bağlamak istediniz ancak bağlantıyı, oturum açmadığınız farklı bir cihazda açtınız.\n\nHâlâ %1$s hesabınızı bağlamak istiyorsanız bağlantıyı oturum açma işlemini başlattığınız cihazda açın. Aksi takdirde bu cihazda oturum açmak için Devam\'a dokunun.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">%1$s ile oturum aç</string>
     <string name="fui_verify_phone_number_title">Telefon numaranızı girin</string>
     <string name="fui_invalid_phone_number">Geçerli bir telefon numarası girin</string>
     <string name="fui_enter_confirmation_code">Şu telefon numarasına gönderdiğimiz 6 haneli kodu girin:</string>

--- a/auth/src/main/res/values-uk/strings.xml
+++ b/auth/src/main/res/values-uk/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Завантаження…</string>
     <string name="fui_sign_in_default">Увійти</string>
-    <string name="fui_cancel">Скасувати</string>
     <string name="fui_continue">Продовжити</string>
     <string name="fui_tos_and_pp">Продовжуючи, ви приймаєте такі документи: %1$s і %2$s.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Посилання для входу та додаткові вказівки надіслано на адресу %1$s. Дотримуйтеся їх, щоб увійти в обліковий запис.</string>
     <string name="fui_email_link_trouble_getting_email_header">Не отримали листа?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Скористайтеся порадами нижче, щоб вирішити проблему.\n\u2022 Перевірте – можливо, електронний лист позначено як спам або відфільтровано.\n\u2022 Перевірте інтернет-з’єднання.\n\u2022 Переконайтеся, що ви правильно вказали електронну адресу.\n\u2022 Перевірте доступний обсяг пам’яті для папки \"Вхідні\" й інші можливі проблеми з налаштуваннями.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Якщо наведені вище поради не допомагають, спробуйте знову надіслати електронний лист (у такому разі посилання в попередньому листі стане неактивним).</string>
     <string name="fui_email_link_resend">Надіслати повторно</string>
     <string name="fui_email_link_wrong_device_header">Виявлено новий пристрій або веб-переглядач.</string>
     <string name="fui_email_link_wrong_device_message">Спробуйте відкрити посилання на пристрої або у веб-переглядачі, де ви починали процедуру входу.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Щоб продовжити, підтвердьте електронну адресу</string>
     <string name="fui_email_link_dismiss_button">Закрити</string>
     <string name="fui_email_link_cross_device_linking_text">Ви збиралися зв’язати %1$s зі своєю електронною адресою, але відкрили надане посилання на пристрої, на якому не ввійшли в обліковий запис.\n\nЩоб зв’язати обліковий запис %1$s, відкрийте посилання на пристрої, де ви почали входити, або натисніть \"Продовжити\", щоб увійти на цьому пристрої.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Увійти, використовуючи %1$s</string>
     <string name="fui_verify_phone_number_title">Введіть свій номер телефону</string>
     <string name="fui_invalid_phone_number">Введіть дійсний номер телефону</string>
     <string name="fui_enter_confirmation_code">Введіть 6-значний код, який ми надіслали на номер</string>

--- a/auth/src/main/res/values-ur/strings.xml
+++ b/auth/src/main/res/values-ur/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">لوڈ ہو رہا ہے…</string>
     <string name="fui_sign_in_default">سائن ان کریں</string>
-    <string name="fui_cancel">منسوخ کریں</string>
     <string name="fui_continue">جاری رکھیں</string>
     <string name="fui_tos_and_pp">جاری رکھ کر، آپ نشاندہی کر رہے ہیں کہ آپ ہماری %1$s اور %2$s کو قبول کرتے ہیں۔</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">ایک سائن ان ای میل اضافی ہدایات کے ساتھ %1$s کو بھیج دی گئی ہے۔ سائن ان مکمل کرنے کیلئے اپنی ای میل چیک کریں۔</string>
     <string name="fui_email_link_trouble_getting_email_header">ای میل حاصل کرنے میں دشواری پیش آ رہی ہے؟</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">یہ عام اصلاحات آزمائیں:‎\n\u2022 چیک کریں کہ آیا ای میل کو اسپام یا فلٹر شدہ کے بطور نشان زد تو نہیں کیا گیا ہے۔‎\n\u2022 اپنا انٹرنیٹ کنکشن چیک کریں۔‎\n\u2022 چیک کریں کہ آپ نے اپنی ای میل میں ہجے کی کوئی غلطی تو نہیں کی ہے۔‎\n\u2022 چیک کریں کہ آپ کے ان باکس میں جگہ ختم تو نہیں ہو رہی ہے یا ان باکس کی ترتیب سے متعلق کوئی دوسرا مسئلہ تو نہیں ہے۔‎\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">اگر مندرجہ بالا مراحل کام نہ کریں تو آپ ای میل دوبارہ بھیج سکتے ہیں۔ نوٹ کریں کہ اس سے پرانی ای میل میں موجود لنک غیر فعال ہو جائے گا۔</string>
     <string name="fui_email_link_resend">دوبارہ بھیجیں</string>
     <string name="fui_email_link_wrong_device_header">نئے آلہ یا براؤزر کا پتا چلا ہے۔</string>
     <string name="fui_email_link_wrong_device_message">جہاں آپ نے سائن ان کا عمل شروع کیا تھا، اسی آلہ یا براؤزر کا استعمال کر کے لنک کھولنے کی کوشش کریں۔</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">سائن ان جاری رکھنے کے لیے ای میل کی توثیق کریں</string>
     <string name="fui_email_link_dismiss_button">برخاست کریں</string>
     <string name="fui_email_link_cross_device_linking_text">آپ نے اصل میں اپنے ای میل اکاؤنٹ کو %1$s کے ساتھ منسلک کرنا چاہتے تھے لیکن آپ نے لنک کو دوسرے آلہ پر کھولا ہے جہاں آپ سائن ان نہیں ہیں۔‎\n\nاگر آپ ابھی بھی اپنے %1$s اکاؤنٹ سے منسلک ہونا چاہتے ہیں، تو اسی آلہ پر لنک کو کھولیں جہاں سے آپ نے سائن ان شروع کیا تھا۔ بصورت دیگر، اس آلہ پر مسلسل سائن کرنے کے لیے تھپتھپائيں۔</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">%1$s کے ساتھ سائن ان کریں</string>
     <string name="fui_verify_phone_number_title">اپنا فون نمبر درج کریں</string>
     <string name="fui_invalid_phone_number">براہ کرم ایک درست فون نمبر درج کریں</string>
     <string name="fui_enter_confirmation_code">ہماری جانب سے حسبِ ذیل کو بھیجا گیا 6 عدد کا کوڈ درج کریں</string>

--- a/auth/src/main/res/values-vi/strings.xml
+++ b/auth/src/main/res/values-vi/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">Đang tải…</string>
     <string name="fui_sign_in_default">Đăng nhập</string>
-    <string name="fui_cancel">Hủy</string>
     <string name="fui_continue">Tiếp tục</string>
     <string name="fui_tos_and_pp">Bằng cách tiếp tục, bạn cho biết rằng bạn chấp nhận %1$s và %2$s của chúng tôi.</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">Email đăng nhập có hướng dẫn bổ sung đã được gửi tới %1$s. Hãy tìm email này trong hộp thư của bạn để hoàn tất đăng nhập.</string>
     <string name="fui_email_link_trouble_getting_email_header">Bạn gặp vấn đề khi nhận email?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">Hãy thử các biện pháp khắc phục phổ biến sau:\n\u2022 Kiểm tra xem email có bị đánh dấu là spam hay đã được lọc.\n\u2022 Kiểm tra kết nối Internet của bạn.\n\u2022 Kiểm tra để đảm bảo bạn không viết sai chính tả tên email.\n\u2022 Kiểm tra để đảm bảo hộp thư đến của bạn chưa hết dung lượng và không có vấn đề về cài đặt hộp thư đến.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">Nếu các bước trên không hiệu quả, bạn có thể gửi lại email. Vui lòng lưu ý rằng thao tác này sẽ hủy kích hoạt đường liên kết trong email cũ.</string>
     <string name="fui_email_link_resend">Gửi lại</string>
     <string name="fui_email_link_wrong_device_header">Đã phát hiện thiết bị hoặc trình duyệt mới.</string>
     <string name="fui_email_link_wrong_device_message">Hãy thử mở đường liên kết bằng cùng một thiết bị hoặc trình duyệt mà bạn dùng để bắt đầu quá trình đăng nhập.</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">Xác nhận email để tiếp tục đăng nhập</string>
     <string name="fui_email_link_dismiss_button">Bỏ qua</string>
     <string name="fui_email_link_cross_device_linking_text">Ban đầu, bạn có ý định kết nối %1$s với tài khoản email của bạn nhưng đã mở đường liên kết trên một thiết bị khác mà bạn chưa đăng nhập.\n\nNếu bạn vẫn muốn kết nối với tài khoản %1$s của mình, hãy mở đường liên kết này trên cùng một thiết bị mà bạn đã đăng nhập từ đầu. Nếu không, hãy nhấn Tiếp tục để đăng nhập trên thiết bị này.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">Đăng nhập bằng %1$s</string>
     <string name="fui_verify_phone_number_title">Nhập số điện thoại của bạn</string>
     <string name="fui_invalid_phone_number">Nhập số điện thoại hợp lệ</string>
     <string name="fui_enter_confirmation_code">Nhập mã 6 chữ số mà chúng tôi đã gửi cho bạn</string>

--- a/auth/src/main/res/values-zh-rCN/strings.xml
+++ b/auth/src/main/res/values-zh-rCN/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">正在加载…</string>
     <string name="fui_sign_in_default">登录</string>
-    <string name="fui_cancel">取消</string>
     <string name="fui_continue">继续</string>
     <string name="fui_tos_and_pp">继续即表示您接受我们的%1$s和%2$s。</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">系统已将含附加说明的登录电子邮件发送至 %1$s。请查收电子邮件以完成登录。</string>
     <string name="fui_email_link_trouble_getting_email_header">无法收到电子邮件？</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">尝试以下常见解决方法：\n\u2022 检查电子邮件是否被标记为垃圾邮件或被过滤。\n\u2022 检查您的互联网连接。\n\u2022 确保没有写错电子邮件地址。\n\u2022 确保收件箱空间充足，且不存在其他与收件箱设置有关的问题。\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">如果上述步骤未能帮助您解决问题，您可以重新发送电子邮件。请注意，重新发送后上一封电子邮件中的链接将失效。</string>
     <string name="fui_email_link_resend">重新发送</string>
     <string name="fui_email_link_wrong_device_header">检测到新设备或新浏览器。</string>
     <string name="fui_email_link_wrong_device_message">请尝试使用您最初进入登录流程时所用的设备或浏览器打开链接。</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">确认电子邮件地址以继续登录</string>
     <string name="fui_email_link_dismiss_button">关闭</string>
     <string name="fui_email_link_cross_device_linking_text">您最初是想将%1$s与您的电子邮件帐号关联起来，但是您换用其他未登录的设备打开了此链接。\n\n如果您仍希望关联您的%1$s帐号，请在您最初开始登录时所用的设备上打开此链接。否则，请点按“继续”以在当前设备上登录。</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">使用%1$s登录</string>
     <string name="fui_verify_phone_number_title">输入您的电话号码</string>
     <string name="fui_invalid_phone_number">请输入有效的电话号码</string>
     <string name="fui_enter_confirmation_code">输入我们发送至以下电话号码的 6 位数验证码</string>

--- a/auth/src/main/res/values-zh-rHK/strings.xml
+++ b/auth/src/main/res/values-zh-rHK/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">載入中…</string>
     <string name="fui_sign_in_default">登入</string>
-    <string name="fui_cancel">取消</string>
     <string name="fui_continue">繼續</string>
     <string name="fui_tos_and_pp">選擇繼續即表示您同意接受我們的《%1$s》和《%2$s》。</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">系統已將內含額外操作說明的登入電子郵件傳送至 %1$s。請查看您的電子郵件以完成登入程序。</string>
     <string name="fui_email_link_trouble_getting_email_header">沒收到電子郵件嗎？</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">請試試下列常用的解決方式：\n\u2022檢查該封電子郵件是否被標示為垃圾郵件或已遭系統篩除。\n\u2022檢查您的網際網路連線狀態。\n\u2022檢查電子郵件地址是否拼寫錯誤。\n\u2022確認收件匣的儲存空間是否足夠，或檢查其他與收件匣設定相關的問題。\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">如果上述步驟全部無效，建議您重新傳送電子郵件。請注意，這個動作會使先前郵件中的連結失效。</string>
     <string name="fui_email_link_resend">重新傳送</string>
     <string name="fui_email_link_wrong_device_header">偵測到新的裝置或瀏覽器。</string>
     <string name="fui_email_link_wrong_device_message">請透過最初登入時使用的裝置或瀏覽器來開啟連結。</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">如要繼續登入，請確認電子郵件地址</string>
     <string name="fui_email_link_dismiss_button">關閉</string>
     <string name="fui_email_link_cross_device_linking_text">您原先想將 %1$s 連結至您的電子郵件帳戶，卻在另一部未登入帳戶的裝置上開啟了連結。\n\n如果您仍想連結您的 %1$s 帳戶，請在開始登入程序的同一部裝置上開啟連結。如不想連結帳戶，請輕觸 [繼續] 以在這部裝置上進行登入程序。</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">透過 %1$s 登入</string>
     <string name="fui_verify_phone_number_title">請輸入您的電話號碼</string>
     <string name="fui_invalid_phone_number">請輸入有效的電話號碼</string>
     <string name="fui_enter_confirmation_code">請輸入傳送至以下電話號碼的 6 位數驗證碼</string>

--- a/auth/src/main/res/values-zh-rTW/strings.xml
+++ b/auth/src/main/res/values-zh-rTW/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">載入中…</string>
     <string name="fui_sign_in_default">登入</string>
-    <string name="fui_cancel">取消</string>
     <string name="fui_continue">繼續</string>
     <string name="fui_tos_and_pp">選擇繼續即表示您同意接受我們的《%1$s》和《%2$s》。</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">系統已將內含額外操作說明的登入電子郵件傳送至 %1$s。請查看您的電子郵件以完成登入程序。</string>
     <string name="fui_email_link_trouble_getting_email_header">沒收到電子郵件嗎？</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">請試試下列常用的解決方式：\n\u2022檢查該封電子郵件是否被標示為垃圾郵件或已遭系統篩除。\n\u2022檢查您的網際網路連線狀態。\n\u2022檢查電子郵件地址是否拼寫錯誤。\n\u2022確認收件匣的儲存空間是否足夠，或檢查其他與收件匣設定相關的問題。\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">如果上述步驟全部無效，建議您重新傳送電子郵件。請注意，這個動作會使先前郵件中的連結失效。</string>
     <string name="fui_email_link_resend">重新傳送</string>
     <string name="fui_email_link_wrong_device_header">偵測到新的裝置或瀏覽器。</string>
     <string name="fui_email_link_wrong_device_message">請透過最初登入時使用的裝置或瀏覽器來開啟連結。</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">如要繼續登入，請確認電子郵件地址</string>
     <string name="fui_email_link_dismiss_button">關閉</string>
     <string name="fui_email_link_cross_device_linking_text">您原先想將 %1$s 連結至您的電子郵件帳戶，卻在另一部未登入帳戶的裝置上開啟了連結。\n\n如果您仍想連結您的 %1$s 帳戶，請在開始登入程序的同一部裝置上開啟連結。如不想連結帳戶，請輕觸 [繼續] 以在這部裝置上進行登入程序。</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">透過 %1$s 登入</string>
     <string name="fui_verify_phone_number_title">請輸入您的電話號碼</string>
     <string name="fui_invalid_phone_number">請輸入有效的電話號碼</string>
     <string name="fui_enter_confirmation_code">請輸入傳送至以下電話號碼的 6 位數驗證碼</string>

--- a/auth/src/main/res/values-zh/strings.xml
+++ b/auth/src/main/res/values-zh/strings.xml
@@ -1,7 +1,6 @@
 <resources tools:ignore="ExtraTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="fui_progress_dialog_loading">正在加载…</string>
     <string name="fui_sign_in_default">登录</string>
-    <string name="fui_cancel">取消</string>
     <string name="fui_continue">继续</string>
     <string name="fui_tos_and_pp">继续即表示您接受我们的%1$s和%2$s。</string>
     <string name="fui_tos_and_pp_footer">%1$s \u00A0 \u00A0 %2$s</string>
@@ -63,7 +62,6 @@
     <string name="fui_email_link_email_sent">系统已将含附加说明的登录电子邮件发送至 %1$s。请查收电子邮件以完成登录。</string>
     <string name="fui_email_link_trouble_getting_email_header">无法收到电子邮件？</string>
     <string name="fui_email_link_trouble_getting_possible_fixes">尝试以下常见解决方法：\n\u2022 检查电子邮件是否被标记为垃圾邮件或被过滤。\n\u2022 检查您的互联网连接。\n\u2022 确保没有写错电子邮件地址。\n\u2022 确保收件箱空间充足，且不存在其他与收件箱设置有关的问题。\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution">如果上述步骤未能帮助您解决问题，您可以重新发送电子邮件。请注意，重新发送后上一封电子邮件中的链接将失效。</string>
     <string name="fui_email_link_resend">重新发送</string>
     <string name="fui_email_link_wrong_device_header">检测到新设备或新浏览器。</string>
     <string name="fui_email_link_wrong_device_message">请尝试使用您最初进入登录流程时所用的设备或浏览器打开链接。</string>
@@ -75,7 +73,6 @@
     <string name="fui_email_link_confirm_email_message">确认电子邮件地址以继续登录</string>
     <string name="fui_email_link_dismiss_button">关闭</string>
     <string name="fui_email_link_cross_device_linking_text">您最初是想将%1$s与您的电子邮件帐号关联起来，但是您换用其他未登录的设备打开了此链接。\n\n如果您仍希望关联您的%1$s帐号，请在您最初开始登录时所用的设备上打开此链接。否则，请点按“继续”以在当前设备上登录。</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text">使用%1$s登录</string>
     <string name="fui_verify_phone_number_title">输入您的电话号码</string>
     <string name="fui_invalid_phone_number">请输入有效的电话号码</string>
     <string name="fui_enter_confirmation_code">输入我们发送至以下电话号码的 6 位数验证码</string>

--- a/auth/src/main/res/values/colors.xml
+++ b/auth/src/main/res/values/colors.xml
@@ -12,5 +12,4 @@
     <color name="fui_bgMicrosoft">#2F2F2F</color>
     <color name="fui_bgYahoo">#720E9E</color>
     <color name="fui_bgApple">#000000</color>
-    <color name="fui_buttonShadow">#64BEBEBE</color>
 </resources>

--- a/auth/src/main/res/values/config.xml
+++ b/auth/src/main/res/values/config.xml
@@ -19,7 +19,7 @@
      See:
      https://developers.facebook.com/docs/facebook-login/android#chrome_custom_tabs
     -->
-    <string name="facebook_login_protocol_scheme" translatable="false">fbYOUR_APP_ID</string>
+    <string name="facebook_login_protocol_scheme" translatable="false">fb_your_app_id</string>
 
     <!--
     The Google web client ID associated with this Android application. The

--- a/auth/src/main/res/values/strings.xml
+++ b/auth/src/main/res/values/strings.xml
@@ -5,7 +5,6 @@
     <string name="fui_default_toolbar_title" translatable="false">@string/app_name</string>
     <string name="fui_progress_dialog_loading" translation_description="Loading text in dialog">Loading…</string>
     <string name="fui_sign_in_default" translation_description="Button text to sign in">Sign in</string>
-    <string name="fui_cancel" translation_description="Button text to cancel">Cancel</string>
     <string name="fui_continue" translation_description="Button text to continue">Continue</string>
     <string name="fui_tos_and_pp" translation_description="Global ToS and privacy policy message">By continuing, you are indicating that you accept our <xliff:g example="https://google.com/terms" id="tos" translation_description="Terms of service text">%1$s</xliff:g> and <xliff:g example="https://google.com/privacy" id="pp" translation_description="Privacy policy text">%2$s</xliff:g>.</string>
     <string name="fui_tos_and_pp_footer" translation_description="Global ToS and Privacy policy footer"><xliff:g example="https://google.com/terms" id="tos" translation_description="Footer ToS text">%1$s</xliff:g> \u00A0 \u00A0 <xliff:g example="https://google.com/privacy" id="pp" translation_description="Footer privacy policy text">%2$s</xliff:g></string>
@@ -103,7 +102,6 @@
     <string name="fui_email_link_email_sent" translation_description="Text to tell the user that the email has been sent">A sign-in email with additional instructions was sent to %1$s. Check your email to complete sign-in.</string>
     <string name="fui_email_link_trouble_getting_email_header" translation_description="Header that is displayed on the trouble signing in activity">Trouble getting email?</string>
     <string name="fui_email_link_trouble_getting_possible_fixes" translation_description="A list of possible fixes for receiving the email">Try these common fixes:\n\u2022 Check if the email was marked as spam or filtered.\n\u2022 Check your internet connection.\n\u2022 Check that you did not misspell your email.\n\u2022 Check that your inbox space is not running out or other inbox setting related issues.\n</string>
-    <string name="fui_email_link_trouble_getting_email_resend_solution" translation_description="Prompt the user to resend the email if the listed fixes do not work">If the steps above didn\'t work, you can resend the email. Note that this will deactivate the link in the older email. </string>
     <string name="fui_email_link_resend" translation_description="Button text to resend">Resend</string>
     <string name="fui_email_link_wrong_device_header" translation_description="Header shown when the user opens a link that was sent from a different device">New device or browser detected.</string>
     <string name="fui_email_link_wrong_device_message" translation_description="Message shown when the user opens a link that was sent from a different device">Try opening the link using the same device or browser where you started the sign-in process.</string>
@@ -115,7 +113,6 @@
     <string name="fui_email_link_confirm_email_message" translation_description="Message shown when prompting the user to confirm their email to finish the sign in flow">Confirm email to continue sign in</string>
     <string name="fui_email_link_dismiss_button" translation_description="Dismiss button for the wrong device or invalid link dialog">Dismiss</string>
     <string name="fui_email_link_cross_device_linking_text" translation_description="Text shown when the user opens an email link on a different device, but they had originally intended to link a provider to their account.">You originally intended to connect %1$s to your email account but have opened the link on a different device where you are not signed in.\n\nIf you still want to connect your %1$s account, open the link on the same device where you started sign-in. Otherwise, tap Continue to sign-in on this device.</string>
-    <string name="fui_email_link_cross_device_sign_in_button_text" translation_description="Sign in with provider text">Sign in with %1$s</string>
 
 
     <!-- Phone number auth -->

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -11,7 +11,7 @@ object Config {
     }
 
     object Plugins {
-        const val android = "com.android.tools.build:gradle:7.0.0-beta05"
+        const val android = "com.android.tools.build:gradle:7.0.0"
         const val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         const val google = "com.google.gms:google-services:4.3.8"
 

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -11,7 +11,7 @@ object Config {
     }
 
     object Plugins {
-        const val android = "com.android.tools.build:gradle:4.0.0"
+        const val android = "com.android.tools.build:gradle:7.0.0-beta05"
         const val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         const val google = "com.google.gms:google-services:4.3.8"
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -4,14 +4,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion(Config.SdkVersions.compile)
+    compileSdk = Config.SdkVersions.compile
 
     defaultConfig {
-        minSdkVersion(Config.SdkVersions.min)
-        targetSdkVersion(Config.SdkVersions.target)
-
-        versionName = Config.version
-        versionCode = 1
+        minSdk = Config.SdkVersions.min
+        targetSdk = Config.SdkVersions.target
 
         resourcePrefix("fui_")
         vectorDrawables.useSupportLibrary = true
@@ -22,7 +19,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    lintOptions {
+    lint {
         // Common lint options across all modules
         disable(
             "IconExpectedSize",

--- a/database/build.gradle.kts
+++ b/database/build.gradle.kts
@@ -4,14 +4,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion(Config.SdkVersions.compile)
+    compileSdk = Config.SdkVersions.compile
 
     defaultConfig {
-        minSdkVersion(Config.SdkVersions.min)
-        targetSdkVersion(Config.SdkVersions.target)
-
-        versionName = Config.version
-        versionCode = 1
+        minSdk = Config.SdkVersions.min
+        targetSdk = Config.SdkVersions.target
 
         resourcePrefix("fui_")
         vectorDrawables.useSupportLibrary = true
@@ -24,7 +21,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    lintOptions {
+    lint {
         // Common lint options across all modules
         disable(
             "IconExpectedSize",

--- a/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/FirebaseRecyclerAdapter.java
@@ -57,7 +57,6 @@ public abstract class FirebaseRecyclerAdapter<T, VH extends RecyclerView.ViewHol
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     public void stopListening() {
         mSnapshots.removeChangeEventListener(this);
-        notifyDataSetChanged();
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)

--- a/firestore/build.gradle.kts
+++ b/firestore/build.gradle.kts
@@ -4,14 +4,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion(Config.SdkVersions.compile)
+    compileSdk = Config.SdkVersions.compile
 
     defaultConfig {
-        minSdkVersion(Config.SdkVersions.min)
-        targetSdkVersion(Config.SdkVersions.target)
-
-        versionName = Config.version
-        versionCode = 1
+        minSdk = Config.SdkVersions.min
+        targetSdk = Config.SdkVersions.target
 
         resourcePrefix("fui_")
         vectorDrawables.useSupportLibrary = true
@@ -20,7 +17,7 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    lintOptions {
+    lint {
         // Common lint options across all modules
         disable(
             "IconExpectedSize",

--- a/firestore/src/main/java/com/firebase/ui/firestore/FirestoreRecyclerAdapter.java
+++ b/firestore/src/main/java/com/firebase/ui/firestore/FirestoreRecyclerAdapter.java
@@ -58,7 +58,6 @@ public abstract class FirestoreRecyclerAdapter<T, VH extends RecyclerView.ViewHo
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     public void stopListening() {
         mSnapshots.removeChangeEventListener(this);
-        notifyDataSetChanged();
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/internal/lint/src/main/java/com/firebaseui/lint/internal/LintIssueRegistry.kt
+++ b/internal/lint/src/main/java/com/firebaseui/lint/internal/LintIssueRegistry.kt
@@ -6,6 +6,9 @@ import com.android.tools.lint.client.api.IssueRegistry
  * Registry for custom FirebaseUI lint checks.
  */
 class LintIssueRegistry : IssueRegistry() {
+    override val api: Int
+        get() = com.android.tools.lint.detector.api.CURRENT_API
+
     override val issues = listOf(
         NonGlobalIdDetector.NON_GLOBAL_ID
     )

--- a/internal/lintchecks/build.gradle.kts
+++ b/internal/lintchecks/build.gradle.kts
@@ -3,14 +3,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion(Config.SdkVersions.compile)
+    compileSdk = Config.SdkVersions.compile
 
     defaultConfig {
-        minSdkVersion(Config.SdkVersions.min)
-        targetSdkVersion(Config.SdkVersions.target)
-
-        versionName = Config.version
-        versionCode = 1
+        minSdk = Config.SdkVersions.min
+        targetSdk = Config.SdkVersions.target
 
         resourcePrefix("fui_")
         vectorDrawables.useSupportLibrary = true
@@ -23,7 +20,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    lintOptions {
+    lint {
         // Common lint options across all modules
         disable(
             "IconExpectedSize",

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -4,14 +4,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion(Config.SdkVersions.compile)
+    compileSdk = Config.SdkVersions.compile
 
     defaultConfig {
-        minSdkVersion(Config.SdkVersions.min)
-        targetSdkVersion(Config.SdkVersions.target)
-
-        versionName = Config.version
-        versionCode = 1
+        minSdk = Config.SdkVersions.min
+        targetSdk = Config.SdkVersions.target
 
         resourcePrefix("fui_")
         vectorDrawables.useSupportLibrary = true
@@ -22,7 +19,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    lintOptions {
+    lint {
         // Common lint options across all modules
         disable(
             "IconExpectedSize",

--- a/lint/src/main/java/com/firebaseui/lint/LintIssueRegistry.kt
+++ b/lint/src/main/java/com/firebaseui/lint/LintIssueRegistry.kt
@@ -6,6 +6,9 @@ import com.android.tools.lint.client.api.IssueRegistry
  * Registry for custom FirebaseUI lint checks.
  */
 class LintIssueRegistry : IssueRegistry() {
+    override val api: Int
+        get() = com.android.tools.lint.detector.api.CURRENT_API
+
     override val issues = listOf(
             FirestoreRecyclerAdapterLifecycleDetector.ISSUE_MISSING_LISTENING_START_METHOD,
             FirestoreRecyclerAdapterLifecycleDetector.ISSUE_MISSING_LISTENING_STOP_METHOD

--- a/proguard-tests/build.gradle.kts
+++ b/proguard-tests/build.gradle.kts
@@ -51,7 +51,8 @@ android {
             "IconExpectedSize",
             "InvalidPackage", // Firestore uses GRPC which makes lint mad
             "NewerVersionAvailable", "GradleDependency", // For reproducible builds
-            "SelectableText", "SyntheticAccessor" // We almost never care about this
+            "SelectableText", "SyntheticAccessor", // We almost never care about this
+            "MediaCapabilities"
         )
 
         isCheckAllWarnings = true

--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -4,14 +4,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion(Config.SdkVersions.compile)
+    compileSdk = Config.SdkVersions.compile
 
     defaultConfig {
-        minSdkVersion(Config.SdkVersions.min)
-        targetSdkVersion(Config.SdkVersions.target)
-
-        versionName = Config.version
-        versionCode = 1
+        minSdk = Config.SdkVersions.min
+        targetSdk = Config.SdkVersions.target
 
         resourcePrefix("fui_")
         vectorDrawables.useSupportLibrary = true
@@ -22,7 +19,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    lintOptions {
+    lint {
         // Common lint options across all modules
         disable(
             "IconExpectedSize",


### PR DESCRIPTION
See #1966 

This PR should:
- [x] update AGP to 7.0.0 stable
- [x] update Gradle to 7.0.2
- [x] update the GitHub Actions workflow to use Java 11 - this is required by Gradle 7.
- [x] remove unused strings, colors and ids to avoid `UnusedIds` and `UnusedResources` lint errors.
- [x] suppress the `UnusedIds` lint error thrown in the `app` module - seems like AGP7 can't yet detect when an id is being used by ViewBinding.
- [x] suppress the `MediaCapabilities` lint error thrown in the `app` module - I couldn't figure out where this error is coming from, but I'm guessing Glide is responsible for it. 
- [x] fix many other lint issues that were thrown by AGP7