### PR TITLE
fix: ensure that when selecting phone or email, it routes straight to that screen

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthUI.kt
@@ -25,6 +25,7 @@ import com.google.firebase.Firebase
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseAuth.AuthStateListener
+import com.google.firebase.auth.FirebaseAuth.IdTokenListener
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.auth
 import kotlinx.coroutines.CancellationException
@@ -255,29 +256,8 @@ class FirebaseAuthUI private constructor(
     fun authStateFlow(): Flow<AuthState> {
         // Create a flow from FirebaseAuth state listener
         val firebaseAuthFlow = callbackFlow {
-            // Set initial state based on current auth state
-            val initialState = auth.currentUser?.let { user ->
-                // Check if email verification is required
-                if (!user.isEmailVerified &&
-                    user.email != null &&
-                    user.providerData.any { it.providerId == "password" }
-                ) {
-                    AuthState.RequiresEmailVerification(
-                        user = user,
-                        email = user.email!!
-                    )
-                } else {
-                    AuthState.Success(result = null, user = user, isNewUser = false)
-                }
-            } ?: AuthState.Idle
-
-            trySend(initialState)
-
-            // Create auth state listener
-            val authStateListener = AuthStateListener { firebaseAuth ->
-                val currentUser = firebaseAuth.currentUser
-                val state = if (currentUser != null) {
-                    // Check if email verification is required
+            fun buildState(currentUser: FirebaseUser?): AuthState {
+                return if (currentUser != null) {
                     if (!currentUser.isEmailVerified &&
                         currentUser.email != null &&
                         currentUser.providerData.any { it.providerId == "password" }
@@ -296,15 +276,31 @@ class FirebaseAuthUI private constructor(
                 } else {
                     AuthState.Idle
                 }
-                trySend(state)
+            }
+
+            // Set initial state based on current auth state
+            val initialState = buildState(auth.currentUser)
+
+            trySend(initialState)
+
+            // Create auth state listener
+            val authStateListener = AuthStateListener { firebaseAuth ->
+                trySend(buildState(firebaseAuth.currentUser))
+            }
+
+            // AuthStateListener does not reliably fire for account linking, but IdTokenListener does.
+            val idTokenListener = IdTokenListener { firebaseAuth ->
+                trySend(buildState(firebaseAuth.currentUser))
             }
 
             // Add listener
             auth.addAuthStateListener(authStateListener)
+            auth.addIdTokenListener(idTokenListener)
 
             // Remove listener when flow collection is cancelled
             awaitClose {
                 auth.removeAuthStateListener(authStateListener)
+                auth.removeIdTokenListener(idTokenListener)
             }
         }
 

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -543,7 +544,7 @@ fun FirebaseAuthScreen(
 
                         if (currentRoute != AuthRoute.Success.route) {
                             navController.navigate(AuthRoute.Success.route) {
-                                popUpTo(AuthRoute.MethodPicker.route) { inclusive = true }
+                                popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
                                 launchSingleTop = true
                             }
                         }
@@ -556,7 +557,7 @@ fun FirebaseAuthScreen(
                         pendingLinkingCredential.value = null
                         if (currentRoute != AuthRoute.Success.route) {
                             navController.navigate(AuthRoute.Success.route) {
-                                popUpTo(AuthRoute.MethodPicker.route) { inclusive = true }
+                                popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
                                 launchSingleTop = true
                             }
                         }
@@ -575,9 +576,9 @@ fun FirebaseAuthScreen(
                         pendingResolver.value = null
                         pendingLinkingCredential.value = null
                         lastSuccessfulUserId.value = null
-                        if (currentRoute != AuthRoute.MethodPicker.route) {
-                            navController.navigate(AuthRoute.MethodPicker.route) {
-                                popUpTo(AuthRoute.MethodPicker.route) { inclusive = true }
+                        if (currentRoute != startRoute.route) {
+                            navController.navigate(startRoute.route) {
+                                popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
                                 launchSingleTop = true
                             }
                         }
@@ -588,9 +589,9 @@ fun FirebaseAuthScreen(
                         pendingResolver.value = null
                         pendingLinkingCredential.value = null
                         lastSuccessfulUserId.value = null
-                        if (currentRoute != AuthRoute.MethodPicker.route) {
-                            navController.navigate(AuthRoute.MethodPicker.route) {
-                                popUpTo(AuthRoute.MethodPicker.route) { inclusive = true }
+                        if (currentRoute != startRoute.route) {
+                            navController.navigate(startRoute.route) {
+                                popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
                                 launchSingleTop = true
                             }
                         }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
@@ -125,6 +125,10 @@ fun FirebaseAuthScreen(
     val emailLinkFromDifferentDevice = remember { mutableStateOf<String?>(null) }
     val lastSignInPreference =
         remember { mutableStateOf<SignInPreferenceManager.SignInPreference?>(null) }
+    val startRoute = remember(configuration.providers, configuration.isProviderChoiceAlwaysShown) {
+        getStartRoute(configuration)
+    }
+    val skipsMethodPicker = startRoute != AuthRoute.MethodPicker
 
     // Load last sign-in preference on launch
     LaunchedEffect(authState) {
@@ -236,7 +240,7 @@ fun FirebaseAuthScreen(
         ) {
             NavHost(
                 navController = navController,
-                startDestination = AuthRoute.MethodPicker.route,
+                startDestination = startRoute.route,
                 enterTransition = configuration.transitions?.enterTransition ?: {
                     fadeIn(animationSpec = tween(700))
                 },
@@ -319,7 +323,9 @@ fun FirebaseAuthScreen(
                         },
                         onCancel = {
                             pendingLinkingCredential.value = null
-                            if (!navController.popBackStack()) {
+                            if (skipsMethodPicker) {
+                                onSignInCancelled()
+                            } else if (!navController.popBackStack()) {
                                 navController.navigate(AuthRoute.MethodPicker.route) {
                                     popUpTo(AuthRoute.MethodPicker.route) { inclusive = true }
                                     launchSingleTop = true
@@ -339,7 +345,9 @@ fun FirebaseAuthScreen(
                             onSignInFailure(exception)
                         },
                         onCancel = {
-                            if (!navController.popBackStack()) {
+                            if (skipsMethodPicker) {
+                                onSignInCancelled()
+                            } else if (!navController.popBackStack()) {
                                 navController.navigate(AuthRoute.MethodPicker.route) {
                                     popUpTo(AuthRoute.MethodPicker.route) { inclusive = true }
                                     launchSingleTop = true
@@ -665,6 +673,18 @@ sealed class AuthRoute(val route: String) {
     object Success : AuthRoute("auth_success")
     object MfaEnrollment : AuthRoute("auth_mfa_enrollment")
     object MfaChallenge : AuthRoute("auth_mfa_challenge")
+}
+
+internal fun getStartRoute(configuration: AuthUIConfiguration): AuthRoute {
+    if (configuration.isProviderChoiceAlwaysShown || configuration.providers.size != 1) {
+        return AuthRoute.MethodPicker
+    }
+
+    return when (configuration.providers.single()) {
+        is AuthProvider.Email -> AuthRoute.Email
+        is AuthProvider.Phone -> AuthRoute.Phone
+        else -> AuthRoute.MethodPicker
+    }
 }
 
 data class AuthSuccessUiContext(

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenRouteTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenRouteTest.kt
@@ -1,0 +1,101 @@
+package com.firebase.ui.auth.ui.screens
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.firebase.ui.auth.configuration.authUIConfiguration
+import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class FirebaseAuthScreenRouteTest {
+
+    private lateinit var applicationContext: Context
+
+    @Before
+    fun setUp() {
+        applicationContext = ApplicationProvider.getApplicationContext()
+    }
+
+    @Test
+    fun `single email provider starts at email route`() {
+        val configuration = authUIConfiguration {
+            context = applicationContext
+            providers {
+                provider(
+                    AuthProvider.Email(
+                        emailLinkActionCodeSettings = null,
+                        passwordValidationRules = emptyList()
+                    )
+                )
+            }
+        }
+
+        assertThat(getStartRoute(configuration)).isEqualTo(AuthRoute.Email)
+    }
+
+    @Test
+    fun `single phone provider starts at phone route`() {
+        val configuration = authUIConfiguration {
+            context = applicationContext
+            providers {
+                provider(
+                    AuthProvider.Phone(
+                        defaultNumber = null,
+                        defaultCountryCode = null,
+                        allowedCountries = null
+                    )
+                )
+            }
+        }
+
+        assertThat(getStartRoute(configuration)).isEqualTo(AuthRoute.Phone)
+    }
+
+    @Test
+    fun `single email provider shows picker when always shown is enabled`() {
+        val configuration = authUIConfiguration {
+            context = applicationContext
+            providers {
+                provider(
+                    AuthProvider.Email(
+                        emailLinkActionCodeSettings = null,
+                        passwordValidationRules = emptyList()
+                    )
+                )
+            }
+            isProviderChoiceAlwaysShown = true
+        }
+
+        assertThat(getStartRoute(configuration)).isEqualTo(AuthRoute.MethodPicker)
+    }
+
+    @Test
+    fun `multiple providers start at method picker`() {
+        val configuration = authUIConfiguration {
+            context = applicationContext
+            providers {
+                provider(
+                    AuthProvider.Email(
+                        emailLinkActionCodeSettings = null,
+                        passwordValidationRules = emptyList()
+                    )
+                )
+                provider(
+                    AuthProvider.Phone(
+                        defaultNumber = null,
+                        defaultCountryCode = null,
+                        allowedCountries = null
+                    )
+                )
+            }
+        }
+
+        assertThat(getStartRoute(configuration)).isEqualTo(AuthRoute.MethodPicker)
+    }
+}

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenRouteTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenRouteTest.kt
@@ -58,6 +58,23 @@ class FirebaseAuthScreenRouteTest {
     }
 
     @Test
+    fun `single google provider starts at method picker`() {
+        val configuration = authUIConfiguration {
+            context = applicationContext
+            providers {
+                provider(
+                    AuthProvider.Google(
+                        scopes = emptyList(),
+                        serverClientId = "test-client-id"
+                    )
+                )
+            }
+        }
+
+        assertThat(getStartRoute(configuration)).isEqualTo(AuthRoute.MethodPicker)
+    }
+
+    @Test
     fun `single email provider shows picker when always shown is enabled`() {
         val configuration = authUIConfiguration {
             context = applicationContext

--- a/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/AnonymousAuthScreenTest.kt
+++ b/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/AnonymousAuthScreenTest.kt
@@ -167,7 +167,7 @@ class AnonymousAuthScreenTest {
     @Test
     fun `anonymous upgrade enabled links new user sign-up and emits RequiresEmailVerification auth state`() {
         val name = "Anonymous Upgrade User"
-        val email = "anonymousupgrade@example.com"
+        val email = "anonymous-upgrade-${System.currentTimeMillis()}@example.com"
         val password = "Test@123"
         val configuration = authUIConfiguration {
             context = applicationContext

--- a/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/EmailAuthScreenTest.kt
+++ b/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/EmailAuthScreenTest.kt
@@ -149,7 +149,7 @@ class EmailAuthScreenTest {
     }
 
     @Test
-    fun `initial EmailAuthMode is SignIn`() {
+    fun `single email provider starts on email screen when provider choice always shown is false`() {
         val configuration = authUIConfiguration {
             context = applicationContext
             providers {
@@ -167,15 +167,30 @@ class EmailAuthScreenTest {
             TestFirebaseAuthScreen(configuration = configuration, authUI = authUI)
         }
 
-        // Click on email provider in AuthMethodPicker
-        composeAndroidTestRule.onNodeWithText(stringProvider.signInWithEmail)
-            .assertIsDisplayed()
-            .performClick()
+        assertDirectEmailStart()
+    }
 
-        composeAndroidTestRule.waitForIdle()
+    @Test
+    fun `single email provider shows method picker when provider choice always shown is true`() {
+        val configuration = authUIConfiguration {
+            context = applicationContext
+            providers {
+                provider(
+                    AuthProvider.Email(
+                        emailLinkActionCodeSettings = null,
+                        passwordValidationRules = emptyList()
+                    )
+                )
+            }
+            isCredentialManagerEnabled = false
+            isProviderChoiceAlwaysShown = true
+        }
 
-        composeAndroidTestRule.onNodeWithText(stringProvider.signInDefault)
-            .assertIsDisplayed()
+        composeAndroidTestRule.setContent {
+            TestFirebaseAuthScreen(configuration = configuration, authUI = authUI)
+        }
+
+        openEmailProviderFromMethodPicker()
     }
 
     @Test
@@ -212,12 +227,7 @@ class EmailAuthScreenTest {
             currentAuthState = authState
         }
 
-        // Click on email provider in AuthMethodPicker
-        composeAndroidTestRule.onNodeWithText(stringProvider.signInWithEmail)
-            .assertIsDisplayed()
-            .performClick()
-
-        composeAndroidTestRule.waitForIdle()
+        assertDirectEmailStart()
 
         composeAndroidTestRule.onNodeWithText(stringProvider.emailHint)
             .performScrollTo()
@@ -306,12 +316,7 @@ class EmailAuthScreenTest {
             currentAuthState = authState
         }
 
-        // Click on email provider in AuthMethodPicker
-        composeAndroidTestRule.onNodeWithText(stringProvider.signInWithEmail)
-            .assertIsDisplayed()
-            .performClick()
-
-        composeAndroidTestRule.waitForIdle()
+        assertDirectEmailStart()
 
         composeAndroidTestRule.onNodeWithText(stringProvider.emailHint)
             .performScrollTo()
@@ -381,12 +386,7 @@ class EmailAuthScreenTest {
             currentAuthState = authState
         }
 
-        // Click on email provider in AuthMethodPicker
-        composeAndroidTestRule.onNodeWithText(stringProvider.signInWithEmail)
-            .assertIsDisplayed()
-            .performClick()
-
-        composeAndroidTestRule.waitForIdle()
+        assertDirectEmailStart()
 
         composeAndroidTestRule.onNodeWithText(stringProvider.signInDefault)
             .assertIsDisplayed()
@@ -471,12 +471,7 @@ class EmailAuthScreenTest {
             currentAuthState = authState
         }
 
-        // Click on email provider in AuthMethodPicker
-        composeAndroidTestRule.onNodeWithText(stringProvider.signInWithEmail)
-            .assertIsDisplayed()
-            .performClick()
-
-        composeAndroidTestRule.waitForIdle()
+        assertDirectEmailStart()
 
         composeAndroidTestRule.onNodeWithText(stringProvider.signInDefault)
             .assertIsDisplayed()
@@ -569,15 +564,7 @@ class EmailAuthScreenTest {
             currentAuthState = authState
         }
 
-        // Click on email provider in AuthMethodPicker
-        composeAndroidTestRule.onNodeWithText(stringProvider.signInWithEmail)
-            .assertIsDisplayed()
-            .performClick()
-
-        composeAndroidTestRule.waitForIdle()
-
-        composeAndroidTestRule.onNodeWithText(stringProvider.signInDefault)
-            .assertIsDisplayed()
+        assertDirectEmailStart()
 
         // Click "Sign in with email link" button to switch to email link mode
         composeAndroidTestRule.onNodeWithText(stringProvider.signInWithEmailLink.uppercase())
@@ -744,6 +731,7 @@ class EmailAuthScreenTest {
                     )
                 )
             }
+            isProviderChoiceAlwaysShown = true
         }
 
         // Track auth state changes
@@ -758,12 +746,7 @@ class EmailAuthScreenTest {
         // STEP 1: Sign up and verify credential saved
         println("TEST: Starting sign-up flow...")
 
-        // Click on email provider
-        composeAndroidTestRule.onNodeWithText(stringProvider.signInWithEmail)
-            .assertIsDisplayed()
-            .performClick()
-
-        composeAndroidTestRule.waitForIdle()
+        openEmailProviderFromMethodPicker()
 
         // Click sign-up
         composeAndroidTestRule.onNodeWithText(stringProvider.signupPageTitle.uppercase())
@@ -816,13 +799,9 @@ class EmailAuthScreenTest {
         // STEP 3: Navigate to SignInUI screen to trigger credential retrieval
         println("TEST: Navigating to sign-in screen to trigger credential retrieval...")
 
-        // Click on email provider to show SignInUI, which will trigger auto-retrieval
-        composeAndroidTestRule.onNodeWithText(stringProvider.signInWithEmail)
-            .assertIsDisplayed()
-            .performClick()
-
         composeAndroidTestRule.waitForIdle()
         shadowOf(Looper.getMainLooper()).idle()
+        clickEmailProviderFromMethodPicker()
 
         // SignInUI's LaunchedEffect should now trigger credential retrieval and auto-sign-in
         println("TEST: Waiting for automatic credential retrieval and auto-sign-in...")
@@ -877,6 +856,7 @@ class EmailAuthScreenTest {
                     )
                 )
             }
+            isProviderChoiceAlwaysShown = true
         }
 
         var currentAuthState: AuthState = AuthState.Idle
@@ -890,11 +870,7 @@ class EmailAuthScreenTest {
         // STEP 1: Sign up and save credential
         println("TEST: Starting sign-up flow...")
 
-        composeAndroidTestRule.onNodeWithText(stringProvider.signInWithEmail)
-            .assertIsDisplayed()
-            .performClick()
-
-        composeAndroidTestRule.waitForIdle()
+        openEmailProviderFromMethodPicker()
 
         composeAndroidTestRule.onNodeWithText(stringProvider.signupPageTitle.uppercase())
             .assertIsDisplayed()
@@ -940,12 +916,9 @@ class EmailAuthScreenTest {
         // STEP 3: Navigate to SignInUI to trigger credential retrieval
         println("TEST: Navigating to sign-in screen...")
 
-        composeAndroidTestRule.onNodeWithText(stringProvider.signInWithEmail)
-            .assertIsDisplayed()
-            .performClick()
-
         composeAndroidTestRule.waitForIdle()
         shadowOf(Looper.getMainLooper()).idle()
+        clickEmailProviderFromMethodPicker()
 
         println("TEST: Waiting for automatic credential retrieval and auto-sign-in...")
 
@@ -997,11 +970,7 @@ class EmailAuthScreenTest {
         }
 
         // Sign up
-        composeAndroidTestRule.onNodeWithText(stringProvider.signInWithEmail)
-            .assertIsDisplayed()
-            .performClick()
-
-        composeAndroidTestRule.waitForIdle()
+        assertDirectEmailStart()
 
         composeAndroidTestRule.onNodeWithText(stringProvider.signupPageTitle.uppercase())
             .assertIsDisplayed()
@@ -1077,5 +1046,22 @@ class EmailAuthScreenTest {
                 }
             }
         }
+    }
+
+    private fun assertDirectEmailStart() {
+        composeAndroidTestRule.waitForIdle()
+        composeAndroidTestRule.onNodeWithText(stringProvider.signInDefault)
+            .assertIsDisplayed()
+    }
+
+    private fun openEmailProviderFromMethodPicker() {
+        clickEmailProviderFromMethodPicker()
+        assertDirectEmailStart()
+    }
+
+    private fun clickEmailProviderFromMethodPicker() {
+        composeAndroidTestRule.onNodeWithText(stringProvider.signInWithEmail)
+            .assertIsDisplayed()
+            .performClick()
     }
 }

--- a/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/GoogleAuthScreenTest.kt
+++ b/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/GoogleAuthScreenTest.kt
@@ -149,13 +149,15 @@ class GoogleAuthScreenTest {
 
     @Test
     fun `anonymous upgrade with google links anonymous user and emits Success auth state`() = runTest {
-        val email = "anonymousupgrade@example.com"
+        val email = "anonymous-google-upgrade-${System.currentTimeMillis()}@example.com"
+        val sub = "anonymous-google-upgrade-${System.nanoTime()}"
         val name = "Anonymous Upgrade User"
         val photoUrl = "https://example.com/avatar.jpg"
 
         // Generate a JWT token for the Google account
         val mockIdToken = generateMockGoogleIdToken(
             email = email,
+            sub = sub,
             name = name,
             photoUrl = photoUrl
         )


### PR DESCRIPTION
- Demonstrates fix, when only email is selected as provider (and `isProviderChoiceAlwaysShown` is set to false which is the default), it should open that screen immediately. 
- Updated `FirebaseAuthUI.kt` to reuse existing logic to get initial state.
- I've pointed this to `version-10.0.0-beta03` which is the latest of master so that we can version another beta release.

fixes https://github.com/firebase/FirebaseUI-Android/issues/2310

### Updated tests for the following reasons:
- EmailAuthScreenTest.kt Updated for the new single-email-provider behavior: direct email screen by default, picker only when isProviderChoiceAlwaysShown = true.
- AnonymousAuthScreenTest.kt Switched to unique test email data to avoid upgrade collisions exposed while updating this flow.
- GoogleAuthScreenTest.kt Switched to unique mock Google identity data to avoid account-linking collisions during upgrade tests.
- FirebaseAuthUI.kt Added IdTokenListener to make upgrade/link auth state updates observable and keep tests stable.

### Screen recording showing moving straight to email screen when only email selected and `isProviderChoiceAlwaysShown` is false

[Screen_recording_20260327_115854.webm](https://github.com/user-attachments/assets/22d1d4d7-4d77-4c29-8ecf-f44e7a40e9f0)
