### PR TITLE
feat(auth): surface GIdP password policy violations with actionable error messages

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/AuthException.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthException.kt
@@ -561,8 +561,8 @@ abstract class AuthException(
             val policyIndex = message.indexOf("PASSWORD_DOES_NOT_MEET_REQUIREMENTS", ignoreCase = true)
             if (policyIndex == -1) return emptyList()
             val start = message.indexOf('[', policyIndex)
-            val end = message.indexOf(']', start)
-            if (start == -1 || end == -1) return emptyList()
+            val end = message.indexOf(']', policyIndex)
+            if (start == -1 || end == -1 || end <= start) return emptyList()
             return message.substring(start + 1, end)
                 .split(',')
                 .map { it.trim() }
@@ -573,7 +573,7 @@ abstract class AuthException(
         // for those. For older SDK versions that may surface short error codes instead
         // (e.g. MISSING_UPPERCASE_CHARACTER), map those to localised strings.
         private fun mapRequirementToString(code: String, stringProvider: AuthUIStringProvider?): String {
-            return when (code.uppercase()) {
+            return when (code.uppercase(java.util.Locale.US)) {
                 "MISSING_UPPERCASE_CHARACTER" ->
                     stringProvider?.passwordMissingUppercase ?: "Password must contain at least one uppercase letter"
                 "MISSING_LOWERCASE_CHARACTER" ->

--- a/auth/src/main/java/com/firebase/ui/auth/AuthException.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthException.kt
@@ -507,12 +507,26 @@ abstract class AuthException(
                 }
 
                 is FirebaseException -> {
-                    NetworkException(
-                        message = stringProvider?.errorNetworkGeneric.nonEmpty()
-                            ?: firebaseException.message
-                            ?: "Network error occurred",
-                        cause = firebaseException
-                    )
+                    val msg = firebaseException.message ?: ""
+                    if (msg.contains("PASSWORD_DOES_NOT_MEET_REQUIREMENTS", ignoreCase = true)) {
+                        val requirements = parsePasswordPolicyRequirements(msg)
+                        val humanReadable = requirements
+                            .joinToString("\n") { mapRequirementToString(it, stringProvider) }
+                        PasswordPolicyViolationException(
+                            message = humanReadable.ifEmpty {
+                                stringProvider?.errorWeakPasswordGeneric.nonEmpty()
+                                    ?: "Password does not meet policy requirements"
+                            },
+                            failingRequirements = requirements,
+                            cause = firebaseException
+                        )
+                    } else {
+                        NetworkException(
+                            message = stringProvider?.errorNetworkGeneric.nonEmpty()
+                                ?: msg.ifEmpty { "Network error occurred" },
+                            cause = firebaseException
+                        )
+                    }
                 }
 
                 else -> {
@@ -539,16 +553,25 @@ abstract class AuthException(
 
         private fun String?.nonEmpty(): String? = this?.ifEmpty { null }
 
+        // Finds the [...] content that immediately follows PASSWORD_DOES_NOT_MEET_REQUIREMENTS
+        // in both FirebaseException and FirebaseAuthWeakPasswordException messages.
+        // GIdP returns human-readable requirement strings inside those brackets, e.g.
+        // "...PASSWORD_DOES_NOT_MEET_REQUIREMENTS:Missing password requirements: [Password must contain at least 10 characters]"
         private fun parsePasswordPolicyRequirements(message: String): List<String> {
-            val start = message.indexOf('[')
-            val end = message.indexOf(']')
-            if (start == -1 || end == -1 || end <= start) return emptyList()
+            val policyIndex = message.indexOf("PASSWORD_DOES_NOT_MEET_REQUIREMENTS", ignoreCase = true)
+            if (policyIndex == -1) return emptyList()
+            val start = message.indexOf('[', policyIndex)
+            val end = message.indexOf(']', start)
+            if (start == -1 || end == -1) return emptyList()
             return message.substring(start + 1, end)
                 .split(',')
                 .map { it.trim() }
                 .filter { it.isNotEmpty() }
         }
 
+        // GIdP already returns human-readable requirement strings, so this is a pass-through
+        // for those. For older SDK versions that may surface short error codes instead
+        // (e.g. MISSING_UPPERCASE_CHARACTER), map those to localised strings.
         private fun mapRequirementToString(code: String, stringProvider: AuthUIStringProvider?): String {
             return when (code.uppercase()) {
                 "MISSING_UPPERCASE_CHARACTER" ->

--- a/auth/src/main/java/com/firebase/ui/auth/AuthException.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthException.kt
@@ -124,6 +124,27 @@ abstract class AuthException(
     ) : AuthException(message, cause)
 
     /**
+     * The password violates one or more Google Identity Platform password policy requirements.
+     *
+     * This exception is thrown when GIdP password policy enforcement is enabled and the supplied
+     * password fails one or more configured constraints (e.g. missing uppercase, missing digit).
+     * [failingRequirements] contains the raw server-side constraint identifiers such as
+     * `MISSING_UPPERCASE_CHARACTER` or `MISSING_NON_ALPHANUMERIC_CHARACTER`.
+     *
+     * [message] is a newline-separated, human-readable description of each failing constraint,
+     * suitable for direct display in the UI.
+     *
+     * @property message Human-readable description of the failing constraints
+     * @property failingRequirements Raw server-side constraint identifiers
+     * @property cause The underlying [Throwable] that caused this exception
+     */
+    class PasswordPolicyViolationException(
+        message: String,
+        val failingRequirements: List<String>,
+        cause: Throwable? = null
+    ) : AuthException(message, cause)
+
+    /**
      * An account with the given email already exists.
      *
      * This exception is thrown when attempting to create a new account with
@@ -354,7 +375,34 @@ abstract class AuthException(
                 // If already an AuthException, return it directly
                 is AuthException -> firebaseException
 
-                // Handle specific Firebase Auth exceptions first (before general FirebaseException)
+                // Handle specific Firebase Auth exceptions first (before general FirebaseException).
+                // FirebaseAuthWeakPasswordException extends FirebaseAuthInvalidCredentialsException,
+                // so it must be checked before the parent type.
+                is FirebaseAuthWeakPasswordException -> {
+                    val sourceText = firebaseException.reason ?: firebaseException.message ?: ""
+                    if (sourceText.contains("PASSWORD_DOES_NOT_MEET_REQUIREMENTS", ignoreCase = true)) {
+                        val requirements = parsePasswordPolicyRequirements(sourceText)
+                        val humanReadable = requirements
+                            .joinToString("\n") { mapRequirementToString(it, stringProvider) }
+                        PasswordPolicyViolationException(
+                            message = humanReadable.ifEmpty {
+                                stringProvider?.errorWeakPasswordGeneric.nonEmpty()
+                                    ?: "Password does not meet policy requirements"
+                            },
+                            failingRequirements = requirements,
+                            cause = firebaseException
+                        )
+                    } else {
+                        WeakPasswordException(
+                            message = stringProvider?.errorWeakPasswordGeneric.nonEmpty()
+                                ?: firebaseException.message
+                                ?: "Password is too weak",
+                            cause = firebaseException,
+                            reason = firebaseException.reason
+                        )
+                    }
+                }
+
                 is FirebaseAuthInvalidCredentialsException -> {
                     InvalidCredentialsException(
                         message = stringProvider?.errorInvalidCredentials.nonEmpty()
@@ -387,16 +435,6 @@ abstract class AuthException(
                             cause = firebaseException
                         )
                     }
-                }
-
-                is FirebaseAuthWeakPasswordException -> {
-                    WeakPasswordException(
-                        message = stringProvider?.errorWeakPasswordGeneric.nonEmpty()
-                            ?: firebaseException.message
-                            ?: "Password is too weak",
-                        cause = firebaseException,
-                        reason = firebaseException.reason
-                    )
                 }
 
                 is FirebaseAuthUserCollisionException -> {
@@ -500,5 +538,29 @@ abstract class AuthException(
         }
 
         private fun String?.nonEmpty(): String? = this?.ifEmpty { null }
+
+        private fun parsePasswordPolicyRequirements(message: String): List<String> {
+            val start = message.indexOf('[')
+            val end = message.indexOf(']')
+            if (start == -1 || end == -1 || end <= start) return emptyList()
+            return message.substring(start + 1, end)
+                .split(',')
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+        }
+
+        private fun mapRequirementToString(code: String, stringProvider: AuthUIStringProvider?): String {
+            return when (code.uppercase()) {
+                "MISSING_UPPERCASE_CHARACTER" ->
+                    stringProvider?.passwordMissingUppercase ?: "Password must contain at least one uppercase letter"
+                "MISSING_LOWERCASE_CHARACTER" ->
+                    stringProvider?.passwordMissingLowercase ?: "Password must contain at least one lowercase letter"
+                "MISSING_NUMERIC_CHARACTER" ->
+                    stringProvider?.passwordMissingDigit ?: "Password must contain at least one number"
+                "MISSING_NON_ALPHANUMERIC_CHARACTER" ->
+                    stringProvider?.passwordMissingSpecialCharacter ?: "Password must contain at least one special character"
+                else -> code
+            }
+        }
     }
 }

--- a/auth/src/main/java/com/firebase/ui/auth/AuthException.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthException.kt
@@ -127,15 +127,13 @@ abstract class AuthException(
      * The password violates one or more Google Identity Platform password policy requirements.
      *
      * This exception is thrown when GIdP password policy enforcement is enabled and the supplied
-     * password fails one or more configured constraints (e.g. missing uppercase, missing digit).
-     * [failingRequirements] contains the raw server-side constraint identifiers such as
-     * `MISSING_UPPERCASE_CHARACTER` or `MISSING_NON_ALPHANUMERIC_CHARACTER`.
+     * password fails one or more configured constraints (e.g. minimum length, missing uppercase).
      *
-     * [message] is a newline-separated, human-readable description of each failing constraint,
-     * suitable for direct display in the UI.
+     * [message] is a newline-separated, human-readable description of each failing constraint
+     * as returned by the server, suitable for direct display in the UI.
      *
      * @property message Human-readable description of the failing constraints
-     * @property failingRequirements Raw server-side constraint identifiers
+     * @property failingRequirements The individual constraint strings from the server
      * @property cause The underlying [Throwable] that caused this exception
      */
     class PasswordPolicyViolationException(
@@ -382,10 +380,8 @@ abstract class AuthException(
                     val sourceText = firebaseException.reason ?: firebaseException.message ?: ""
                     if (sourceText.contains("PASSWORD_DOES_NOT_MEET_REQUIREMENTS", ignoreCase = true)) {
                         val requirements = parsePasswordPolicyRequirements(sourceText)
-                        val humanReadable = requirements
-                            .joinToString("\n") { mapRequirementToString(it, stringProvider) }
                         PasswordPolicyViolationException(
-                            message = humanReadable.ifEmpty {
+                            message = requirements.joinToString("\n").ifEmpty {
                                 stringProvider?.errorWeakPasswordGeneric.nonEmpty()
                                     ?: "Password does not meet policy requirements"
                             },
@@ -510,10 +506,8 @@ abstract class AuthException(
                     val msg = firebaseException.message ?: ""
                     if (msg.contains("PASSWORD_DOES_NOT_MEET_REQUIREMENTS", ignoreCase = true)) {
                         val requirements = parsePasswordPolicyRequirements(msg)
-                        val humanReadable = requirements
-                            .joinToString("\n") { mapRequirementToString(it, stringProvider) }
                         PasswordPolicyViolationException(
-                            message = humanReadable.ifEmpty {
+                            message = requirements.joinToString("\n").ifEmpty {
                                 stringProvider?.errorWeakPasswordGeneric.nonEmpty()
                                     ?: "Password does not meet policy requirements"
                             },
@@ -567,23 +561,6 @@ abstract class AuthException(
                 .split(',')
                 .map { it.trim() }
                 .filter { it.isNotEmpty() }
-        }
-
-        // GIdP already returns human-readable requirement strings, so this is a pass-through
-        // for those. For older SDK versions that may surface short error codes instead
-        // (e.g. MISSING_UPPERCASE_CHARACTER), map those to localised strings.
-        private fun mapRequirementToString(code: String, stringProvider: AuthUIStringProvider?): String {
-            return when (code.uppercase(java.util.Locale.US)) {
-                "MISSING_UPPERCASE_CHARACTER" ->
-                    stringProvider?.passwordMissingUppercase ?: "Password must contain at least one uppercase letter"
-                "MISSING_LOWERCASE_CHARACTER" ->
-                    stringProvider?.passwordMissingLowercase ?: "Password must contain at least one lowercase letter"
-                "MISSING_NUMERIC_CHARACTER" ->
-                    stringProvider?.passwordMissingDigit ?: "Password must contain at least one number"
-                "MISSING_NON_ALPHANUMERIC_CHARACTER" ->
-                    stringProvider?.passwordMissingSpecialCharacter ?: "Password must contain at least one special character"
-                else -> code
-            }
         }
     }
 }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/components/ErrorRecoveryDialog.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/components/ErrorRecoveryDialog.kt
@@ -140,6 +140,11 @@ private fun getRecoveryMessage(
             } ?: baseMessage
         }
 
+        is AuthException.PasswordPolicyViolationException -> {
+            error.message?.takeIf { it.isNotBlank() }
+                ?: stringProvider.weakPasswordRecoveryMessage
+        }
+
         is AuthException.EmailAlreadyInUseException -> {
             // Include email if available
             val baseMessage = stringProvider.emailAlreadyInUseRecoveryMessage
@@ -201,6 +206,7 @@ private fun getRecoveryActionText(
         is AuthException.NetworkException,
         is AuthException.InvalidCredentialsException,
         is AuthException.WeakPasswordException,
+        is AuthException.PasswordPolicyViolationException,
         is AuthException.TooManyRequestsException,
         is AuthException.PhoneVerificationCooldownException -> stringProvider.retryAction
         is AuthException.UnknownException -> stringProvider.retryAction
@@ -221,6 +227,7 @@ private fun isRecoverable(error: AuthException): Boolean {
         is AuthException.InvalidCredentialsException -> true
         is AuthException.UserNotFoundException -> true
         is AuthException.WeakPasswordException -> true
+        is AuthException.PasswordPolicyViolationException -> true
         is AuthException.EmailAlreadyInUseException -> true
         is AuthException.TooManyRequestsException -> false // User must wait
         is AuthException.PhoneVerificationCooldownException -> false // User must wait for cooldown

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
@@ -306,7 +306,7 @@ fun EmailAuthScreen(
                         password = passwordTextValue.value,
                     )
                 } catch (e: Exception) {
-
+                    onError(AuthException.from(e, stringProvider))
                 }
             }
         },
@@ -318,7 +318,7 @@ fun EmailAuthScreen(
                         actionCodeSettings = configuration.passwordResetActionCodeSettings,
                     )
                 } catch (e: Exception) {
-
+                    onError(AuthException.from(e, stringProvider))
                 }
             }
         },

--- a/auth/src/test/java/com/firebase/ui/auth/AuthExceptionTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/AuthExceptionTest.kt
@@ -232,7 +232,7 @@ class AuthExceptionTest {
         val firebaseException = FirebaseAuthWeakPasswordException(
             "ERROR_WEAK_PASSWORD",
             "weak",
-            "PASSWORD_DOES_NOT_MEET_REQUIREMENTS : [MISSING_UPPERCASE_CHARACTER, MISSING_NUMERIC_CHARACTER]"
+            "PASSWORD_DOES_NOT_MEET_REQUIREMENTS : [Password must contain uppercase, Password must contain a number]"
         )
 
         val result = AuthException.from(firebaseException)
@@ -240,26 +240,10 @@ class AuthExceptionTest {
         assertThat(result).isInstanceOf(AuthException.PasswordPolicyViolationException::class.java)
         val policyEx = result as AuthException.PasswordPolicyViolationException
         assertThat(policyEx.failingRequirements).containsExactly(
-            "MISSING_UPPERCASE_CHARACTER",
-            "MISSING_NUMERIC_CHARACTER"
+            "Password must contain uppercase",
+            "Password must contain a number"
         ).inOrder()
-    }
-
-    @Test
-    fun `from() maps policy violation short codes via string provider`() {
-        val firebaseException = FirebaseAuthWeakPasswordException(
-            "ERROR_WEAK_PASSWORD",
-            "weak",
-            "PASSWORD_DOES_NOT_MEET_REQUIREMENTS : [MISSING_UPPERCASE_CHARACTER, MISSING_NUMERIC_CHARACTER]"
-        )
-        val stringProvider = mock(AuthUIStringProvider::class.java)
-        whenever(stringProvider.passwordMissingUppercase).thenReturn("Needs uppercase")
-        whenever(stringProvider.passwordMissingDigit).thenReturn("Needs a number")
-
-        val result = AuthException.from(firebaseException, stringProvider)
-
-        assertThat(result).isInstanceOf(AuthException.PasswordPolicyViolationException::class.java)
-        assertThat(result.message).isEqualTo("Needs uppercase\nNeeds a number")
+        assertThat(policyEx.message).isEqualTo("Password must contain uppercase\nPassword must contain a number")
     }
 
     @Test

--- a/auth/src/test/java/com/firebase/ui/auth/AuthExceptionTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/AuthExceptionTest.kt
@@ -191,7 +191,44 @@ class AuthExceptionTest {
     // =============================================================================================
 
     @Test
-    fun `from() maps GIdP policy violation in reason to PasswordPolicyViolationException`() {
+    fun `from() maps GIdP policy violation FirebaseException to PasswordPolicyViolationException`() {
+        val msg = "An internal error has occurred. [ PASSWORD_DOES_NOT_MEET_REQUIREMENTS:" +
+                "Missing password requirements: [Password must contain at least 10 characters] ]"
+        val firebaseException = object : com.google.firebase.FirebaseException(msg) {}
+
+        val result = AuthException.from(firebaseException)
+
+        assertThat(result).isInstanceOf(AuthException.PasswordPolicyViolationException::class.java)
+        val policyEx = result as AuthException.PasswordPolicyViolationException
+        assertThat(policyEx.failingRequirements).containsExactly(
+            "Password must contain at least 10 characters"
+        )
+        assertThat(policyEx.message).isEqualTo("Password must contain at least 10 characters")
+        assertThat(policyEx.cause).isEqualTo(firebaseException)
+    }
+
+    @Test
+    fun `from() maps GIdP policy violation with multiple requirements`() {
+        val msg = "An internal error has occurred. [ PASSWORD_DOES_NOT_MEET_REQUIREMENTS:" +
+                "Missing password requirements: [Password must contain at least 10 characters, " +
+                "Password must contain at least one uppercase letter] ]"
+        val firebaseException = object : com.google.firebase.FirebaseException(msg) {}
+
+        val result = AuthException.from(firebaseException)
+
+        assertThat(result).isInstanceOf(AuthException.PasswordPolicyViolationException::class.java)
+        val policyEx = result as AuthException.PasswordPolicyViolationException
+        assertThat(policyEx.failingRequirements).containsExactly(
+            "Password must contain at least 10 characters",
+            "Password must contain at least one uppercase letter"
+        ).inOrder()
+        assertThat(policyEx.message).isEqualTo(
+            "Password must contain at least 10 characters\nPassword must contain at least one uppercase letter"
+        )
+    }
+
+    @Test
+    fun `from() maps GIdP policy violation in FirebaseAuthWeakPasswordException reason`() {
         val firebaseException = FirebaseAuthWeakPasswordException(
             "ERROR_WEAK_PASSWORD",
             "weak",
@@ -206,35 +243,15 @@ class AuthExceptionTest {
             "MISSING_UPPERCASE_CHARACTER",
             "MISSING_NUMERIC_CHARACTER"
         ).inOrder()
-        assertThat(policyEx.cause).isEqualTo(firebaseException)
     }
 
     @Test
-    fun `from() maps GIdP policy violation in message when reason is null to PasswordPolicyViolationException`() {
-        val firebaseException = FirebaseAuthWeakPasswordException(
-            "ERROR_WEAK_PASSWORD",
-            "PASSWORD_DOES_NOT_MEET_REQUIREMENTS : [MISSING_LOWERCASE_CHARACTER, MISSING_NON_ALPHANUMERIC_CHARACTER]",
-            null
-        )
-
-        val result = AuthException.from(firebaseException)
-
-        assertThat(result).isInstanceOf(AuthException.PasswordPolicyViolationException::class.java)
-        val policyEx = result as AuthException.PasswordPolicyViolationException
-        assertThat(policyEx.failingRequirements).containsExactly(
-            "MISSING_LOWERCASE_CHARACTER",
-            "MISSING_NON_ALPHANUMERIC_CHARACTER"
-        ).inOrder()
-    }
-
-    @Test
-    fun `from() maps policy violation with string provider to human-readable message`() {
+    fun `from() maps policy violation short codes via string provider`() {
         val firebaseException = FirebaseAuthWeakPasswordException(
             "ERROR_WEAK_PASSWORD",
             "weak",
             "PASSWORD_DOES_NOT_MEET_REQUIREMENTS : [MISSING_UPPERCASE_CHARACTER, MISSING_NUMERIC_CHARACTER]"
         )
-
         val stringProvider = mock(AuthUIStringProvider::class.java)
         whenever(stringProvider.passwordMissingUppercase).thenReturn("Needs uppercase")
         whenever(stringProvider.passwordMissingDigit).thenReturn("Needs a number")
@@ -246,19 +263,17 @@ class AuthExceptionTest {
     }
 
     @Test
-    fun `from() maps unknown requirement code to raw code string`() {
-        val firebaseException = FirebaseAuthWeakPasswordException(
-            "ERROR_WEAK_PASSWORD",
-            "weak",
-            "PASSWORD_DOES_NOT_MEET_REQUIREMENTS : [SOME_FUTURE_REQUIREMENT]"
-        )
+    fun `from() passes through unknown requirement strings as-is`() {
+        val msg = "An internal error has occurred. [ PASSWORD_DOES_NOT_MEET_REQUIREMENTS:" +
+                "Missing password requirements: [Some future requirement] ]"
+        val firebaseException = object : com.google.firebase.FirebaseException(msg) {}
 
         val result = AuthException.from(firebaseException)
 
         assertThat(result).isInstanceOf(AuthException.PasswordPolicyViolationException::class.java)
         val policyEx = result as AuthException.PasswordPolicyViolationException
-        assertThat(policyEx.failingRequirements).containsExactly("SOME_FUTURE_REQUIREMENT")
-        assertThat(policyEx.message).isEqualTo("SOME_FUTURE_REQUIREMENT")
+        assertThat(policyEx.failingRequirements).containsExactly("Some future requirement")
+        assertThat(policyEx.message).isEqualTo("Some future requirement")
     }
 
     @Test
@@ -272,6 +287,15 @@ class AuthExceptionTest {
         val result = AuthException.from(firebaseException)
 
         assertThat(result).isInstanceOf(AuthException.WeakPasswordException::class.java)
+    }
+
+    @Test
+    fun `from() maps plain FirebaseException without policy to NetworkException`() {
+        val firebaseException = object : com.google.firebase.FirebaseException("Network timeout") {}
+
+        val result = AuthException.from(firebaseException)
+
+        assertThat(result).isInstanceOf(AuthException.NetworkException::class.java)
     }
 
     @Test

--- a/auth/src/test/java/com/firebase/ui/auth/AuthExceptionTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/AuthExceptionTest.kt
@@ -19,6 +19,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.firebase.FirebaseException
 import com.google.firebase.auth.FirebaseAuthException
 import com.google.firebase.auth.FirebaseAuthInvalidUserException
+import com.google.firebase.auth.FirebaseAuthWeakPasswordException
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
@@ -113,6 +114,7 @@ class AuthExceptionTest {
         assertThat(AuthException.InvalidCredentialsException("Test")).isInstanceOf(AuthException::class.java)
         assertThat(AuthException.UserNotFoundException("Test")).isInstanceOf(AuthException::class.java)
         assertThat(AuthException.WeakPasswordException("Test")).isInstanceOf(AuthException::class.java)
+        assertThat(AuthException.PasswordPolicyViolationException("Test", emptyList())).isInstanceOf(AuthException::class.java)
         assertThat(AuthException.EmailAlreadyInUseException("Test")).isInstanceOf(AuthException::class.java)
         assertThat(AuthException.TooManyRequestsException("Test")).isInstanceOf(AuthException::class.java)
         assertThat(AuthException.MfaRequiredException("Test")).isInstanceOf(AuthException::class.java)
@@ -182,5 +184,101 @@ class AuthExceptionTest {
         val result = AuthException.from(firebaseException)
 
         assertThat(result.message).isEqualTo("Firebase: user disabled")
+    }
+
+    // =============================================================================================
+    // GIdP password policy
+    // =============================================================================================
+
+    @Test
+    fun `from() maps GIdP policy violation in reason to PasswordPolicyViolationException`() {
+        val firebaseException = FirebaseAuthWeakPasswordException(
+            "ERROR_WEAK_PASSWORD",
+            "weak",
+            "PASSWORD_DOES_NOT_MEET_REQUIREMENTS : [MISSING_UPPERCASE_CHARACTER, MISSING_NUMERIC_CHARACTER]"
+        )
+
+        val result = AuthException.from(firebaseException)
+
+        assertThat(result).isInstanceOf(AuthException.PasswordPolicyViolationException::class.java)
+        val policyEx = result as AuthException.PasswordPolicyViolationException
+        assertThat(policyEx.failingRequirements).containsExactly(
+            "MISSING_UPPERCASE_CHARACTER",
+            "MISSING_NUMERIC_CHARACTER"
+        ).inOrder()
+        assertThat(policyEx.cause).isEqualTo(firebaseException)
+    }
+
+    @Test
+    fun `from() maps GIdP policy violation in message when reason is null to PasswordPolicyViolationException`() {
+        val firebaseException = FirebaseAuthWeakPasswordException(
+            "ERROR_WEAK_PASSWORD",
+            "PASSWORD_DOES_NOT_MEET_REQUIREMENTS : [MISSING_LOWERCASE_CHARACTER, MISSING_NON_ALPHANUMERIC_CHARACTER]",
+            null
+        )
+
+        val result = AuthException.from(firebaseException)
+
+        assertThat(result).isInstanceOf(AuthException.PasswordPolicyViolationException::class.java)
+        val policyEx = result as AuthException.PasswordPolicyViolationException
+        assertThat(policyEx.failingRequirements).containsExactly(
+            "MISSING_LOWERCASE_CHARACTER",
+            "MISSING_NON_ALPHANUMERIC_CHARACTER"
+        ).inOrder()
+    }
+
+    @Test
+    fun `from() maps policy violation with string provider to human-readable message`() {
+        val firebaseException = FirebaseAuthWeakPasswordException(
+            "ERROR_WEAK_PASSWORD",
+            "weak",
+            "PASSWORD_DOES_NOT_MEET_REQUIREMENTS : [MISSING_UPPERCASE_CHARACTER, MISSING_NUMERIC_CHARACTER]"
+        )
+
+        val stringProvider = mock(AuthUIStringProvider::class.java)
+        whenever(stringProvider.passwordMissingUppercase).thenReturn("Needs uppercase")
+        whenever(stringProvider.passwordMissingDigit).thenReturn("Needs a number")
+
+        val result = AuthException.from(firebaseException, stringProvider)
+
+        assertThat(result).isInstanceOf(AuthException.PasswordPolicyViolationException::class.java)
+        assertThat(result.message).isEqualTo("Needs uppercase\nNeeds a number")
+    }
+
+    @Test
+    fun `from() maps unknown requirement code to raw code string`() {
+        val firebaseException = FirebaseAuthWeakPasswordException(
+            "ERROR_WEAK_PASSWORD",
+            "weak",
+            "PASSWORD_DOES_NOT_MEET_REQUIREMENTS : [SOME_FUTURE_REQUIREMENT]"
+        )
+
+        val result = AuthException.from(firebaseException)
+
+        assertThat(result).isInstanceOf(AuthException.PasswordPolicyViolationException::class.java)
+        val policyEx = result as AuthException.PasswordPolicyViolationException
+        assertThat(policyEx.failingRequirements).containsExactly("SOME_FUTURE_REQUIREMENT")
+        assertThat(policyEx.message).isEqualTo("SOME_FUTURE_REQUIREMENT")
+    }
+
+    @Test
+    fun `from() maps plain weak password (no policy) to WeakPasswordException`() {
+        val firebaseException = FirebaseAuthWeakPasswordException(
+            "ERROR_WEAK_PASSWORD",
+            "The given password is invalid.",
+            "Password should be at least 6 characters"
+        )
+
+        val result = AuthException.from(firebaseException)
+
+        assertThat(result).isInstanceOf(AuthException.WeakPasswordException::class.java)
+    }
+
+    @Test
+    fun `PasswordPolicyViolationException stores failingRequirements correctly`() {
+        val requirements = listOf("MISSING_UPPERCASE_CHARACTER", "MISSING_NUMERIC_CHARACTER")
+        val exception = AuthException.PasswordPolicyViolationException("msg", requirements)
+
+        assertThat(exception.failingRequirements).isEqualTo(requirements)
     }
 }


### PR DESCRIPTION
Closes #2128.

When [Google Identity Platform password policy enforcement](https://cloud.google.com/identity-platform/docs/password-policy) is enabled, the Firebase Auth SDK returns a `PASSWORD_DOES_NOT_MEET_REQUIREMENTS` error with the specific failing constraints. 

Previously FirebaseUI silently swallowed these errors — users saw nothing or a generic "unknown error" dialog.

## Changes
- Adds `AuthException.PasswordPolicyViolationException` with a human-readable message and the list of failing requirements
- Detects `PASSWORD_DOES_NOT_MEET_REQUIREMENTS` in both `FirebaseAuthWeakPasswordException.reason` and the raw `FirebaseException` message (actual type from SDK 24.0.1+)
- Fixes subclass ordering in `AuthException.from()` so `FirebaseAuthWeakPasswordException` is no longer matched as `InvalidCredentialsException`
- Surfaces the policy message in `ErrorRecoveryDialog` with a "Try again" action
- Fixes the silent `catch {}` in `EmailAuthScreen.onSignUpClick` that was discarding all sign-up errors

> **NOTE:** If `passwordValidationRules` in `AuthUIConfiguration` doesn't match the policy configured in the
> Firebase console, the client-side check won't catch the weak password before submission and this exception
> will be thrown instead.

### Expected Behavior
<img width="300" alt="Screenshot_1780908844" src="https://github.com/user-attachments/assets/e8802a78-3855-4061-bac3-0101fbd9d888" />
