### PR TITLE
chore: update release process and docs

### DIFF
--- a/docs/internal/releasing.md
+++ b/docs/internal/releasing.md
@@ -6,7 +6,7 @@ more complex.
 ## 0 - Decide when to release
 
 All releases should have a milestone. A release is ready to go when all issues/PRs in the milestone
-are either closed or have the `fix-implemented` lablel.
+are either closed or have the `fix-implemented` label.
 
 FirebaseUI does not have strict guidance on release frequency. Minor and patch releases can go out
 as soon as they are ready. Major releases with breaking changes should happen as infrequently as
@@ -28,7 +28,6 @@ Next, make the following changes on the release branch:
   * Update `Config.kt` and `gradle.properties` to remove the `SNAPSHOT` from the version name and set the release version.
   * Update `README.md` and `auth/README.md` to point to the latest version of the library
     and to have the correct descriptions of transitive dependencies.
-  * Empty `CHANGELOG.md`
 
 Commit the changes with a generic message:
 
@@ -48,8 +47,8 @@ When ready, merge the pull request.
 
 ### Credentials
 
-The library is published to Maven Central by the firebase-sonatype account, Googlers can find the
-password for this account in [Valentine](http://valentine/)
+The library is published to Maven Central by the `firebase-sonatype` account, Googlers can find the
+password for this account in [Valentine](http://go/valentine/)
 
 ### GPG Key
 
@@ -77,36 +76,68 @@ Finally upload your key to the keyserver:
 gpg --keyserver hkp://keys.openpgp.org --send-keys <YOUR KEY ID>
 ```
 
+You might receive an email from `keyserver@keys.openpgp.org` to verify your email.
+Click the link in the email to complete the verification before proceeding.
+
+<details>
+
+<summary>gpg: keyserver send failed: Server indicated a failure</summary>
+
+If you run into the `gpg: keyserver send failed: Server indicated a failure` error when trying to
+ upload the key from a macOS machine, you can try the solution proposed [here](https://github.com/asdf-vm/asdf-nodejs/issues/192#issuecomment-797448073):
+
+```shell
+echo "standard-resolver" >  ~/.gnupg/dirmngr.conf
+```
+
+and then:
+
+```shell
+sudo pkill dirmngr
+```
+
+</details>
+
 ### Local Properties
 
-Open your `$HOME/.gradle/gradle.properties` file at and fill in the values:
+1. Navigate to https://oss.sonatype.org/ and **Log In** using the credentials from [Valentine](http://go/valentine).
+1. Follow [these instructions](https://central.sonatype.org/publish/generate-token/) to **Access User Token**.
+    You should see an XML that looks like this:
+    ```xml
+    <server>
+        <id>${server}</id>
+        <username>tokenuser</username>
+        <password>tokenkey-dlghnfgh8+4LfXmg5Hsd8jd</password>
+    </server>
+    ```
+1. Open your `$HOME/.gradle/gradle.properties` file and fill in the values:
 
 ```
 signing.keyId=<KEY ID>
 signing.password=<PASSWORD YOU CHOSE>
 signing.secretKeyRingFile=<FULL PATH TO YOUR GPG FILE>
-mavenCentralRepositoryUsername=firebase-sonatype
-mavenCentralRepositoryUsername=<PASSWORD FROM VALENTINE>
+mavenCentralUsername=<USERNAME FROM THE XML ABOVE (eg. tokenuser)>
+mavenCentralPassword=<PASSWORD FROM THE XML ABOVE (eg. tokenkey-dlghnfgh8+4LfXmg5Hsd8jd)>
 ```
 
-## 2b - Publish and Release
+## 2b - Publish and release
 
-### Publish
+_Publish_ and _release_ [used to be done](https://github.com/firebase/FirebaseUI-Android/blob/9.0.0/docs/internal/releasing.md#2b---publish-and-release)
+in two separate manual steps, but starting in [v0.22.0](https://vanniktech.github.io/gradle-maven-publish-plugin/changelog/#0220-2022-09-09)
+of the `com.vanniktech:gradle-maven-publish-plugin`, the `publishAllPublicationsToMavenRepository`
+now handles the _publish_ step automatically and you only need to perform the _release_ manually.
 
-Once you are sure the release branch is healthy, run the following command:
+Once you are sure the release branch is healthy, run the following commands:
 
 ```shell
 ./gradlew clean :library:prepareArtifacts
 ./gradlew --no-daemon --no-parallel publishAllPublicationsToMavenRepository
 ```
 
-### Release
-
 Follow [the instructions here](https://central.sonatype.org/pages/releasing-the-deployment.html):
 
-  1. Navigate to https://oss.sonatype.org/ and **Log In**
+  1. Navigate to https://oss.sonatype.org/ and **Log In**, if you haven't already.
   1. On the left side click **Staging Repositories** and look for the `com.firebaseui` repo.
-  1. Click **Close** ... wait a few minutes (you can check status with **Refresh**)
   1. Click **Release**
 
 ## 3 - Update issues, milestones, and release notes
@@ -117,7 +148,7 @@ First, go to the milestone for the released version and for each open issue:
   * Comment to let anyone watching know that the fix/feature has been released.
 
 Next, create a git tag for the latest version. In GitHub, create release notes based on the
-template from the previous version and assign the release ntoes to the tag.
+template from the previous version and assign the release notes to the tag.
 
 ## 4 - Prepare next development branch
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,3 +28,6 @@ POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
 POM_DEVELOPER_NAME=FirebaseUI Contributors
 POM_DEVELOPER_URL=https://github.com/firebase/FirebaseUI-Android/graphs/contributors
+# See https://vanniktech.github.io/gradle-maven-publish-plugin/changelog/#0200-2022-06-02
+SONATYPE_HOST=DEFAULT
+RELEASE_SIGNING_ENABLED=true


### PR DESCRIPTION
This PR should:
- Add new properties to gradle.properties due to changes in the `gradle-maven-publish-plugin`
- Update our internal release instructions doc to document the new process (and fix typos)

To preview the rendered Markdown: https://github.com/firebase/FirebaseUI-Android/blob/rpf/update-release-infra/docs/internal/releasing.md