### PR TITLE
refactor(rtdb, firestore): prevent paging from throwing ExecutionException

### DIFF
--- a/database/src/main/java/com/firebase/ui/database/paging/DatabasePagingSource.java
+++ b/database/src/main/java/com/firebase/ui/database/paging/DatabasePagingSource.java
@@ -88,7 +88,13 @@ public class DatabasePagingSource extends RxPagingSource<String, DataSnapshot> {
                             details).toException();
                 }
             } catch (ExecutionException e) {
-                throw new Exception(e.getCause());
+                if (e.getCause() instanceof Exception) {
+                    // throw the original Exception
+                    throw (Exception) e.getCause();
+                }
+                // Only throw a new Exception when the original
+                // Throwable cannot be cast to Exception
+                throw new Exception(e);
             }
         }).subscribeOn(Schedulers.io()).onErrorReturn(LoadResult.Error::new);
     }


### PR DESCRIPTION
After the discussion in #1983 I noticed that `throw new Exception(e.getCause())` is actually throwing the original exception wrapped in a new `Exception` object. So instead of instantiating an `Exception`, the library should now try to cast from `Throwable` and only instantiate as a last resort.

This PR also updates firestore to have the same behavior.