### PR TITLE
fix(auth): allow SAML providers in AuthUIConfiguration

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/configuration/AuthUIConfiguration.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/AuthUIConfiguration.kt
@@ -63,10 +63,12 @@ class AuthUIConfigurationBuilder {
             "At least one provider must be configured"
         }
 
-        // No unsupported providers (allow predefined providers and custom OIDC providers starting with "oidc.")
+        // No unsupported providers (allow predefined providers and custom OIDC/SAML providers)
         val supportedProviderIds = Provider.entries.map { it.id }.toSet()
         val unknownProviders = providers.filter { provider ->
-            provider.providerId !in supportedProviderIds && !provider.providerId.startsWith("oidc.")
+            provider.providerId !in supportedProviderIds &&
+                    !provider.providerId.startsWith("oidc.") &&
+                    !provider.providerId.startsWith("saml.")
         }
         require(unknownProviders.isEmpty()) {
             "Unknown providers: ${unknownProviders.joinToString { it.providerId }}"

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/AuthUIConfiguration.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/AuthUIConfiguration.kt
@@ -65,10 +65,10 @@ class AuthUIConfigurationBuilder {
 
         // No unsupported providers (allow predefined providers and custom OIDC/SAML providers)
         val supportedProviderIds = Provider.entries.map { it.id }.toSet()
+        val customPrefixes = listOf("oidc.", "saml.")
         val unknownProviders = providers.filter { provider ->
             provider.providerId !in supportedProviderIds &&
-                    !provider.providerId.startsWith("oidc.") &&
-                    !provider.providerId.startsWith("saml.")
+                    customPrefixes.none { provider.providerId.startsWith(it) }
         }
         require(unknownProviders.isEmpty()) {
             "Unknown providers: ${unknownProviders.joinToString { it.providerId }}"

--- a/auth/src/test/java/com/firebase/ui/auth/configuration/AuthUIConfigurationTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/configuration/AuthUIConfigurationTest.kt
@@ -325,7 +325,7 @@ class AuthUIConfigurationTest {
     }
 
     @Test
-    fun `validation accepts custom OIDC providers`() {
+    fun `validation accepts custom OIDC and SAML providers`() {
         val linkedInProvider = AuthProvider.GenericOAuth(
             providerName = "LinkedIn",
             providerId = "oidc.linkedin",
@@ -348,17 +348,30 @@ class AuthUIConfigurationTest {
             contentColor = null,
         )
 
+        val samlProvider = AuthProvider.GenericOAuth(
+            providerName = "Corp SSO",
+            providerId = "saml.corp-sso",
+            scopes = listOf(),
+            customParameters = mapOf(),
+            buttonLabel = "Sign in with Corp SSO",
+            buttonIcon = null,
+            buttonColor = null,
+            contentColor = null,
+        )
+
         val config = authUIConfiguration {
             context = applicationContext
             providers {
                 provider(linkedInProvider)
                 provider(oktaProvider)
+                provider(samlProvider)
             }
         }
 
-        assertThat(config.providers).hasSize(2)
+        assertThat(config.providers).hasSize(3)
         assertThat(config.providers[0].providerId).isEqualTo("oidc.linkedin")
         assertThat(config.providers[1].providerId).isEqualTo("oidc.okta")
+        assertThat(config.providers[2].providerId).isEqualTo("saml.corp-sso")
     }
 
     @Test


### PR DESCRIPTION
The provider ID allowlist only permitted oidc.-prefixed IDs for custom providers via GenericOAuth. This adds `saml. `to the same check so Firebase SAML providers (e.g. `saml.corp-sso`) pass validation rather than being rejected as unknown.