### PR TITLE
feat(auth): add reauthentication flow with automatic operation retry

### DIFF
--- a/app/src/main/java/com/firebaseui/android/demo/HighLevelApiDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/HighLevelApiDemoActivity.kt
@@ -25,11 +25,19 @@ import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.FirebaseAuthUI
@@ -212,6 +220,9 @@ private fun AppAuthenticatedContent(
     val configuration = uiContext.configuration
     when (state) {
         is AuthState.Success -> {
+            val context = LocalContext.current
+            val lifecycleOwner = LocalLifecycleOwner.current
+            var isDeletingAccount by remember { mutableStateOf(false) }
             val user = uiContext.authUI.getCurrentUser()
             val identifier = user.displayIdentifier()
             Column(
@@ -260,6 +271,28 @@ private fun AppAuthenticatedContent(
                 Spacer(modifier = Modifier.height(8.dp))
                 Button(onClick = uiContext.onSignOut) {
                     Text(stringProvider.signOutAction)
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(
+                    onClick = {
+                        lifecycleOwner.lifecycleScope.launch {
+                            isDeletingAccount = true
+                            try {
+                                uiContext.authUI.delete(context)
+                            } catch (e: AuthException.InvalidCredentialsException) {
+                                // ReauthenticationRequired state was emitted —
+                                // FirebaseAuthScreen navigates to the reauth flow automatically.
+                                Log.d("HighLevelApiDemoActivity", "Reauth required before delete")
+                            } catch (e: AuthException) {
+                                Log.e("HighLevelApiDemoActivity", "Delete failed", e)
+                            } finally {
+                                isDeletingAccount = false
+                            }
+                        }
+                    },
+                    enabled = !isDeletingAccount
+                ) {
+                    if (isDeletingAccount) CircularProgressIndicator() else Text("Delete account")
                 }
             }
         }

--- a/app/src/main/java/com/firebaseui/android/demo/HighLevelApiDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/HighLevelApiDemoActivity.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -20,6 +22,7 @@ import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.ShapeDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TooltipAnchorPosition
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
@@ -28,6 +31,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.lifecycleScope
@@ -38,6 +42,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.FirebaseAuthUI
@@ -200,6 +205,13 @@ class HighLevelApiDemoActivity : ComponentActivity() {
                         onSignInCancelled = {
                             Log.d("HighLevelApiDemoActivity", "Authentication cancelled")
                         },
+                        reauthContent = { state, onDismiss ->
+                            ReauthDialog(
+                                authUI = authUI,
+                                state = state,
+                                onDismiss = onDismiss,
+                            )
+                        },
                         authenticatedContent = { state, uiContext ->
                             AppAuthenticatedContent(state, uiContext)
                         }
@@ -225,6 +237,19 @@ private fun AppAuthenticatedContent(
             var isDeletingAccount by remember { mutableStateOf(false) }
             val user = uiContext.authUI.getCurrentUser()
             val identifier = user.displayIdentifier()
+            var showChangePasswordDialog by remember { mutableStateOf(false) }
+
+            if (showChangePasswordDialog) {
+                ChangePasswordDialog(
+                    authUI = uiContext.authUI,
+                    configuration = uiContext.configuration,
+                    stringProvider = uiContext.stringProvider,
+                    context = context,
+                    lifecycleOwner = lifecycleOwner,
+                    onDismiss = { showChangePasswordDialog = false },
+                )
+            }
+
             Column(
                 modifier = Modifier.fillMaxSize(),
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -271,6 +296,10 @@ private fun AppAuthenticatedContent(
                 Spacer(modifier = Modifier.height(8.dp))
                 Button(onClick = uiContext.onSignOut) {
                     Text(stringProvider.signOutAction)
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(onClick = { showChangePasswordDialog = true }) {
+                    Text("Change password (withReauth)")
                 }
                 Spacer(modifier = Modifier.height(8.dp))
                 Button(
@@ -358,4 +387,199 @@ private fun AppAuthenticatedContent(
             }
         }
     }
+}
+
+@Composable
+private fun ReauthDialog(
+    authUI: FirebaseAuthUI,
+    state: AuthState.ReauthenticationRequired,
+    onDismiss: () -> Unit,
+) {
+    var password by remember { mutableStateOf("") }
+    var isVerifying by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    val coroutineScope = rememberCoroutineScope()
+    val email = state.user.email.orEmpty()
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        title = {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text("Verify your identity")
+                state.reason?.let { reason ->
+                    Text(
+                        reason,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    "Signing in as $email",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                com.firebase.ui.auth.ui.components.AuthTextField(
+                    value = password,
+                    onValueChange = {
+                        password = it
+                        errorMessage = null
+                    },
+                    label = { Text("Password") },
+                    isSecureTextField = true,
+                    isError = errorMessage != null,
+                    errorMessage = errorMessage,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+        confirmButton = {
+            Button(
+                onClick = {
+                    coroutineScope.launch {
+                        isVerifying = true
+                        errorMessage = null
+                        try {
+                            val result = authUI.auth
+                                .signInWithEmailAndPassword(email, password)
+                                .await()
+                            result.user?.let { user ->
+                                authUI.updateAuthState(AuthState.Success(result, user))
+                            }
+                        } catch (e: Exception) {
+                            errorMessage = "Incorrect password. Please try again."
+                        } finally {
+                            isVerifying = false
+                        }
+                    }
+                },
+                enabled = password.isNotBlank() && !isVerifying,
+            ) {
+                if (isVerifying) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp,
+                    )
+                } else {
+                    Text("Verify")
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun ChangePasswordDialog(
+    authUI: FirebaseAuthUI,
+    configuration: com.firebase.ui.auth.configuration.AuthUIConfiguration,
+    stringProvider: com.firebase.ui.auth.configuration.string_provider.AuthUIStringProvider,
+    context: android.content.Context,
+    lifecycleOwner: androidx.lifecycle.LifecycleOwner,
+    onDismiss: () -> Unit,
+) {
+    var newPassword by remember { mutableStateOf("") }
+    var confirmPassword by remember { mutableStateOf("") }
+    var isUpdating by remember { mutableStateOf(false) }
+    var updateError by remember { mutableStateOf<String?>(null) }
+
+    val emailProvider = remember(configuration) {
+        configuration.providers.filterIsInstance<com.firebase.ui.auth.configuration.auth_provider.AuthProvider.Email>().firstOrNull()
+    }
+    val passwordValidator = remember(emailProvider, stringProvider) {
+        com.firebase.ui.auth.configuration.validators.PasswordValidator(
+            stringProvider = stringProvider,
+            rules = emailProvider?.passwordValidationRules ?: emptyList(),
+        )
+    }
+    val confirmValidator = remember(stringProvider) {
+        com.firebase.ui.auth.configuration.validators.PasswordValidator(
+            stringProvider = stringProvider,
+            rules = emptyList(),
+        )
+    }
+
+    val passwordsMatch = newPassword == confirmPassword
+    val isValid = !passwordValidator.hasError && newPassword.isNotBlank() &&
+            passwordsMatch && confirmPassword.isNotBlank()
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Change password") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                com.firebase.ui.auth.ui.components.AuthTextField(
+                    value = newPassword,
+                    onValueChange = {
+                        newPassword = it
+                        updateError = null
+                    },
+                    label = { Text("New password") },
+                    isSecureTextField = true,
+                    validator = passwordValidator,
+                )
+                com.firebase.ui.auth.ui.components.AuthTextField(
+                    value = confirmPassword,
+                    onValueChange = {
+                        confirmPassword = it
+                        updateError = null
+                    },
+                    label = { Text("Confirm password") },
+                    isSecureTextField = true,
+                    isError = confirmPassword.isNotEmpty() && !passwordsMatch,
+                    errorMessage = if (confirmPassword.isNotEmpty() && !passwordsMatch) "Passwords do not match" else null,
+                    validator = confirmValidator,
+                )
+                if (updateError != null) {
+                    Text(
+                        updateError!!,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+        confirmButton = {
+            Button(
+                onClick = {
+                    lifecycleOwner.lifecycleScope.launch {
+                        isUpdating = true
+                        updateError = null
+                        try {
+                            authUI.withReauth(
+                                context,
+                                reason = "Verify your identity to change your password",
+                            ) {
+                                authUI.getCurrentUser()?.updatePassword(newPassword)?.await()
+                                Log.d("HighLevelApiDemoActivity", "Password changed successfully")
+                                onDismiss()
+                            }
+                        } catch (e: Exception) {
+                            updateError = "Failed to update password. Please try again."
+                        } finally {
+                            isUpdating = false
+                        }
+                    }
+                },
+                enabled = isValid && !isUpdating,
+            ) {
+                if (isUpdating) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp,
+                    )
+                } else {
+                    Text("Update")
+                }
+            }
+        },
+    )
 }

--- a/auth/README.md
+++ b/auth/README.md
@@ -52,6 +52,7 @@ Equivalent FirebaseUI libraries are available for [iOS](https://github.com/fireb
    - [High-Level API (Recommended)](#high-level-api-recommended)
    - [Low-Level API (Advanced)](#low-level-api-advanced)
    - [Custom UI with Slots](#custom-ui-with-slots)
+   - [Reauthentication](#reauthentication)
 8. [Theming & Customization](#theming--customization)
    - [Using Default Themes](#using-default-themes)
    - [Using Adaptive Theme](#using-adaptive-theme-recommended)
@@ -794,129 +795,256 @@ class AuthActivity : ComponentActivity() {
 
 ### Custom UI with Slots
 
-For complete UI control while keeping authentication logic, use content slots:
+`FirebaseAuthScreen` accepts optional slot parameters that let you replace individual screens with your own UI while keeping all authentication logic intact. Each slot receives a state object with the data and callbacks needed to drive your UI.
 
 ```kotlin
-@Composable
-fun CustomEmailAuth() {
-    val emailConfig = AuthProvider.Email(
-        passwordValidationRules = listOf(
-            PasswordRule.MinimumLength(8),
-            PasswordRule.RequireDigit
-        )
-    )
-
-    EmailAuthScreen(
-        configuration = emailConfig,
-        onSuccess = { /* ... */ },
-        onError = { /* ... */ },
-        onCancel = { /* ... */ }
-    ) { state ->
-        // Custom UI with full control
-        when (state.mode) {
-            EmailAuthMode.SignIn -> {
-                CustomSignInUI(state)
-            }
-            EmailAuthMode.SignUp -> {
-                CustomSignUpUI(state)
-            }
-            EmailAuthMode.ResetPassword -> {
-                CustomResetPasswordUI(state)
-            }
-        }
-    }
+FirebaseAuthScreen(
+    configuration = configuration,
+    onSignInSuccess = { /* ... */ },
+    onSignInFailure = { /* ... */ },
+    onSignInCancelled = { /* ... */ },
+    customMethodPickerLayout = { providers, onProviderSelected -> /* ... */ },
+    customMethodPickerTermsConfiguration = MethodPickerTermsConfiguration(
+        content = { Text("By continuing you agree to our Terms") },
+        accepted = termsAccepted,
+        disableProvidersUntilAccepted = true,
+    ),
+    emailContent = { state -> /* ... */ },
+    phoneContent = { state -> /* ... */ },
+    mfaEnrollmentContent = { state -> /* ... */ },
+    mfaChallengeContent = { state -> /* ... */ },
+    reauthContent = { state, onDismiss -> /* ... */ },
+) { authState, uiContext ->
+    // authenticated content
 }
+```
 
-@Composable
-fun CustomSignInUI(state: EmailAuthContentState) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(
-            text = "Welcome Back!",
-            style = MaterialTheme.typography.headlineLarge
-        )
+#### Method picker (`customMethodPickerLayout`)
 
-        Spacer(modifier = Modifier.height(32.dp))
+Replaces the default provider selection screen. Receives the configured providers and a callback to invoke when the user selects one.
 
-        OutlinedTextField(
-            value = state.email,
-            onValueChange = state.onEmailChange,
-            label = { Text("Email") },
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
-            modifier = Modifier.fillMaxWidth()
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        OutlinedTextField(
-            value = state.password,
-            onValueChange = state.onPasswordChange,
-            label = { Text("Password") },
-            visualTransformation = PasswordVisualTransformation(),
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-            modifier = Modifier.fillMaxWidth()
-        )
-
-        if (state.error != null) {
-            Text(
-                text = state.error!!,
-                color = MaterialTheme.colorScheme.error,
-                modifier = Modifier.padding(top = 8.dp)
-            )
-        }
-
-        Spacer(modifier = Modifier.height(24.dp))
-
-        Button(
-            onClick = state.onSignInClick,
-            enabled = !state.isLoading,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            if (state.isLoading) {
-                CircularProgressIndicator(modifier = Modifier.size(24.dp))
-            } else {
-                Text("Sign In")
+```kotlin
+customMethodPickerLayout = { providers, onProviderSelected ->
+    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+        providers.forEach { provider ->
+            OutlinedButton(
+                onClick = { onProviderSelected(provider) },
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+            ) {
+                Text("Continue with ${provider.providerName}")
             }
-        }
-
-        TextButton(onClick = state.onGoToResetPassword) {
-            Text("Forgot Password?")
-        }
-
-        TextButton(onClick = state.onGoToSignUp) {
-            Text("Create Account")
         }
     }
 }
 ```
 
-Similarly, create custom phone authentication UI:
+Use `customMethodPickerTermsConfiguration` alongside it to add a terms-of-service checkbox that can optionally gate provider selection until accepted.
 
 ```kotlin
-@Composable
-fun CustomPhoneAuth() {
-    val phoneConfig = AuthProvider.Phone(defaultCountryCode = "US")
+customMethodPickerTermsConfiguration = MethodPickerTermsConfiguration(
+    content = { Text("I agree to the Terms of Service") },
+    accepted = termsAccepted,
+    disableProvidersUntilAccepted = true,
+)
+```
 
-    PhoneAuthScreen(
-        configuration = phoneConfig,
-        onSuccess = { /* ... */ },
-        onError = { /* ... */ },
-        onCancel = { /* ... */ }
-    ) { state ->
-        when (state.step) {
-            PhoneAuthStep.EnterPhoneNumber -> {
-                CustomPhoneNumberInput(state)
+#### Email (`emailContent`)
+
+Replaces the default email sign-in / sign-up / password reset screens. The `EmailAuthContentState` carries the current `mode` (`SignIn`, `SignUp`, `ResetPassword`, `EmailLinkSignIn`), field values, and callbacks for every action.
+
+```kotlin
+emailContent = { state ->
+    when (state.mode) {
+        EmailAuthMode.SignIn -> {
+            Column {
+                OutlinedTextField(
+                    value = state.email,
+                    onValueChange = state.onEmailChange,
+                    label = { Text("Email") },
+                )
+                OutlinedTextField(
+                    value = state.password,
+                    onValueChange = state.onPasswordChange,
+                    label = { Text("Password") },
+                    visualTransformation = PasswordVisualTransformation(),
+                )
+                state.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+                Button(onClick = state.onSignInClick, enabled = !state.isLoading) {
+                    Text("Sign in")
+                }
+                TextButton(onClick = state.onGoToSignUp) { Text("Create account") }
+                TextButton(onClick = state.onGoToResetPassword) { Text("Forgot password?") }
             }
-            PhoneAuthStep.EnterVerificationCode -> {
-                CustomVerificationCodeInput(state)
+        }
+        EmailAuthMode.SignUp -> { /* ... */ }
+        EmailAuthMode.ResetPassword -> { /* ... */ }
+        EmailAuthMode.EmailLinkSignIn -> { /* ... */ }
+    }
+}
+```
+
+#### Phone (`phoneContent`)
+
+Replaces the default phone number entry and SMS code verification screens. The `PhoneAuthContentState` carries the current `step` (`EnterPhoneNumber`, `EnterVerificationCode`), field values, and callbacks.
+
+```kotlin
+phoneContent = { state ->
+    when (state.step) {
+        PhoneAuthStep.EnterPhoneNumber -> {
+            Column {
+                OutlinedTextField(
+                    value = state.phoneNumber,
+                    onValueChange = state.onPhoneNumberChange,
+                    label = { Text("Phone number") },
+                )
+                state.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+                Button(onClick = state.onSendCodeClick, enabled = !state.isLoading) {
+                    Text("Send code")
+                }
+            }
+        }
+        PhoneAuthStep.EnterVerificationCode -> {
+            Column {
+                OutlinedTextField(
+                    value = state.verificationCode,
+                    onValueChange = state.onVerificationCodeChange,
+                    label = { Text("Verification code") },
+                )
+                Button(onClick = state.onVerifyCodeClick, enabled = !state.isLoading) {
+                    Text("Verify")
+                }
+                if (state.resendTimer == 0) {
+                    TextButton(onClick = state.onResendCodeClick) { Text("Resend code") }
+                }
             }
         }
     }
 }
+```
+
+#### MFA enrollment (`mfaEnrollmentContent`)
+
+Replaces the default MFA enrollment screens. The `MfaEnrollmentContentState` carries the current `step`, `availableFactors`, `enrolledFactors`, and callbacks for factor selection, unenrollment, and navigation.
+
+```kotlin
+mfaEnrollmentContent = { state ->
+    when (state.step) {
+        MfaEnrollmentStep.SelectFactor -> {
+            Column {
+                state.availableFactors.forEach { factor ->
+                    Button(onClick = { state.onFactorSelected(factor) }) {
+                        Text("Enroll ${factor.name}")
+                    }
+                }
+                state.onSkipClick?.let { skip ->
+                    TextButton(onClick = skip) { Text("Skip") }
+                }
+            }
+        }
+        // Handle other steps...
+        else -> { /* ... */ }
+    }
+}
+```
+
+#### MFA challenge (`mfaChallengeContent`)
+
+Replaces the default MFA verification screen shown during sign-in. The `MfaChallengeContentState` carries `factorType`, `verificationCode`, `resendTimer`, and callbacks to verify or resend.
+
+```kotlin
+mfaChallengeContent = { state ->
+    Column {
+        state.maskedPhoneNumber?.let { Text("Code sent to $it") }
+        OutlinedTextField(
+            value = state.verificationCode,
+            onValueChange = state.onVerificationCodeChange,
+            label = { Text("Verification code") },
+        )
+        state.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+        Button(onClick = state.onVerifyClick, enabled = !state.isLoading) {
+            Text("Verify")
+        }
+        if (state.resendTimer == 0) {
+            state.onResendCodeClick?.let { resend ->
+                TextButton(onClick = resend) { Text("Resend code") }
+            }
+        } else {
+            Text("Resend available in ${state.resendTimer}s")
+        }
+        TextButton(onClick = state.onCancelClick) { Text("Cancel") }
+    }
+}
+```
+
+#### Reauthentication (`reauthContent`)
+
+Replaces the default reauthentication bottom sheet shown when a sensitive operation requires the user to re-verify their identity. Receives the `AuthState.ReauthenticationRequired` state (including an optional `reason` string and the signed-in `user`) and an `onDismiss` callback that resets auth state to `Idle`.
+
+```kotlin
+reauthContent = { state, onDismiss ->
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Verify your identity") },
+        text = {
+            Column {
+                state.reason?.let { Text(it) }
+                OutlinedTextField(
+                    value = password,
+                    onValueChange = { password = it },
+                    label = { Text("Password") },
+                    visualTransformation = PasswordVisualTransformation(),
+                )
+            }
+        },
+        confirmButton = {
+            Button(onClick = {
+                // Re-authenticate then update auth state on success
+            }) { Text("Confirm") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
+}
+```
+
+For most cases, use [`withReauth`](#reauthentication) instead — it handles the full reauth cycle automatically and only shows the default bottom sheet. Use `reauthContent` when you need a custom design for the reauth UI.
+
+### Reauthentication
+
+Firebase requires the user to have signed in recently before performing sensitive operations like deleting their account or changing their password. If the session is too old, Firebase throws `FirebaseAuthRecentLoginRequiredException`.
+
+`withReauth` wraps any sensitive operation. If the exception is thrown, it automatically emits `AuthState.ReauthenticationRequired` and — once the user reauthenticates via the default bottom sheet or your `reauthContent` slot — retries the original operation.
+
+```kotlin
+lifecycleScope.launch {
+    authUI.withReauth(
+        context = context,
+        reason = "Verify your identity to delete your account",
+    ) {
+        auth.currentUser?.delete()?.await()
+    }
+}
+```
+
+`withReauth` handles the full cycle:
+
+1. Runs the operation.
+2. If `FirebaseAuthRecentLoginRequiredException` is thrown, emits `AuthState.ReauthenticationRequired` with the retry attached.
+3. `FirebaseAuthScreen` shows the reauth UI scoped to the user's linked providers.
+4. On successful reauthentication, retries the operation automatically and emits `AuthState.Success` or `AuthState.Error`.
+
+**Activity-based alternative:** use `createReauthFlow` to start a standalone reauthentication activity scoped to the current user's linked providers, returning an `AuthFlowController`.
+
+```kotlin
+val reauth = authUI.createReauthFlow(
+    context = context,
+    configuration = authUIConfiguration {
+        // Providers are automatically filtered to those linked to the current user
+    },
+)
+val intent = reauth.createIntent(context)
+launcher.launch(intent)
 ```
 
 ## Multi-Factor Authentication

--- a/auth/src/main/java/com/firebase/ui/auth/AuthFlowController.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthFlowController.kt
@@ -103,7 +103,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  */
 class AuthFlowController internal constructor(
     private val authUI: FirebaseAuthUI,
-    private val configuration: AuthUIConfiguration
+    internal val configuration: AuthUIConfiguration
 ) {
 
     private val coroutineScope = CoroutineScope(Dispatchers.Main + Job())

--- a/auth/src/main/java/com/firebase/ui/auth/AuthState.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthState.kt
@@ -209,6 +209,35 @@ abstract class AuthState private constructor() {
     }
 
     /**
+     * Reauthentication is required before a sensitive operation (e.g. delete account, change email)
+     * can proceed. Use [FirebaseAuthUI.createReauthFlow] to launch the reauthentication flow.
+     *
+     * @property user The [FirebaseUser] that needs to reauthenticate
+     * @property reason Optional human-readable reason to show the user
+     */
+    class ReauthenticationRequired(
+        val user: FirebaseUser,
+        val reason: String? = null,
+        // Not included in equals/hashCode — lambdas have no meaningful equality.
+        val retryOperation: (suspend (android.content.Context) -> Unit)? = null,
+    ) : AuthState() {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is ReauthenticationRequired) return false
+            return user == other.user && reason == other.reason
+        }
+
+        override fun hashCode(): Int {
+            var result = user.hashCode()
+            result = 31 * result + (reason?.hashCode() ?: 0)
+            return result
+        }
+
+        override fun toString(): String =
+            "AuthState.ReauthenticationRequired(user=$user, reason=$reason)"
+    }
+
+    /**
      * Password reset link has been sent to the user's email.
      */
     class PasswordResetLinkSent : AuthState() {

--- a/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthUI.kt
@@ -488,6 +488,50 @@ class FirebaseAuthUI private constructor(
      * @throws AuthException.UnknownException for other errors
      * @since 10.0.0
      */
+    /**
+     * Executes a sensitive operation, automatically handling reauthentication if required.
+     *
+     * If the [operation] throws [FirebaseAuthRecentLoginRequiredException], this method emits
+     * [AuthState.ReauthenticationRequired] with the operation attached as [AuthState.ReauthenticationRequired.retryOperation].
+     * [FirebaseAuthScreen] observes this state and presents a reauthentication sheet; on success
+     * the operation is retried automatically without any further action from the caller.
+     *
+     * All other exceptions propagate normally.
+     *
+     * **Example:**
+     * ```kotlin
+     * lifecycleScope.launch {
+     *     authUI.withReauth(context, reason = "Verify your identity to change email") {
+     *         user.updateEmail(newEmail).await()
+     *     }
+     * }
+     * ```
+     *
+     * @param context Android [Context]
+     * @param reason Optional message shown to the user explaining why reauthentication is needed
+     * @param operation The sensitive operation to attempt
+     * @since 10.0.0
+     */
+    suspend fun withReauth(
+        context: Context,
+        reason: String? = null,
+        operation: suspend () -> Unit,
+    ) {
+        try {
+            operation()
+        } catch (e: FirebaseAuthRecentLoginRequiredException) {
+            val user = auth.currentUser
+                ?: throw AuthException.UserNotFoundException(message = "No user is currently signed in")
+            updateAuthState(
+                AuthState.ReauthenticationRequired(
+                    user = user,
+                    reason = reason,
+                    retryOperation = { operation() },
+                )
+            )
+        }
+    }
+
     suspend fun delete(context: Context) {
         try {
             val currentUser = auth.currentUser

--- a/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthUI.kt
@@ -526,7 +526,22 @@ class FirebaseAuthUI private constructor(
                 AuthState.ReauthenticationRequired(
                     user = user,
                     reason = reason,
-                    retryOperation = { operation() },
+                    retryOperation = {
+                        try {
+                            operation()
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            updateAuthState(AuthState.Error(e))
+                            return@ReauthenticationRequired
+                        }
+                        val currentUser = auth.currentUser
+                        if (currentUser != null) {
+                            updateAuthState(AuthState.Success(result = null, user = currentUser))
+                        } else {
+                            updateAuthState(AuthState.Idle)
+                        }
+                    },
                 )
             )
         }

--- a/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthUI.kt
@@ -19,6 +19,8 @@ import android.content.Intent
 import androidx.annotation.RestrictTo
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.configuration.auth_provider.filterToLinkedProviders
+import com.google.firebase.auth.FirebaseAuthRecentLoginRequiredException
 import com.firebase.ui.auth.configuration.auth_provider.signOutFromFacebook
 import com.firebase.ui.auth.configuration.auth_provider.signOutFromGoogle
 import com.google.firebase.Firebase
@@ -209,6 +211,45 @@ class FirebaseAuthUI private constructor(
      */
     fun createAuthFlow(configuration: AuthUIConfiguration): AuthFlowController {
         return AuthFlowController(this, configuration)
+    }
+
+    /**
+     * Creates a reauthentication flow scoped to the current user's linked providers.
+     *
+     * This method builds a sign-in flow where:
+     * - Only providers already linked to the current [FirebaseUser] are offered
+     * - Account creation is disabled
+     * - The credential path calls [FirebaseUser.reauthenticateWithCredential] instead of
+     *   [FirebaseAuth.signInWithCredential]
+     *
+     * Use this before sensitive operations (delete account, change email, etc.) that require
+     * a recent sign-in.
+     *
+     * @param configuration Base [AuthUIConfiguration] whose provider list is filtered to
+     *   the user's linked providers. All other settings are preserved.
+     * @param reason Optional human-readable string shown to the user explaining why
+     *   reauthentication is needed (e.g. "To delete your account we need to verify it's you").
+     * @return An [AuthFlowController] configured for reauthentication
+     * @throws AuthException.UserNotFoundException if no user is currently signed in
+     * @throws IllegalStateException if none of the configured providers are linked to the
+     *   current user
+     * @since 10.0.0
+     */
+    fun createReauthFlow(configuration: AuthUIConfiguration): AuthFlowController {
+        val currentUser = auth.currentUser
+            ?: throw AuthException.UserNotFoundException(
+                message = "No user is currently signed in"
+            )
+        val linked = configuration.providers.filterToLinkedProviders(currentUser)
+        check(linked.isNotEmpty()) {
+            "No configured providers are linked to the current user"
+        }
+        val reauthConfig = configuration.copy(
+            providers = linked,
+            isNewEmailAccountsAllowed = false,
+            isReauthenticationMode = true,
+        )
+        return AuthFlowController(this, reauthConfig)
     }
 
     /**
@@ -463,6 +504,19 @@ class FirebaseAuthUI private constructor(
             // Update state to idle (user deleted and signed out)
             updateAuthState(AuthState.Idle)
 
+        } catch (e: FirebaseAuthRecentLoginRequiredException) {
+            auth.currentUser?.let {
+                updateAuthState(
+                    AuthState.ReauthenticationRequired(
+                        user = it,
+                        retryOperation = { ctx -> delete(ctx) },
+                    )
+                )
+            }
+            throw AuthException.InvalidCredentialsException(
+                message = e.message ?: "Recent login required for this operation",
+                cause = e
+            )
         } catch (e: CancellationException) {
             // Handle coroutine cancellation
             val cancelledException = AuthException.AuthCancelledException(

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/AuthUIConfiguration.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/AuthUIConfiguration.kt
@@ -51,6 +51,7 @@ class AuthUIConfigurationBuilder {
     var isDisplayNameRequired: Boolean = true
     var isProviderChoiceAlwaysShown: Boolean = false
     var transitions: AuthUITransitions? = null
+    internal var isReauthenticationMode: Boolean = false
 
     fun providers(block: AuthProvidersBuilder.() -> Unit) =
         providers.addAll(AuthProvidersBuilder().apply(block).build())
@@ -118,7 +119,8 @@ class AuthUIConfigurationBuilder {
             isNewEmailAccountsAllowed = isNewEmailAccountsAllowed,
             isDisplayNameRequired = isDisplayNameRequired,
             isProviderChoiceAlwaysShown = isProviderChoiceAlwaysShown,
-            transitions = transitions
+            transitions = transitions,
+            isReauthenticationMode = isReauthenticationMode,
         )
     }
 }
@@ -215,4 +217,34 @@ class AuthUIConfiguration(
      * If null, uses default fade in/out transitions.
      */
     val transitions: AuthUITransitions? = null,
-)
+
+    /**
+     * When true, the flow operates as a reauthentication flow: account creation is disabled and
+     * only providers already linked to the current user are shown. Set by [FirebaseAuthUI.createReauthFlow].
+     */
+    internal val isReauthenticationMode: Boolean = false,
+) {
+    internal fun copy(
+        providers: List<AuthProvider> = this.providers,
+        isNewEmailAccountsAllowed: Boolean = this.isNewEmailAccountsAllowed,
+        isReauthenticationMode: Boolean = this.isReauthenticationMode,
+    ): AuthUIConfiguration = AuthUIConfiguration(
+        context = this.context,
+        providers = providers,
+        theme = this.theme,
+        locale = this.locale,
+        stringProvider = this.stringProvider,
+        isCredentialManagerEnabled = this.isCredentialManagerEnabled,
+        isMfaEnabled = this.isMfaEnabled,
+        isAnonymousUpgradeEnabled = this.isAnonymousUpgradeEnabled,
+        tosUrl = this.tosUrl,
+        privacyPolicyUrl = this.privacyPolicyUrl,
+        logo = this.logo,
+        passwordResetActionCodeSettings = this.passwordResetActionCodeSettings,
+        isNewEmailAccountsAllowed = isNewEmailAccountsAllowed,
+        isDisplayNameRequired = this.isDisplayNameRequired,
+        isProviderChoiceAlwaysShown = this.isProviderChoiceAlwaysShown,
+        transitions = this.transitions,
+        isReauthenticationMode = isReauthenticationMode,
+    )
+}

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/PasswordRule.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/PasswordRule.kt
@@ -111,7 +111,7 @@ abstract class PasswordRule {
      * @param password The password to validate
      * @return true if the password meets this rule's requirements, false otherwise
      */
-    internal abstract fun isValid(password: String): Boolean
+    abstract fun isValid(password: String): Boolean
 
     /**
      * Returns the appropriate error message for this rule when validation fails.
@@ -119,5 +119,5 @@ abstract class PasswordRule {
      * @param stringProvider The string provider for localized error messages
      * @return The localized error message for this rule
      */
-    internal abstract fun getErrorMessage(stringProvider: AuthUIStringProvider): String
+    abstract fun getErrorMessage(stringProvider: AuthUIStringProvider): String
 }

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AuthProvider.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AuthProvider.kt
@@ -1052,3 +1052,17 @@ abstract class AuthProvider(open val providerId: String, open val providerName: 
         }
     }
 }
+
+/**
+ * Filters this provider list to only those whose [AuthProvider.providerId] matches a provider
+ * already linked to [user], as reported by [com.google.firebase.auth.FirebaseUser.providerData].
+ *
+ * Used by [com.firebase.ui.auth.FirebaseAuthUI.createReauthFlow] to restrict the reauthentication
+ * UI to methods the user has actually registered.
+ */
+internal fun List<AuthProvider>.filterToLinkedProviders(
+    user: com.google.firebase.auth.FirebaseUser,
+): List<AuthProvider> {
+    val linkedIds = user.providerData.map { it.providerId }.toSet()
+    return filter { it.providerId in linkedIds }
+}

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/EmailAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/EmailAuthProvider+FirebaseAuthUI.kt
@@ -47,6 +47,23 @@ import kotlinx.coroutines.tasks.await
 private const val TAG = "EmailAuthProvider"
 
 /**
+ * Signs in or reauthenticates with [credential] depending on [AuthUIConfiguration.isReauthenticationMode].
+ *
+ * - Normal mode: [com.google.firebase.auth.FirebaseAuth.signInWithCredential], returns [AuthResult].
+ * - Reauth mode: [com.google.firebase.auth.FirebaseUser.reauthenticate] (Task<Void>), returns null.
+ *   Callers must reconstruct auth state from [com.google.firebase.auth.FirebaseAuth.currentUser].
+ */
+internal suspend fun FirebaseAuthUI.signInOrReauth(
+    credential: AuthCredential,
+    config: AuthUIConfiguration,
+): AuthResult? = if (config.isReauthenticationMode) {
+    auth.currentUser!!.reauthenticate(credential).await()
+    null
+} else {
+    auth.signInWithCredential(credential).await()
+}
+
+/**
  * Creates an email/password account or links the credential to an anonymous user.
  *
  * Mirrors the legacy email sign-up handler: validates password strength, validates custom
@@ -325,6 +342,14 @@ internal suspend fun FirebaseAuthUI.signInWithEmailAndPassword(
 ): AuthResult? {
     try {
         updateAuthState(AuthState.Loading("Signing in..."))
+        // In reauth mode build a credential and go through signInAndLinkWithCredential so
+        // signInOrReauth routes to FirebaseUser.reauthenticate() instead of signInWithCredential().
+        if (config.isReauthenticationMode) {
+            return signInAndLinkWithCredential(
+                config = config,
+                credential = EmailAuthProvider.getCredential(email, password),
+            )
+        }
         return if (canUpgradeAnonymous(config, auth)) {
             // Anonymous upgrade flow: validate credential in scratch auth
             val credentialToValidate = EmailAuthProvider.getCredential(email, password)
@@ -551,17 +576,22 @@ internal suspend fun FirebaseAuthUI.signInAndLinkWithCredential(
 ): AuthResult? {
     try {
         updateAuthState(AuthState.Loading("Signing in user..."))
-        return if (canUpgradeAnonymous(config, auth) || canLinkCredential(config, auth)) {
+        val result = if (canUpgradeAnonymous(config, auth) || canLinkCredential(config, auth)) {
             auth.currentUser?.linkWithCredential(credential)?.await()
         } else {
-            auth.signInWithCredential(credential).await()
-        }.also { result ->
-            // Merge profile information from the provider
-            result?.user?.let {
-                mergeProfile(auth, displayName, photoUrl)
-            }
-            updateAuthStateWithResult(result)
+            signInOrReauth(credential, config)
         }
+        // signInOrReauth returns null in reauth mode (Task<Void> has no AuthResult).
+        // Reconstruct success state from the now-reauthenticated current user.
+        if (result == null && config.isReauthenticationMode) {
+            auth.currentUser?.let {
+                updateAuthState(AuthState.Success(result = null, user = it, isNewUser = false))
+            }
+            return null
+        }
+        result?.user?.let { mergeProfile(auth, displayName, photoUrl) }
+        updateAuthStateWithResult(result)
+        return result
     } catch (e: FirebaseAuthMultiFactorException) {
         // MFA required - extract resolver and update state
         val resolver = e.resolver

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/EmailAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/EmailAuthProvider+FirebaseAuthUI.kt
@@ -57,7 +57,9 @@ internal suspend fun FirebaseAuthUI.signInOrReauth(
     credential: AuthCredential,
     config: AuthUIConfiguration,
 ): AuthResult? = if (config.isReauthenticationMode) {
-    auth.currentUser!!.reauthenticate(credential).await()
+    val currentUser = auth.currentUser
+        ?: throw AuthException.UserNotFoundException(message = "No user is currently signed in for reauthentication")
+    currentUser.reauthenticate(credential).await()
     null
 } else {
     auth.signInWithCredential(credential).await()

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/FacebookAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/FacebookAuthProvider+FirebaseAuthUI.kt
@@ -71,7 +71,7 @@ internal fun FirebaseAuthUI.rememberSignInWithFacebookLauncher(
         onResult = {},
     )
 
-    DisposableEffect(Unit) {
+    DisposableEffect(config) {
         loginManager.registerCallback(
             callbackManager,
             object : FacebookCallback<LoginResult> {

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProvider+FirebaseAuthUI.kt
@@ -59,7 +59,7 @@ internal fun FirebaseAuthUI.rememberGoogleSignInHandler(
     provider: AuthProvider.Google,
 ): () -> Unit {
     val coroutineScope = rememberCoroutineScope()
-    return remember(this) {
+    return remember(this, config) {
         {
             coroutineScope.launch {
                 try {

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
@@ -169,8 +169,11 @@ internal suspend fun FirebaseAuthUI.signInWithProvider(
         val authResult = when {
             canUpgradeAnonymous(config, auth) ->
                 auth.currentUser?.startActivityForLinkWithProvider(activity, oauthProvider)?.await()
-            config.isReauthenticationMode ->
-                auth.currentUser!!.startActivityForReauthenticateWithProvider(activity, oauthProvider).await()
+            config.isReauthenticationMode -> {
+                val currentUser = auth.currentUser
+                    ?: throw AuthException.UserNotFoundException(message = "No user is currently signed in for reauthentication")
+                currentUser.startActivityForReauthenticateWithProvider(activity, oauthProvider).await()
+            }
             else ->
                 auth.startActivityForSignInWithProvider(activity, oauthProvider).await()
         }

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
@@ -61,7 +61,7 @@ internal fun FirebaseAuthUI.rememberOAuthSignInHandler(
                 "Ensure FirebaseAuthScreen is used within an Activity."
     )
 
-    return remember(this, provider.providerId) {
+    return remember(this, provider.providerId, config) {
         {
             coroutineScope.launch {
                 try {
@@ -165,11 +165,14 @@ internal suspend fun FirebaseAuthUI.signInWithProvider(
             return
         }
 
-        // Determine if we should upgrade anonymous user or do normal sign-in
-        val authResult = if (canUpgradeAnonymous(config, auth)) {
-            auth.currentUser?.startActivityForLinkWithProvider(activity, oauthProvider)?.await()
-        } else {
-            auth.startActivityForSignInWithProvider(activity, oauthProvider).await()
+        // Determine if we should upgrade anonymous user, reauthenticate, or do normal sign-in
+        val authResult = when {
+            canUpgradeAnonymous(config, auth) ->
+                auth.currentUser?.startActivityForLinkWithProvider(activity, oauthProvider)?.await()
+            config.isReauthenticationMode ->
+                auth.currentUser!!.startActivityForReauthenticateWithProvider(activity, oauthProvider).await()
+            else ->
+                auth.startActivityForSignInWithProvider(activity, oauthProvider).await()
         }
 
         // Extract OAuth credential and complete sign-in

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/validators/PasswordValidator.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/validators/PasswordValidator.kt
@@ -17,7 +17,7 @@ package com.firebase.ui.auth.configuration.validators
 import com.firebase.ui.auth.configuration.PasswordRule
 import com.firebase.ui.auth.configuration.string_provider.AuthUIStringProvider
 
-internal class PasswordValidator(
+class PasswordValidator(
     override val stringProvider: AuthUIStringProvider,
     private val rules: List<PasswordRule>
 ) : FieldValidator {

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
@@ -123,6 +123,7 @@ fun FirebaseAuthScreen(
     phoneContent: (@Composable (PhoneAuthContentState) -> Unit)? = null,
     mfaEnrollmentContent: (@Composable (MfaEnrollmentContentState) -> Unit)? = null,
     mfaChallengeContent: (@Composable (MfaChallengeContentState) -> Unit)? = null,
+    reauthContent: (@Composable (state: AuthState.ReauthenticationRequired, onDismiss: () -> Unit) -> Unit)? = null,
     authenticatedContent: (@Composable (state: AuthState, uiContext: AuthSuccessUiContext) -> Unit)? = null,
 ) {
     // Set FirebaseUI version
@@ -142,6 +143,7 @@ fun FirebaseAuthScreen(
     val pendingLinkingCredential = remember { mutableStateOf<AuthCredential?>(null) }
     val pendingResolver = remember { mutableStateOf<MultiFactorResolver?>(null) }
     val pendingReauthConfig = remember { mutableStateOf<AuthUIConfiguration?>(null) }
+    val pendingReauthState = remember { mutableStateOf<AuthState.ReauthenticationRequired?>(null) }
     val pendingReauthOperation = remember { mutableStateOf<(suspend (android.content.Context) -> Unit)?>(null) }
     val emailLinkFromDifferentDevice = remember { mutableStateOf<String?>(null) }
     val lastSignInPreference =
@@ -440,6 +442,7 @@ fun FirebaseAuthScreen(
                         pendingReauthOperation.value?.let { retry ->
                             pendingReauthOperation.value = null
                             pendingReauthConfig.value = null
+                            pendingReauthState.value = null
                             // Lock the state to Loading before launching the retry so no
                             // intermediate Success emission can navigate to AuthRoute.Success.
                             authUI.updateAuthState(AuthState.Loading())
@@ -481,12 +484,15 @@ fun FirebaseAuthScreen(
                             )
                             return@LaunchedEffect
                         }
-                        pendingReauthConfig.value = configuration.copy(
-                            providers = linked,
-                            isNewEmailAccountsAllowed = false,
-                            isReauthenticationMode = true,
-                        )
-                        // ModalBottomSheet appears automatically when pendingReauthConfig is set.
+                        if (reauthContent != null) {
+                            pendingReauthState.value = state
+                        } else {
+                            pendingReauthConfig.value = configuration.copy(
+                                providers = linked,
+                                isNewEmailAccountsAllowed = false,
+                                isReauthenticationMode = true,
+                            )
+                        }
                     }
 
                     is AuthState.RequiresEmailVerification,
@@ -514,6 +520,7 @@ fun FirebaseAuthScreen(
                     is AuthState.Cancelled -> {
                         pendingReauthOperation.value = null
                         pendingReauthConfig.value = null
+                        pendingReauthState.value = null
                         pendingResolver.value = null
                         pendingLinkingCredential.value = null
                         lastSuccessfulUserId.value = null
@@ -529,6 +536,7 @@ fun FirebaseAuthScreen(
                     is AuthState.Idle -> {
                         pendingReauthOperation.value = null
                         pendingReauthConfig.value = null
+                        pendingReauthState.value = null
                         pendingResolver.value = null
                         pendingLinkingCredential.value = null
                         lastSuccessfulUserId.value = null
@@ -607,7 +615,17 @@ fun FirebaseAuthScreen(
                 LoadingDialog(loadingState.message ?: stringProvider.progressDialogLoading)
             }
 
-            // Reauth bottom sheet — appears over the current screen without navigating away.
+            // Custom reauth UI — rendered when the caller provides reauthContent.
+            val pendingReauth = pendingReauthState.value
+            if (pendingReauth != null && reauthContent != null) {
+                reauthContent(pendingReauth) {
+                    pendingReauthOperation.value = null
+                    pendingReauthState.value = null
+                    authUI.updateAuthState(AuthState.Idle)
+                }
+            }
+
+            // Default reauth bottom sheet — used when reauthContent is not provided.
             val reauthConfig = pendingReauthConfig.value
             if (reauthConfig != null) {
                 ModalBottomSheet(

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -37,6 +38,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TooltipAnchorPosition
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -63,6 +65,7 @@ import com.firebase.ui.auth.FirebaseAuthUI
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.configuration.MfaConfiguration
 import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.configuration.auth_provider.filterToLinkedProviders
 import com.firebase.ui.auth.configuration.auth_provider.rememberAnonymousSignInHandler
 import com.firebase.ui.auth.configuration.auth_provider.rememberGoogleSignInHandler
 import com.firebase.ui.auth.configuration.auth_provider.rememberOAuthSignInHandler
@@ -103,6 +106,7 @@ import kotlinx.coroutines.tasks.await
  *
  * @since 10.0.0
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FirebaseAuthScreen(
     configuration: AuthUIConfiguration,
@@ -137,6 +141,8 @@ fun FirebaseAuthScreen(
     val lastSuccessfulUserId = remember { mutableStateOf<String?>(null) }
     val pendingLinkingCredential = remember { mutableStateOf<AuthCredential?>(null) }
     val pendingResolver = remember { mutableStateOf<MultiFactorResolver?>(null) }
+    val pendingReauthConfig = remember { mutableStateOf<AuthUIConfiguration?>(null) }
+    val pendingReauthOperation = remember { mutableStateOf<(suspend (android.content.Context) -> Unit)?>(null) }
     val emailLinkFromDifferentDevice = remember { mutableStateOf<String?>(null) }
     val lastSignInPreference =
         remember { mutableStateOf<SignInPreferenceManager.SignInPreference?>(null) }
@@ -150,99 +156,24 @@ fun FirebaseAuthScreen(
         lastSignInPreference.value = SignInPreferenceManager.getLastSignIn(context)
     }
 
-    val anonymousProvider =
-        configuration.providers.filterIsInstance<AuthProvider.Anonymous>().firstOrNull()
-    val googleProvider =
-        configuration.providers.filterIsInstance<AuthProvider.Google>().firstOrNull()
     val emailProvider = configuration.providers.filterIsInstance<AuthProvider.Email>().firstOrNull()
-    val facebookProvider =
-        configuration.providers.filterIsInstance<AuthProvider.Facebook>().firstOrNull()
-    val appleProvider = configuration.providers.filterIsInstance<AuthProvider.Apple>().firstOrNull()
-    val githubProvider =
-        configuration.providers.filterIsInstance<AuthProvider.Github>().firstOrNull()
-    val microsoftProvider =
-        configuration.providers.filterIsInstance<AuthProvider.Microsoft>().firstOrNull()
-    val yahooProvider = configuration.providers.filterIsInstance<AuthProvider.Yahoo>().firstOrNull()
-    val twitterProvider =
-        configuration.providers.filterIsInstance<AuthProvider.Twitter>().firstOrNull()
-    val genericOAuthProviders =
-        configuration.providers.filterIsInstance<AuthProvider.GenericOAuth>()
-
     val logoAsset = configuration.logo
-
-    val onSignInAnonymously = anonymousProvider?.let {
-        authUI.rememberAnonymousSignInHandler()
-    }
-
-    val onSignInWithGoogle = googleProvider?.let {
-        authUI.rememberGoogleSignInHandler(
-            context = context,
-            config = configuration,
-            provider = it
-        )
-    }
-
-    val onSignInWithFacebook = facebookProvider?.let {
-        authUI.rememberSignInWithFacebookLauncher(
-            context = context,
-            config = configuration,
-            provider = it
-        )
-    }
-
-    val onSignInWithApple = appleProvider?.let {
-        authUI.rememberOAuthSignInHandler(
-            context = context,
-            activity = activity,
-            config = configuration,
-            provider = it
-        )
-    }
-
-    val onSignInWithGithub = githubProvider?.let {
-        authUI.rememberOAuthSignInHandler(
-            context = context,
-            activity = activity,
-            config = configuration,
-            provider = it
-        )
-    }
-
-    val onSignInWithMicrosoft = microsoftProvider?.let {
-        authUI.rememberOAuthSignInHandler(
-            context = context,
-            activity = activity,
-            config = configuration,
-            provider = it
-        )
-    }
-
-    val onSignInWithYahoo = yahooProvider?.let {
-        authUI.rememberOAuthSignInHandler(
-            context = context,
-            activity = activity,
-            config = configuration,
-            provider = it
-        )
-    }
-
-    val onSignInWithTwitter = twitterProvider?.let {
-        authUI.rememberOAuthSignInHandler(
-            context = context,
-            activity = activity,
-            config = configuration,
-            provider = it
-        )
-    }
-
-    val genericOAuthHandlers = genericOAuthProviders.associateWith {
-        authUI.rememberOAuthSignInHandler(
-            context = context,
-            activity = activity,
-            config = configuration,
-            provider = it
-        )
-    }
+    val onProviderSelected = authUI.rememberOnProviderSelected(
+        context = context,
+        activity = activity,
+        config = configuration,
+        onNavigate = { route -> navController.navigate(route.route) },
+        onUnknownProvider = { provider ->
+            onSignInFailure(
+                AuthException.UnknownException(
+                    message = "Provider ${provider.providerId} is not supported in FirebaseAuthScreen",
+                    cause = IllegalArgumentException(
+                        "Provider ${provider.providerId} is not supported in FirebaseAuthScreen"
+                    )
+                )
+            )
+        },
+    )
 
     CompositionLocalProvider(
         LocalAuthUIStringProvider provides configuration.stringProvider,
@@ -281,46 +212,7 @@ fun FirebaseAuthScreen(
                             lastSignInPreference = lastSignInPreference.value,
                             customLayout = customMethodPickerLayout,
                             termsConfiguration = customMethodPickerTermsConfiguration,
-                            onProviderSelected = { provider ->
-                                when (provider) {
-                                    is AuthProvider.Anonymous -> onSignInAnonymously?.invoke()
-
-                                    is AuthProvider.Email -> {
-                                        navController.navigate(AuthRoute.Email.route)
-                                    }
-
-                                    is AuthProvider.Phone -> {
-                                        navController.navigate(AuthRoute.Phone.route)
-                                    }
-
-                                    is AuthProvider.Google -> onSignInWithGoogle?.invoke()
-
-                                    is AuthProvider.Facebook -> onSignInWithFacebook?.invoke()
-
-                                    is AuthProvider.Apple -> onSignInWithApple?.invoke()
-
-                                    is AuthProvider.Github -> onSignInWithGithub?.invoke()
-
-                                    is AuthProvider.Microsoft -> onSignInWithMicrosoft?.invoke()
-
-                                    is AuthProvider.Yahoo -> onSignInWithYahoo?.invoke()
-
-                                    is AuthProvider.Twitter -> onSignInWithTwitter?.invoke()
-
-                                    is AuthProvider.GenericOAuth -> genericOAuthHandlers[provider]?.invoke()
-
-                                    else -> {
-                                        onSignInFailure(
-                                            AuthException.UnknownException(
-                                                message = "Provider ${provider.providerId} is not supported in FirebaseAuthScreen",
-                                                cause = IllegalArgumentException(
-                                                    "Provider ${provider.providerId} is not supported in FirebaseAuthScreen"
-                                                )
-                                            )
-                                        )
-                                    }
-                                }
-                            }
+                            onProviderSelected = onProviderSelected,
                         )
                     }
                 }
@@ -544,6 +436,17 @@ fun FirebaseAuthScreen(
                         pendingResolver.value = null
                         pendingLinkingCredential.value = null
 
+                        // If reauth just completed, execute the pending retry and skip normal success handling
+                        pendingReauthOperation.value?.let { retry ->
+                            pendingReauthOperation.value = null
+                            pendingReauthConfig.value = null
+                            // Lock the state to Loading before launching the retry so no
+                            // intermediate Success emission can navigate to AuthRoute.Success.
+                            authUI.updateAuthState(AuthState.Loading())
+                            coroutineScope.launch { retry(context) }
+                            return@LaunchedEffect
+                        }
+
                         state.result?.let { result ->
                             if (state.user.uid != lastSuccessfulUserId.value) {
                                 onSignInSuccess(result)
@@ -563,6 +466,27 @@ fun FirebaseAuthScreen(
                                 launchSingleTop = true
                             }
                         }
+                    }
+
+                    is AuthState.ReauthenticationRequired -> {
+                        pendingReauthOperation.value = state.retryOperation
+                        val linked = configuration.providers.filterToLinkedProviders(state.user)
+                        if (linked.isEmpty()) {
+                            authUI.updateAuthState(
+                                AuthState.Error(
+                                    AuthException.UnknownException(
+                                        "No configured providers are linked to the current user"
+                                    )
+                                )
+                            )
+                            return@LaunchedEffect
+                        }
+                        pendingReauthConfig.value = configuration.copy(
+                            providers = linked,
+                            isNewEmailAccountsAllowed = false,
+                            isReauthenticationMode = true,
+                        )
+                        // ModalBottomSheet appears automatically when pendingReauthConfig is set.
                     }
 
                     is AuthState.RequiresEmailVerification,
@@ -588,6 +512,8 @@ fun FirebaseAuthScreen(
                     }
 
                     is AuthState.Cancelled -> {
+                        pendingReauthOperation.value = null
+                        pendingReauthConfig.value = null
                         pendingResolver.value = null
                         pendingLinkingCredential.value = null
                         lastSuccessfulUserId.value = null
@@ -601,6 +527,8 @@ fun FirebaseAuthScreen(
                     }
 
                     is AuthState.Idle -> {
+                        pendingReauthOperation.value = null
+                        pendingReauthConfig.value = null
                         pendingResolver.value = null
                         pendingLinkingCredential.value = null
                         lastSuccessfulUserId.value = null
@@ -677,6 +605,34 @@ fun FirebaseAuthScreen(
             val loadingState = authState as? AuthState.Loading
             if (loadingState != null) {
                 LoadingDialog(loadingState.message ?: stringProvider.progressDialogLoading)
+            }
+
+            // Reauth bottom sheet — appears over the current screen without navigating away.
+            val reauthConfig = pendingReauthConfig.value
+            if (reauthConfig != null) {
+                ModalBottomSheet(
+                    onDismissRequest = {
+                        pendingReauthOperation.value = null
+                        pendingReauthConfig.value = null
+                        authUI.updateAuthState(AuthState.Idle)
+                    },
+                    sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+                ) {
+                    ReauthSheetContent(
+                        authUI = authUI,
+                        reauthConfig = reauthConfig,
+                        activity = activity,
+                        context = context,
+                        emailContent = emailContent,
+                        phoneContent = phoneContent,
+                        customMethodPickerLayout = customMethodPickerLayout,
+                        onDismiss = {
+                            pendingReauthOperation.value = null
+                            pendingReauthConfig.value = null
+                            authUI.updateAuthState(AuthState.Idle)
+                        },
+                    )
+                }
             }
         }
     }
@@ -894,4 +850,122 @@ private fun LoadingDialog(message: String) {
             }
         }
     )
+}
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ReauthSheetContent(
+    authUI: FirebaseAuthUI,
+    reauthConfig: AuthUIConfiguration,
+    activity: android.app.Activity?,
+    context: android.content.Context,
+    emailContent: (@Composable (EmailAuthContentState) -> Unit)?,
+    phoneContent: (@Composable (PhoneAuthContentState) -> Unit)?,
+    customMethodPickerLayout: (@Composable (List<AuthProvider>, (AuthProvider) -> Unit) -> Unit)?,
+    onDismiss: () -> Unit,
+) {
+    val sheetNavController = rememberNavController()
+    val startRoute = remember(reauthConfig) { getStartRoute(reauthConfig) }
+    val skipsMethodPicker = startRoute != AuthRoute.MethodPicker
+    val onProviderSelected = authUI.rememberOnProviderSelected(
+        context = context,
+        activity = activity,
+        config = reauthConfig,
+        onNavigate = { route -> sheetNavController.navigate(route.route) },
+    )
+
+    NavHost(
+        navController = sheetNavController,
+        startDestination = startRoute.route,
+        enterTransition = { fadeIn(animationSpec = tween(700)) },
+        exitTransition = { fadeOut(animationSpec = tween(700)) },
+        popEnterTransition = { fadeIn(animationSpec = tween(700)) },
+        popExitTransition = { fadeOut(animationSpec = tween(700)) },
+    ) {
+        composable(AuthRoute.MethodPicker.route) {
+            Scaffold { innerPadding ->
+                AuthMethodPicker(
+                    modifier = Modifier.padding(innerPadding),
+                    providers = reauthConfig.providers,
+                    customLayout = customMethodPickerLayout,
+                    onProviderSelected = onProviderSelected,
+                )
+            }
+        }
+
+        composable(AuthRoute.Email.route) {
+            com.firebase.ui.auth.ui.screens.email.EmailAuthScreen(
+                context = context,
+                configuration = reauthConfig,
+                authUI = authUI,
+                content = emailContent,
+                onSuccess = {},
+                onError = {},
+                onCancel = {
+                    if (skipsMethodPicker || !sheetNavController.popBackStack()) onDismiss()
+                }
+            )
+        }
+
+        composable(AuthRoute.Phone.route) {
+            com.firebase.ui.auth.ui.screens.phone.PhoneAuthScreen(
+                context = context,
+                configuration = reauthConfig,
+                authUI = authUI,
+                content = phoneContent,
+                onSuccess = {},
+                onError = {},
+                onCancel = {
+                    if (skipsMethodPicker || !sheetNavController.popBackStack()) onDismiss()
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun FirebaseAuthUI.rememberOnProviderSelected(
+    context: android.content.Context,
+    activity: android.app.Activity?,
+    config: AuthUIConfiguration,
+    onNavigate: (AuthRoute) -> Unit,
+    onUnknownProvider: ((AuthProvider) -> Unit)? = null,
+): (AuthProvider) -> Unit {
+    val anonymousProvider = config.providers.filterIsInstance<AuthProvider.Anonymous>().firstOrNull()
+    val googleProvider = config.providers.filterIsInstance<AuthProvider.Google>().firstOrNull()
+    val facebookProvider = config.providers.filterIsInstance<AuthProvider.Facebook>().firstOrNull()
+    val appleProvider = config.providers.filterIsInstance<AuthProvider.Apple>().firstOrNull()
+    val githubProvider = config.providers.filterIsInstance<AuthProvider.Github>().firstOrNull()
+    val microsoftProvider = config.providers.filterIsInstance<AuthProvider.Microsoft>().firstOrNull()
+    val yahooProvider = config.providers.filterIsInstance<AuthProvider.Yahoo>().firstOrNull()
+    val twitterProvider = config.providers.filterIsInstance<AuthProvider.Twitter>().firstOrNull()
+    val genericOAuthProviders = config.providers.filterIsInstance<AuthProvider.GenericOAuth>()
+
+    val onSignInAnonymously = anonymousProvider?.let { rememberAnonymousSignInHandler() }
+    val onSignInWithGoogle = googleProvider?.let { rememberGoogleSignInHandler(context, config, it) }
+    val onSignInWithFacebook = facebookProvider?.let { rememberSignInWithFacebookLauncher(context, config, it) }
+    val onSignInWithApple = appleProvider?.let { rememberOAuthSignInHandler(context, activity, config, it) }
+    val onSignInWithGithub = githubProvider?.let { rememberOAuthSignInHandler(context, activity, config, it) }
+    val onSignInWithMicrosoft = microsoftProvider?.let { rememberOAuthSignInHandler(context, activity, config, it) }
+    val onSignInWithYahoo = yahooProvider?.let { rememberOAuthSignInHandler(context, activity, config, it) }
+    val onSignInWithTwitter = twitterProvider?.let { rememberOAuthSignInHandler(context, activity, config, it) }
+    val genericOAuthHandlers = genericOAuthProviders.associateWith {
+        rememberOAuthSignInHandler(context, activity, config, it)
+    }
+
+    return { provider ->
+        when (provider) {
+            is AuthProvider.Anonymous -> onSignInAnonymously?.invoke()
+            is AuthProvider.Email -> onNavigate(AuthRoute.Email)
+            is AuthProvider.Phone -> onNavigate(AuthRoute.Phone)
+            is AuthProvider.Google -> onSignInWithGoogle?.invoke()
+            is AuthProvider.Facebook -> onSignInWithFacebook?.invoke()
+            is AuthProvider.Apple -> onSignInWithApple?.invoke()
+            is AuthProvider.Github -> onSignInWithGithub?.invoke()
+            is AuthProvider.Microsoft -> onSignInWithMicrosoft?.invoke()
+            is AuthProvider.Yahoo -> onSignInWithYahoo?.invoke()
+            is AuthProvider.Twitter -> onSignInWithTwitter?.invoke()
+            is AuthProvider.GenericOAuth -> genericOAuthHandlers[provider]?.invoke()
+            else -> onUnknownProvider?.invoke(provider)
+        }
+    }
 }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
@@ -446,7 +446,15 @@ fun FirebaseAuthScreen(
                             // Lock the state to Loading before launching the retry so no
                             // intermediate Success emission can navigate to AuthRoute.Success.
                             authUI.updateAuthState(AuthState.Loading())
-                            coroutineScope.launch { retry(context) }
+                            coroutineScope.launch {
+                                try {
+                                    retry(context)
+                                } catch (e: kotlinx.coroutines.CancellationException) {
+                                    throw e
+                                } catch (e: Exception) {
+                                    authUI.updateAuthState(AuthState.Error(e))
+                                }
+                            }
                             return@LaunchedEffect
                         }
 

--- a/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthUIAuthStateTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthUIAuthStateTest.kt
@@ -498,6 +498,31 @@ class FirebaseAuthUIAuthStateTest {
     }
 
     @Test
+    fun `withReauth() retryOperation restores auth state after successful retry`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        `when`(mockFirebaseAuth.currentUser).thenReturn(mockFirebaseUser)
+        var callCount = 0
+
+        authUI.withReauth(context) {
+            callCount++
+            if (callCount == 1) throw FirebaseAuthRecentLoginRequiredException(
+                "ERROR_REQUIRES_RECENT_LOGIN", "Recent login required"
+            )
+        }
+
+        val state = authUI.authStateFlow().first() as AuthState.ReauthenticationRequired
+
+        // Simulate FirebaseAuthScreen: set Loading, then invoke the retry
+        authUI.updateAuthState(AuthState.Loading())
+        state.retryOperation!!(context)
+
+        // Auth state must not be stuck on Loading — withReauth owns the state lifecycle
+        val authState = authUI.authStateFlow().first()
+        assertThat(authState).isNotInstanceOf(AuthState.Loading::class.java)
+        assertThat(authState).isInstanceOf(AuthState.Success::class.java)
+    }
+
+    @Test
     fun `withReauth() does not throw when reauth is needed`() = runTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
         `when`(mockFirebaseAuth.currentUser).thenReturn(mockFirebaseUser)

--- a/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthUIAuthStateTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthUIAuthStateTest.kt
@@ -436,6 +436,94 @@ class FirebaseAuthUIAuthStateTest {
         assertThat(state.retryOperation).isNotNull()
     }
 
+    // =============================================================================================
+    // withReauth() Tests
+    // =============================================================================================
+
+    @Test
+    fun `withReauth() executes operation normally when no reauth needed`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        `when`(mockFirebaseAuth.currentUser).thenReturn(mockFirebaseUser)
+        var callCount = 0
+
+        authUI.withReauth(context) { callCount++ }
+
+        assertThat(callCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `withReauth() emits ReauthenticationRequired when FirebaseAuthRecentLoginRequiredException thrown`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        `when`(mockFirebaseAuth.currentUser).thenReturn(mockFirebaseUser)
+
+        authUI.withReauth(context) {
+            throw FirebaseAuthRecentLoginRequiredException("ERROR_REQUIRES_RECENT_LOGIN", "Recent login required")
+        }
+
+        assertThat(authUI.authStateFlow().first()).isInstanceOf(AuthState.ReauthenticationRequired::class.java)
+        val state = authUI.authStateFlow().first() as AuthState.ReauthenticationRequired
+        assertThat(state.user).isEqualTo(mockFirebaseUser)
+    }
+
+    @Test
+    fun `withReauth() forwards reason to ReauthenticationRequired state`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        `when`(mockFirebaseAuth.currentUser).thenReturn(mockFirebaseUser)
+
+        authUI.withReauth(context, reason = "Verify identity to change email") {
+            throw FirebaseAuthRecentLoginRequiredException("ERROR_REQUIRES_RECENT_LOGIN", "Recent login required")
+        }
+
+        val state = authUI.authStateFlow().first() as AuthState.ReauthenticationRequired
+        assertThat(state.reason).isEqualTo("Verify identity to change email")
+    }
+
+    @Test
+    fun `withReauth() attaches retryOperation that re-invokes the original operation`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        `when`(mockFirebaseAuth.currentUser).thenReturn(mockFirebaseUser)
+        var callCount = 0
+
+        authUI.withReauth(context) {
+            callCount++
+            if (callCount == 1) throw FirebaseAuthRecentLoginRequiredException(
+                "ERROR_REQUIRES_RECENT_LOGIN", "Recent login required"
+            )
+        }
+
+        val state = authUI.authStateFlow().first() as AuthState.ReauthenticationRequired
+        assertThat(state.retryOperation).isNotNull()
+        state.retryOperation!!(context)
+        assertThat(callCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `withReauth() does not throw when reauth is needed`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        `when`(mockFirebaseAuth.currentUser).thenReturn(mockFirebaseUser)
+
+        // Should complete without throwing
+        authUI.withReauth(context) {
+            throw FirebaseAuthRecentLoginRequiredException("ERROR_REQUIRES_RECENT_LOGIN", "Recent login required")
+        }
+    }
+
+    @Test
+    fun `withReauth() propagates non-reauth exceptions`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        `when`(mockFirebaseAuth.currentUser).thenReturn(mockFirebaseUser)
+        val cause = RuntimeException("Network error")
+        var thrown: Exception? = null
+
+        try {
+            authUI.withReauth(context) { throw cause }
+        } catch (e: Exception) {
+            thrown = e
+        }
+
+        assertThat(thrown).isEqualTo(cause)
+    }
+
     @Test
     fun `delete() retryOperation re-invokes delete on execution`() = runTest {
         val mockUser = mock(FirebaseUser::class.java)

--- a/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthUIAuthStateTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthUIAuthStateTest.kt
@@ -18,12 +18,16 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
+import android.content.Context
+import com.google.android.gms.tasks.TaskCompletionSource
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseAuth.AuthStateListener
+import com.google.firebase.auth.FirebaseAuthRecentLoginRequiredException
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.MultiFactorResolver
 import com.google.firebase.auth.UserInfo
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
@@ -37,6 +41,7 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
 import org.mockito.Mock
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
@@ -380,5 +385,82 @@ class FirebaseAuthUIAuthStateTest {
         // Verify properties
         assertThat(state.user).isEqualTo(mockFirebaseUser)
         assertThat(state.missingFields).containsExactly("displayName", "photoUrl")
+    }
+
+    // =============================================================================================
+    // delete() ReauthenticationRequired state Tests
+    // =============================================================================================
+
+    @Test
+    fun `delete() emits ReauthenticationRequired state when recent login required`() = runTest {
+        val mockUser = mock(FirebaseUser::class.java)
+        val tcs = TaskCompletionSource<Void>()
+        tcs.setException(
+            FirebaseAuthRecentLoginRequiredException(
+                "ERROR_REQUIRES_RECENT_LOGIN", "Recent login required"
+            )
+        )
+        `when`(mockFirebaseAuth.currentUser).thenReturn(mockUser)
+        `when`(mockUser.delete()).thenReturn(tcs.task)
+
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        try {
+            authUI.delete(context)
+        } catch (_: AuthException.InvalidCredentialsException) {
+            // expected — existing contract preserved
+        }
+
+        assertThat(authUI.authStateFlow().first()).isInstanceOf(AuthState.ReauthenticationRequired::class.java)
+        val state = authUI.authStateFlow().first() as AuthState.ReauthenticationRequired
+        assertThat(state.user).isEqualTo(mockUser)
+    }
+
+    @Test
+    fun `delete() attaches retryOperation to ReauthenticationRequired state`() = runTest {
+        val mockUser = mock(FirebaseUser::class.java)
+        val tcs = TaskCompletionSource<Void>()
+        tcs.setException(
+            FirebaseAuthRecentLoginRequiredException(
+                "ERROR_REQUIRES_RECENT_LOGIN", "Recent login required"
+            )
+        )
+        `when`(mockFirebaseAuth.currentUser).thenReturn(mockUser)
+        `when`(mockUser.delete()).thenReturn(tcs.task)
+
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        try { authUI.delete(context) } catch (_: AuthException.InvalidCredentialsException) {}
+
+        val state = authUI.authStateFlow().first() as AuthState.ReauthenticationRequired
+        // Fails until delete() passes retryOperation into the state
+        assertThat(state.retryOperation).isNotNull()
+    }
+
+    @Test
+    fun `delete() retryOperation re-invokes delete on execution`() = runTest {
+        val mockUser = mock(FirebaseUser::class.java)
+
+        val failTcs = TaskCompletionSource<Void>()
+        failTcs.setException(
+            FirebaseAuthRecentLoginRequiredException(
+                "ERROR_REQUIRES_RECENT_LOGIN", "Recent login required"
+            )
+        )
+        val successTcs = TaskCompletionSource<Void>()
+        successTcs.setResult(null)
+
+        `when`(mockFirebaseAuth.currentUser).thenReturn(mockUser)
+        `when`(mockUser.delete())
+            .thenReturn(failTcs.task)
+            .thenReturn(successTcs.task)
+
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        try { authUI.delete(context) } catch (_: AuthException.InvalidCredentialsException) {}
+
+        val state = authUI.authStateFlow().first() as AuthState.ReauthenticationRequired
+        // Fails until delete() passes retryOperation into the state
+        state.retryOperation!!(context)
+
+        verify(mockUser, times(2)).delete()
     }
 }

--- a/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthUITest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthUITest.kt
@@ -19,6 +19,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
 import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.configuration.authUIConfiguration
 import com.google.android.gms.tasks.TaskCompletionSource
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.FirebaseApp
@@ -678,6 +679,96 @@ class FirebaseAuthUITest {
             assertThat(e.cause).isEqualTo(networkException)
         }
     }
+
+    // =============================================================================================
+    // createReauthFlow Tests
+    // =============================================================================================
+
+    private fun baseConfig(vararg providers: AuthProvider): com.firebase.ui.auth.configuration.AuthUIConfiguration {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        return authUIConfiguration {
+            this.context = context
+            providers.forEach { p -> this.providers { provider(p) } }
+        }
+    }
+
+    @Test
+    fun `createReauthFlow throws UserNotFoundException when no user is signed in`() {
+        val mockAuth = mock(FirebaseAuth::class.java)
+        `when`(mockAuth.currentUser).thenReturn(null)
+        val authUI = FirebaseAuthUI.create(defaultApp, mockAuth)
+
+        try {
+            authUI.createReauthFlow(baseConfig(AuthProvider.Email(emailLinkActionCodeSettings = null, passwordValidationRules = emptyList())))
+            assertThat(false).isTrue()
+        } catch (e: AuthException.UserNotFoundException) {
+            assertThat(e.message).contains("No user is currently signed in")
+        }
+    }
+
+    @Test
+    fun `createReauthFlow throws when no configured provider is linked to the current user`() {
+        val mockUser = mock(FirebaseUser::class.java)
+        val info = mock(UserInfo::class.java)
+        `when`(info.providerId).thenReturn("password")
+        `when`(mockUser.providerData).thenReturn(listOf(info))
+        val mockAuth = mock(FirebaseAuth::class.java)
+        `when`(mockAuth.currentUser).thenReturn(mockUser)
+        val authUI = FirebaseAuthUI.create(defaultApp, mockAuth)
+
+        // Config only has Google; user only has email linked
+        val config = baseConfig(AuthProvider.Google(scopes = emptyList(), serverClientId = "id"))
+
+        try {
+            authUI.createReauthFlow(config)
+            assertThat(false).isTrue()
+        } catch (e: IllegalStateException) {
+            assertThat(e.message).contains("No configured providers are linked")
+        }
+    }
+
+    @Test
+    fun `createReauthFlow returns a controller whose config has only linked providers`() {
+        val mockUser = mock(FirebaseUser::class.java)
+        val emailInfo = mock(UserInfo::class.java)
+        val googleInfo = mock(UserInfo::class.java)
+        `when`(emailInfo.providerId).thenReturn("password")
+        `when`(googleInfo.providerId).thenReturn("google.com")
+        `when`(mockUser.providerData).thenReturn(listOf(emailInfo, googleInfo))
+        val mockAuth = mock(FirebaseAuth::class.java)
+        `when`(mockAuth.currentUser).thenReturn(mockUser)
+        val authUI = FirebaseAuthUI.create(defaultApp, mockAuth)
+
+        // Three providers configured; only Email and Google are linked — Phone should be stripped
+        val config = baseConfig(
+            AuthProvider.Email(emailLinkActionCodeSettings = null, passwordValidationRules = emptyList()),
+            AuthProvider.Google(scopes = emptyList(), serverClientId = "id"),
+            AuthProvider.Phone(defaultNumber = null, defaultCountryCode = null, allowedCountries = null),
+        )
+
+        val controller = authUI.createReauthFlow(config)
+
+        assertThat(controller.configuration.providers.map { it.providerId })
+            .containsExactly("password", "google.com")
+    }
+
+    @Test
+    fun `createReauthFlow resulting config disables new account creation and enables reauth mode`() {
+        val mockUser = mock(FirebaseUser::class.java)
+        val info = mock(UserInfo::class.java)
+        `when`(info.providerId).thenReturn("password")
+        `when`(mockUser.providerData).thenReturn(listOf(info))
+        val mockAuth = mock(FirebaseAuth::class.java)
+        `when`(mockAuth.currentUser).thenReturn(mockUser)
+        val authUI = FirebaseAuthUI.create(defaultApp, mockAuth)
+
+        val config = baseConfig(AuthProvider.Email(emailLinkActionCodeSettings = null, passwordValidationRules = emptyList()))
+        val controller = authUI.createReauthFlow(config)
+
+        assertThat(controller.configuration.isNewEmailAccountsAllowed).isFalse()
+        assertThat(controller.configuration.isReauthenticationMode).isTrue()
+    }
+
 
     @Test
     fun `canHandleIntent returns true when auth validates email link`() {

--- a/auth/src/test/java/com/firebase/ui/auth/configuration/AuthUIConfigurationTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/configuration/AuthUIConfigurationTest.kt
@@ -479,7 +479,8 @@ class AuthUIConfigurationTest {
             "isNewEmailAccountsAllowed",
             "isDisplayNameRequired",
             "isProviderChoiceAlwaysShown",
-            "transitions"
+            "transitions",
+            "isReauthenticationMode"
         )
 
         val actualProperties = allProperties.map { it.name }.toSet()

--- a/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/AuthProviderTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/AuthProviderTest.kt
@@ -4,10 +4,14 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.firebase.ui.auth.R
 import com.google.common.truth.Truth.assertThat
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.UserInfo
 import com.google.firebase.auth.actionCodeSettings
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -403,6 +407,77 @@ class AuthProviderTest {
             assertThat(e).isInstanceOf(IllegalArgumentException::class.java)
             assertThat(e.message).isEqualTo("Provider ID cannot be null or empty")
         }
+    }
+
+    // =============================================================================================
+    // filterToLinkedProviders Tests
+    // =============================================================================================
+
+    private fun mockUser(vararg providerIds: String): FirebaseUser {
+        val user = mock(FirebaseUser::class.java)
+        val infos = providerIds.map { id ->
+            mock(UserInfo::class.java).also { `when`(it.providerId).thenReturn(id) }
+        }
+        `when`(user.providerData).thenReturn(infos)
+        return user
+    }
+
+    @Test
+    fun `filterToLinkedProviders keeps only providers matching user providerData`() {
+        val user = mockUser("password", "google.com")
+        val providers = listOf(
+            AuthProvider.Email(emailLinkActionCodeSettings = null, passwordValidationRules = emptyList()),
+            AuthProvider.Google(scopes = emptyList(), serverClientId = "id"),
+            AuthProvider.Phone(defaultNumber = null, defaultCountryCode = null, allowedCountries = null),
+        )
+
+        val result = providers.filterToLinkedProviders(user)
+
+        assertThat(result.map { it.providerId }).containsExactly("password", "google.com")
+    }
+
+    @Test
+    fun `filterToLinkedProviders returns empty list when no providers match`() {
+        val user = mockUser("password")
+        val providers = listOf(
+            AuthProvider.Google(scopes = emptyList(), serverClientId = "id"),
+        )
+
+        val result = providers.filterToLinkedProviders(user)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `filterToLinkedProviders returns all providers when all are linked`() {
+        val user = mockUser("password", "phone")
+        val email = AuthProvider.Email(emailLinkActionCodeSettings = null, passwordValidationRules = emptyList())
+        val phone = AuthProvider.Phone(defaultNumber = null, defaultCountryCode = null, allowedCountries = null)
+
+        val result = listOf(email, phone).filterToLinkedProviders(user)
+
+        assertThat(result).containsExactly(email, phone)
+    }
+
+    @Test
+    fun `filterToLinkedProviders on empty list returns empty list`() {
+        val user = mockUser("password")
+
+        val result = emptyList<AuthProvider>().filterToLinkedProviders(user)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `filterToLinkedProviders ignores providers linked to user but absent from list`() {
+        val user = mockUser("password", "google.com", "facebook.com")
+        val providers = listOf(
+            AuthProvider.Email(emailLinkActionCodeSettings = null, passwordValidationRules = emptyList()),
+        )
+
+        val result = providers.filterToLinkedProviders(user)
+
+        assertThat(result.map { it.providerId }).containsExactly("password")
     }
 
     @Test

--- a/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/ReauthFlowTest.kt
+++ b/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/ReauthFlowTest.kt
@@ -1,0 +1,311 @@
+package com.firebase.ui.auth.ui.screens
+
+import android.content.Context
+import android.os.Looper
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import com.firebase.ui.auth.AuthState
+import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.configuration.authUIConfiguration
+import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.configuration.string_provider.DefaultAuthUIStringProvider
+import com.firebase.ui.auth.configuration.string_provider.LocalAuthUIStringProvider
+import com.firebase.ui.auth.testutil.AUTH_STATE_WAIT_TIMEOUT_MS
+import com.firebase.ui.auth.testutil.EmulatorAuthApi
+import com.firebase.ui.auth.testutil.ensureFreshUser
+import com.firebase.ui.auth.testutil.verifyEmailInEmulator
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import org.junit.After
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@Config(sdk = [34])
+@RunWith(RobolectricTestRunner::class)
+class ReauthFlowTest {
+
+    @get:Rule
+    val composeAndroidTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private lateinit var applicationContext: Context
+    private lateinit var stringProvider: DefaultAuthUIStringProvider
+    private lateinit var authUI: FirebaseAuthUI
+    private lateinit var emulatorApi: EmulatorAuthApi
+
+    @Before
+    fun setUp() {
+        applicationContext = ApplicationProvider.getApplicationContext()
+        stringProvider = DefaultAuthUIStringProvider(applicationContext)
+
+        FirebaseApp.getApps(applicationContext).forEach { it.delete() }
+
+        val firebaseApp = FirebaseApp.initializeApp(
+            applicationContext,
+            FirebaseOptions.Builder()
+                .setApiKey("fake-api-key")
+                .setApplicationId("fake-app-id")
+                .setProjectId("fake-project-id")
+                .build()
+        )
+
+        authUI = FirebaseAuthUI.getInstance()
+        authUI.auth.useEmulator("127.0.0.1", 9099)
+
+        emulatorApi = EmulatorAuthApi(
+            projectId = firebaseApp.options.projectId
+                ?: throw IllegalStateException("Project ID is required"),
+            emulatorHost = "127.0.0.1",
+            emulatorPort = 9099,
+        )
+
+        emulatorApi.clearEmulatorData()
+    }
+
+    @After
+    fun tearDown() {
+        FirebaseAuthUI.clearInstanceCache()
+        emulatorApi.clearEmulatorData()
+    }
+
+    /**
+     * Full cycle: sign in via the main flow, then emit ReauthenticationRequired to simulate a
+     * sensitive operation. Verifies the default ModalBottomSheet reauth UI appears, completing
+     * reauthentication triggers the pending retry operation.
+     *
+     * The initial sign-in must complete first so the main screen shows the authenticated view —
+     * this avoids having two simultaneous email input forms (one in the main sign-in screen and
+     * one in the reauth bottom sheet).
+     */
+    @Test
+    fun `reauth bottom sheet appears and triggers retry operation on successful reauthentication`() {
+        val email = "reauth-test-${System.currentTimeMillis()}@example.com"
+        val password = "test123"
+
+        val user = ensureFreshUser(authUI, email, password)
+        requireNotNull(user) { "Failed to create user" }
+
+        // Email must be verified so sign-in (both initial and reauth) resolves to Success.
+        try {
+            verifyEmailInEmulator(authUI, emulatorApi, user)
+        } catch (e: Exception) {
+            Assume.assumeTrue(
+                "Skipping: Firebase Auth Emulator OOB codes not available. Error: ${e.message}",
+                false
+            )
+        }
+
+        // Sign out so the screen starts on the sign-in form.
+        authUI.auth.signOut()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        var currentAuthState: AuthState = AuthState.Idle
+        var retryOperationCalled = false
+
+        val configuration = authUIConfiguration {
+            context = applicationContext
+            providers {
+                provider(
+                    AuthProvider.Email(
+                        emailLinkActionCodeSettings = null,
+                        passwordValidationRules = emptyList()
+                    )
+                )
+            }
+            isCredentialManagerEnabled = false
+        }
+
+        composeAndroidTestRule.setContent {
+            CompositionLocalProvider(
+                LocalAuthUIStringProvider provides DefaultAuthUIStringProvider(applicationContext)
+            ) {
+                FirebaseAuthScreen(
+                    configuration = configuration,
+                    authUI = authUI,
+                    onSignInSuccess = {},
+                    onSignInFailure = {},
+                    onSignInCancelled = {},
+                ) { state, _ ->
+                    if (state is AuthState.Success) Text("AUTHENTICATED") else Text("NOT AUTHENTICATED")
+                }
+                val authState by authUI.authStateFlow().collectAsState(AuthState.Idle)
+                currentAuthState = authState
+            }
+        }
+
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // Step 1: Complete initial sign-in via the main screen form.
+        composeAndroidTestRule.onNodeWithText(stringProvider.emailHint)
+            .performScrollTo()
+            .performTextInput(email)
+        composeAndroidTestRule.onNodeWithText(stringProvider.passwordHint)
+            .performScrollTo()
+            .performTextInput(password)
+        composeAndroidTestRule.onNodeWithText(stringProvider.signInDefault.uppercase())
+            .performScrollTo()
+            .performClick()
+
+        shadowOf(Looper.getMainLooper()).idle()
+
+        composeAndroidTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
+            shadowOf(Looper.getMainLooper()).idle()
+            currentAuthState is AuthState.Success
+        }
+
+        // Main screen now shows authenticated content — no email form visible.
+        composeAndroidTestRule.onNodeWithText("AUTHENTICATED").assertIsDisplayed()
+
+        val signedInUser = requireNotNull(authUI.auth.currentUser) { "User must be signed in" }
+
+        // Step 2: Emit ReauthenticationRequired to simulate a sensitive operation requiring reauth.
+        authUI.updateAuthState(
+            AuthState.ReauthenticationRequired(
+                user = signedInUser,
+                reason = "Please verify your identity to continue",
+                retryOperation = { retryOperationCalled = true },
+            )
+        )
+
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // Wait for the reauth bottom sheet email form to appear (now the only email form visible).
+        composeAndroidTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
+            shadowOf(Looper.getMainLooper()).idle()
+            composeAndroidTestRule.onAllNodesWithText(stringProvider.emailHint)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Step 3: Enter credentials in the reauth bottom sheet.
+        composeAndroidTestRule.onNodeWithText(stringProvider.emailHint)
+            .performScrollTo()
+            .performTextInput(email)
+        composeAndroidTestRule.onNodeWithText(stringProvider.passwordHint)
+            .performScrollTo()
+            .performTextInput(password)
+        composeAndroidTestRule.onNodeWithText(stringProvider.signInDefault.uppercase())
+            .performScrollTo()
+            .performClick()
+
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // Verify the retry operation fires after successful reauthentication.
+        composeAndroidTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
+            shadowOf(Looper.getMainLooper()).idle()
+            retryOperationCalled
+        }
+
+        assertThat(retryOperationCalled).isTrue()
+    }
+
+    /**
+     * Verifies that when reauthContent is provided, it receives the ReauthenticationRequired state
+     * and calling onDismiss resets the auth state to Idle.
+     */
+    @Test
+    fun `custom reauthContent receives ReauthenticationRequired state and dismisses to Idle`() {
+        val email = "reauth-custom-${System.currentTimeMillis()}@example.com"
+        val password = "test123"
+
+        val user = ensureFreshUser(authUI, email, password)
+        requireNotNull(user) { "Failed to create user" }
+
+        val capturedUser = requireNotNull(authUI.auth.currentUser) { "User must be signed in after creation" }
+        authUI.auth.signOut()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        var currentAuthState: AuthState = AuthState.Idle
+        val expectedReason = "Sensitive operation requires sign-in"
+
+        val configuration = authUIConfiguration {
+            context = applicationContext
+            providers {
+                provider(
+                    AuthProvider.Email(
+                        emailLinkActionCodeSettings = null,
+                        passwordValidationRules = emptyList()
+                    )
+                )
+            }
+            isCredentialManagerEnabled = false
+        }
+
+        composeAndroidTestRule.setContent {
+            CompositionLocalProvider(
+                LocalAuthUIStringProvider provides DefaultAuthUIStringProvider(applicationContext)
+            ) {
+                FirebaseAuthScreen(
+                    configuration = configuration,
+                    authUI = authUI,
+                    onSignInSuccess = {},
+                    onSignInFailure = {},
+                    onSignInCancelled = {},
+                    reauthContent = { reauthState, onDismiss ->
+                        Column {
+                            Text("REAUTH REQUIRED - ${reauthState.reason}")
+                            Button(onClick = onDismiss) { Text("DISMISS REAUTH") }
+                        }
+                    },
+                ) { _, _ ->
+                    Text("CONTENT")
+                }
+                val authState by authUI.authStateFlow().collectAsState(AuthState.Idle)
+                currentAuthState = authState
+            }
+        }
+
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // Emit ReauthenticationRequired to trigger the custom reauthContent slot.
+        authUI.updateAuthState(
+            AuthState.ReauthenticationRequired(
+                user = capturedUser,
+                reason = expectedReason,
+            )
+        )
+
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // Verify the custom reauth content is displayed with the correct reason.
+        composeAndroidTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
+            shadowOf(Looper.getMainLooper()).idle()
+            composeAndroidTestRule.onAllNodesWithText("REAUTH REQUIRED - $expectedReason")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeAndroidTestRule.onNodeWithText("REAUTH REQUIRED - $expectedReason")
+            .assertIsDisplayed()
+
+        // Dismiss the custom reauth UI via the onDismiss callback.
+        composeAndroidTestRule.onNodeWithText("DISMISS REAUTH").performClick()
+
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // Verify that dismissing resets auth state to Idle.
+        composeAndroidTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
+            shadowOf(Looper.getMainLooper()).idle()
+            currentAuthState is AuthState.Idle
+        }
+
+        assertThat(currentAuthState).isInstanceOf(AuthState.Idle::class.java)
+    }
+}


### PR DESCRIPTION
Closes #563 .

Implements the reauthentication flow.

`FirebaseAuthScreen` now handles `AuthState.ReauthenticationRequired` internally. When this state is emitted, it automatically shows a bottom sheet scoped to only the providers already linked to the current user, disables new account creation, and retries the original operation on successful reauthentication — all without any extra wiring from the caller.

Two new APIs expose this to apps:

**`withReauth`** — wraps any sensitive Firebase operation. If it throws `FirebaseAuthRecentLoginRequiredException`, it emits `ReauthenticationRequired` with the operation attached as a retry. `FirebaseAuthScreen` picks it up, shows the reauth sheet, and re-runs the operation automatically on success.

```kotlin
lifecycleScope.launch {
    authUI.withReauth(context, reason = "Verify your identity to delete your account") {
        user.delete().await()
    }
}
```

**`createReauthFlow`** — activity-based alternative returning an `AuthFlowController` for apps that want an explicit, launcher-style reauth flow scoped to the current user's linked providers.

`FirebaseAuthScreen` also gains a `reauthContent` slot for apps that want to supply their own reauth UI instead of the default bottom sheet.

## Preview
[Reauthentication Demo.webm](https://github.com/user-attachments/assets/df0861a3-f6d9-453c-ad03-daabe63a345a)


