### PR TITLE
refactor: hide sign up button for email link auth

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/email/CheckEmailFragment.java
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/email/CheckEmailFragment.java
@@ -95,6 +95,11 @@ public class CheckEmailFragment extends FragmentBase implements
         mSignInButton.setOnClickListener(this);
         mSignUpButton.setOnClickListener(this);
 
+        // Hide sign up button for email link authentication
+        if (getEmailProvider().equals(EmailAuthProvider.EMAIL_LINK_SIGN_IN_METHOD)) {
+            mSignUpButton.setVisibility(View.GONE);
+        }
+
         TextView termsText = view.findViewById(R.id.email_tos_and_pp_text);
         TextView footerText = view.findViewById(R.id.email_footer_tos_and_pp_text);
         FlowParameters flowParameters = getFlowParams();


### PR DESCRIPTION
For email link auth we don't need both buttons to be displayed in the UI.

### Email/password
<img width="360px" src="https://github.com/user-attachments/assets/6246ae4f-7473-47fe-bfc6-d9037f01c90d">



### Email Link
<img width="360px" src="https://github.com/user-attachments/assets/a8c771cc-f966-4d77-864f-3a074320142a">
