### PR TITLE
FirestorePagingAdapter simply crashes due to an unknown reason #2060

### DIFF
--- a/firestore/src/main/java/com/firebase/ui/firestore/paging/FirestorePagingSource.java
+++ b/firestore/src/main/java/com/firebase/ui/firestore/paging/FirestorePagingSource.java
@@ -54,6 +54,9 @@ public class FirestorePagingSource extends RxPagingSource<PageKey, DocumentSnaps
                 // Only throw a new Exception when the original
                 // Throwable cannot be cast to Exception
                 throw new Exception(e);
+            } catch (InterruptedException e) {
+                // Handle interruption gracefully, e.g.:
+                return LoadResult.Error(e);
             }
         }).subscribeOn(Schedulers.io()).onErrorReturn(LoadResult.Error::new);
     }


### PR DESCRIPTION
This PR fixes a crash in FirestorePagingAdapter that occurs when the paging source is invalidated, such as during rapid refreshes or when using a small page size. The crash was caused by an unhandled InterruptedException thrown by Tasks.await in FirestorePagingSource. When the paging source is disposed, the background thread running the Firestore query can be interrupted, resulting in an UndeliverableException from RxJava.

**Changes made:**

- Handled InterruptedException in FirestorePagingSource.loadSingle.
- When an interruption occurs, the code now returns a LoadResult.Error, allowing the paging library to handle the error gracefully instead of crashing the app.

**Related Issue**
Fixes #2060

**How to test**
Use a small PagingConfig.pageSize (e.g., 1) or trigger rapid refreshes in your app.
Observe that the app no longer crashes with an UndeliverableException and handles paging interruptions gracefully.