### PR TITLE
chore: Update Firebase BoM to 32.2.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -95,9 +95,6 @@ dependencies {
     implementation(Config.Libs.Misc.permissions)
     implementation(Config.Libs.Androidx.constraint)
     debugImplementation(Config.Libs.Misc.leakCanary)
-    debugImplementation(Config.Libs.Misc.leakCanaryFragments)
-    releaseImplementation(Config.Libs.Misc.leakCanaryNoop)
-    testImplementation(Config.Libs.Misc.leakCanaryNoop)
 }
 
 apply(plugin = "com.google.gms.google-services")

--- a/app/src/main/java/com/firebase/uidemo/FirebaseUIDemo.java
+++ b/app/src/main/java/com/firebase/uidemo/FirebaseUIDemo.java
@@ -1,7 +1,5 @@
 package com.firebase.uidemo;
 
-import com.squareup.leakcanary.LeakCanary;
-
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.multidex.MultiDexApplication;
 
@@ -13,11 +11,5 @@ public class FirebaseUIDemo extends MultiDexApplication {
     @Override
     public void onCreate() {
         super.onCreate();
-        if (LeakCanary.isInAnalyzerProcess(this)) {
-            // This process is dedicated to LeakCanary for heap analysis.
-            // You should not init your app in this process.
-            return;
-        }
-        LeakCanary.install(this);
     }
 }

--- a/auth/src/test/java/com/firebase/ui/auth/ui/phone/PhoneNumberUtilsTest.java
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/phone/PhoneNumberUtilsTest.java
@@ -84,38 +84,6 @@ public class PhoneNumberUtilsTest {
     }
 
     @Test
-    @Config(sdk = 16)
-    public void testFormatNumberToE164_belowApi21() {
-        String validPhoneNumber = "+919994947354";
-        CountryInfo indiaCountryInfo = new CountryInfo(new Locale("", "IN"), 91);
-        // no leading plus
-        assertEquals(validPhoneNumber, format("9994947354", indiaCountryInfo));
-        // fully formatted
-        assertEquals(validPhoneNumber, format("+919994947354", indiaCountryInfo));
-        // parantheses and hyphens
-        assertEquals(validPhoneNumber, format("(99949) 47-354", indiaCountryInfo));
-
-        // The following cases would fail for lower api versions.
-        // Leaving tests in place to formally identify cases
-
-        // no leading +
-        // assertEquals(validPhoneNumber, format("919994947354", indiaCountryInfo));
-
-        // with hyphens
-        // assertEquals(validPhoneNumber, format("+91-(999)-(49)-(47354)",
-        // indiaCountryInfo));
-
-        // with spaces leading plus
-        // assertEquals(validPhoneNumber, format("+91 99949 47354", indiaCountryInfo));
-
-        // space formatting
-        // assertEquals(validPhoneNumber, format("91 99949 47354", indiaCountryInfo));
-
-        // invalid phone number
-        // assertNull(format("999474735", indiaCountryInfo));
-    }
-
-    @Test
     public void testGetCurrentCountryInfo_fromSim() {
         Context context = mock(Context.class);
         TelephonyManager telephonyManager = mock(TelephonyManager.class);

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -45,7 +45,7 @@ object Config {
         }
 
         object Firebase {
-            const val bom = "com.google.firebase:firebase-bom:28.2.0"
+            const val bom = "com.google.firebase:firebase-bom:32.2.0"
             const val auth = "com.google.firebase:firebase-auth"
             const val database = "com.google.firebase:firebase-database"
             const val firestore = "com.google.firebase:firebase-firestore"

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -61,14 +61,10 @@ object Config {
         }
 
         object Misc {
-            private const val leakCanaryVersion = "1.6.1"
+            private const val leakCanaryVersion = "2.12"
             private const val glideVersion = "4.11.0"
 
             const val leakCanary = "com.squareup.leakcanary:leakcanary-android:$leakCanaryVersion"
-            const val leakCanaryFragments =
-                    "com.squareup.leakcanary:leakcanary-support-fragment:$leakCanaryVersion"
-            const val leakCanaryNoop =
-                    "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryVersion"
 
             const val glide = "com.github.bumptech.glide:glide:$glideVersion"
             const val glideCompiler = "com.github.bumptech.glide:compiler:$glideVersion"

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -7,7 +7,7 @@ object Config {
     object SdkVersions {
         const val compile = 33
         const val target = 33
-        const val min = 16
+        const val min = 21
     }
 
     object Plugins {

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -5,8 +5,8 @@ object Config {
     private const val kotlinVersion = "1.7.10"
 
     object SdkVersions {
-        const val compile = 29
-        const val target = 29
+        const val compile = 33
+        const val target = 33
         const val min = 16
     }
 

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -79,7 +79,7 @@ object Config {
             const val mockito = "org.mockito:mockito-android:2.21.0"
             const val robolectric = "org.robolectric:robolectric:4.3.1"
 
-            const val core = "androidx.test:core:1.3.0"
+            const val core = "androidx.test:core:1.5.0"
             const val archCoreTesting = "androidx.arch.core:core-testing:2.1.0"
             const val runner = "androidx.test:runner:1.3.0"
             const val rules = "androidx.test:rules:1.3.0"


### PR DESCRIPTION
This PR should:

- Update the Firebase BoM to 23.2.0
- Bump the compileSdk and targetSdk to 33
- Bump the minSdk to 21
- Bump leakcanary to 2.12
- Bump androidx.test:core to 1.5.0
- Remove auth's "below api 21" test