### PR TITLE
refactor(auth): log an exception if the device has no browser installed

### DIFF
--- a/auth/src/main/AndroidManifest.xml
+++ b/auth/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <!-- Used to check if a browser is available before launching phone auth -->
-    <!-- See data/ui/phone/PhoneNumberVerificationHandler.isBrowserAvailable() -->
+    <!-- See ui/phone/PhoneNumberVerificationHandler.isBrowserAvailable() -->
     <queries>
         <intent>
             <action android:name="android.intent.action.VIEW" />

--- a/auth/src/main/AndroidManifest.xml
+++ b/auth/src/main/AndroidManifest.xml
@@ -7,6 +7,16 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <!-- Used to check if a browser is available before launching phone auth -->
+    <!-- See data/ui/phone/PhoneNumberVerificationHandler.isBrowserAvailable() -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="http" />
+        </intent>
+    </queries>
+
     <application>
 
         <meta-data

--- a/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneNumberVerificationHandler.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/phone/PhoneNumberVerificationHandler.java
@@ -2,8 +2,10 @@ package com.firebase.ui.auth.ui.phone;
 
 import android.app.Activity;
 import android.app.Application;
+import android.content.ActivityNotFoundException;
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
-
 import com.firebase.ui.auth.data.model.PhoneNumberVerificationRequiredException;
 import com.firebase.ui.auth.data.model.Resource;
 import com.firebase.ui.auth.viewmodel.AuthViewModelBase;
@@ -58,7 +60,11 @@ public class PhoneNumberVerificationHandler extends AuthViewModelBase<PhoneVerif
         if (force) {
             optionsBuilder.setForceResendingToken(mForceResendingToken);
         }
-        PhoneAuthProvider.verifyPhoneNumber(optionsBuilder.build());
+        if (isBrowserAvailable(activity)) {
+            PhoneAuthProvider.verifyPhoneNumber(optionsBuilder.build());
+        } else {
+            setResult(Resource.forFailure(new ActivityNotFoundException("No browser was found in this device")));
+        }
     }
 
     public void submitVerificationCode(String number, String code) {
@@ -76,5 +82,10 @@ public class PhoneNumberVerificationHandler extends AuthViewModelBase<PhoneVerif
         if (mVerificationId == null && savedInstanceState != null) {
             mVerificationId = savedInstanceState.getString(VERIFICATION_ID_KEY);
         }
+    }
+
+    private boolean isBrowserAvailable(Activity activity) {
+        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://"));
+        return browserIntent.resolveActivity(activity.getPackageManager()) != null;
     }
 }


### PR DESCRIPTION
Adding a workaround to prevent app from crashing when there is no browser installed.
See firebase/firebase-android-sdk#4006

Checks if the device has a browser. If not, log an exception.