### PR TITLE
fix(auth): preserve linkDomain in email link ActionCodeSettings

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AuthProvider.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AuthProvider.kt
@@ -211,6 +211,7 @@ abstract class AuthProvider(open val providerId: String, open val providerName: 
             return actionCodeSettings {
                 url = continueUrl
                 handleCodeInApp = emailLinkActionCodeSettings.canHandleCodeInApp()
+                linkDomain = emailLinkActionCodeSettings.linkDomain
                 iosBundleId = emailLinkActionCodeSettings.iosBundle
                 setAndroidPackageName(
                     emailLinkActionCodeSettings.androidPackageName ?: "",

--- a/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/AuthProviderTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/AuthProviderTest.kt
@@ -33,6 +33,29 @@ class AuthProviderTest {
     // =============================================================================================
 
     @Test
+    fun `addSessionInfoToActionCodeSettings preserves linkDomain`() {
+        val actionCodeSettings = actionCodeSettings {
+            url = "https://example.com"
+            handleCodeInApp = true
+            linkDomain = "myapp.page.link"
+            setAndroidPackageName("com.example", true, null)
+        }
+
+        val provider = AuthProvider.Email(
+            isEmailLinkSignInEnabled = true,
+            emailLinkActionCodeSettings = actionCodeSettings,
+            passwordValidationRules = emptyList()
+        )
+
+        val result = provider.addSessionInfoToActionCodeSettings(
+            sessionId = "abc123",
+            anonymousUserId = ""
+        )
+
+        assertThat(result.linkDomain).isEqualTo("myapp.page.link")
+    }
+
+    @Test
     fun `email provider with valid configuration should succeed`() {
         val provider = AuthProvider.Email(
             emailLinkActionCodeSettings = null,


### PR DESCRIPTION
Fixes #1730 

When sending an email sign-in link, addSessionInfoToActionCodeSettings rebuilt the ActionCodeSettings without forwarding linkDomain, so custom domains were silently ignored and the default project domain was always used instead. This adds linkDomain to the rebuilt settings and a regression test to cover it.

