### PR TITLE
feat(storage): add StringLoader to support loading gs:// URL strings directly via Glide

### DIFF
--- a/storage/README.md
+++ b/storage/README.md
@@ -72,6 +72,39 @@ GlideApp.with(this /* context */)
         .into(imageView);
 ```
 
+#### Loading from a gs:// URL string
+
+If your image paths are stored as `gs://` URL strings (e.g. retrieved from Firestore) rather
+than as `StorageReference` objects, register `FirebaseImageLoader.StringLoader.Factory` in your
+`AppGlideModule` alongside the default loader:
+
+```java
+@GlideModule
+public class MyAppGlideModule extends AppGlideModule {
+
+    @Override
+    public void registerComponents(Context context, Glide glide, Registry registry) {
+        registry.append(StorageReference.class, InputStream.class,
+                new FirebaseImageLoader.Factory());
+        registry.append(String.class, InputStream.class,
+                new FirebaseImageLoader.StringLoader.Factory());
+    }
+}
+```
+
+You can then pass a `gs://` string directly to Glide:
+
+```java
+String gsUrl = "gs://my-bucket.appspot.com/images/photo.png";
+
+GlideApp.with(this /* context */)
+        .load(gsUrl)
+        .into(imageView);
+```
+
+`StringLoader` only intercepts strings that start with `gs://`, so Glide's built-in loaders
+for `http://`, `https://`, and other schemes continue to work as normal.
+
 ### Troubleshooting
 
 If GlideApp is not an importable class, build your application first before trying to use.

--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -51,4 +51,7 @@ dependencies {
     api(Config.Libs.Firebase.storage)
     // Override Play Services
     implementation(Config.Libs.Androidx.legacySupportv4)
+
+    testImplementation(Config.Libs.Test.junit)
+    testImplementation(Config.Libs.Test.mockitoCore)
 }

--- a/storage/src/main/java/com/firebase/ui/storage/images/FirebaseImageLoader.java
+++ b/storage/src/main/java/com/firebase/ui/storage/images/FirebaseImageLoader.java
@@ -12,6 +12,7 @@ import com.bumptech.glide.load.model.ModelLoaderFactory;
 import com.bumptech.glide.load.model.MultiModelLoaderFactory;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
 import com.google.firebase.storage.StreamDownloadTask;
 
@@ -84,6 +85,45 @@ public class FirebaseImageLoader implements ModelLoader<StorageReference, InputS
     @Override
     public boolean handles(@NonNull StorageReference reference) {
         return true;
+    }
+
+    /**
+     * ModelLoader that accepts a {@code gs://} URL string and delegates to
+     * {@link FirebaseStorageFetcher}, so callers can pass a plain gs:// string instead of a
+     * {@link StorageReference}.
+     */
+    public static class StringLoader implements ModelLoader<String, InputStream> {
+
+        @Nullable
+        @Override
+        public LoadData<InputStream> buildLoadData(@NonNull String gsUrl,
+                                                   int width,
+                                                   int height,
+                                                   @NonNull Options options) {
+            try {
+                StorageReference ref = FirebaseStorage.getInstance().getReferenceFromUrl(gsUrl);
+                return new LoadData<>(new FirebaseStorageKey(ref), new FirebaseStorageFetcher(ref));
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }
+
+        @Override
+        public boolean handles(@NonNull String gsUrl) {
+            return gsUrl.startsWith("gs://");
+        }
+
+        public static class Factory implements ModelLoaderFactory<String, InputStream> {
+
+            @NonNull
+            @Override
+            public ModelLoader<String, InputStream> build(@NonNull MultiModelLoaderFactory factory) {
+                return new StringLoader();
+            }
+
+            @Override
+            public void teardown() {}
+        }
     }
 
     private static class FirebaseStorageKey implements Key {

--- a/storage/src/main/java/com/firebase/ui/storage/images/FirebaseImageLoader.java
+++ b/storage/src/main/java/com/firebase/ui/storage/images/FirebaseImageLoader.java
@@ -95,15 +95,27 @@ public class FirebaseImageLoader implements ModelLoader<StorageReference, InputS
     public static class StringLoader implements ModelLoader<String, InputStream> {
 
         @Nullable
+        private final FirebaseStorage mStorage;
+
+        public StringLoader() {
+            mStorage = null;
+        }
+
+        public StringLoader(@NonNull FirebaseStorage storage) {
+            mStorage = storage;
+        }
+
+        @Nullable
         @Override
         public LoadData<InputStream> buildLoadData(@NonNull String gsUrl,
                                                    int width,
                                                    int height,
                                                    @NonNull Options options) {
             try {
-                StorageReference ref = FirebaseStorage.getInstance().getReferenceFromUrl(gsUrl);
+                FirebaseStorage storage = mStorage != null ? mStorage : FirebaseStorage.getInstance();
+                StorageReference ref = storage.getReferenceFromUrl(gsUrl);
                 return new LoadData<>(new FirebaseStorageKey(ref), new FirebaseStorageFetcher(ref));
-            } catch (IllegalArgumentException e) {
+            } catch (IllegalArgumentException | IllegalStateException e) {
                 return null;
             }
         }
@@ -115,10 +127,21 @@ public class FirebaseImageLoader implements ModelLoader<StorageReference, InputS
 
         public static class Factory implements ModelLoaderFactory<String, InputStream> {
 
+            @Nullable
+            private final FirebaseStorage mStorage;
+
+            public Factory() {
+                mStorage = null;
+            }
+
+            public Factory(@NonNull FirebaseStorage storage) {
+                mStorage = storage;
+            }
+
             @NonNull
             @Override
             public ModelLoader<String, InputStream> build(@NonNull MultiModelLoaderFactory factory) {
-                return new StringLoader();
+                return mStorage != null ? new StringLoader(mStorage) : new StringLoader();
             }
 
             @Override

--- a/storage/src/test/java/com/firebase/ui/storage/images/StringLoaderTest.java
+++ b/storage/src/test/java/com/firebase/ui/storage/images/StringLoaderTest.java
@@ -1,0 +1,98 @@
+package com.firebase.ui.storage.images;
+
+import com.bumptech.glide.load.Options;
+import com.bumptech.glide.load.model.ModelLoader.LoadData;
+import com.google.firebase.storage.FirebaseStorage;
+import com.google.firebase.storage.StorageReference;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.InputStream;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StringLoaderTest {
+
+    private static final String VALID_GS_URL = "gs://my-bucket.appspot.com/images/photo.png";
+    private static final String INVALID_GS_URL = "gs://bad-url";
+
+    @Mock FirebaseStorage mStorage;
+    @Mock StorageReference mRef;
+
+    @Before
+    public void setUp() {
+        when(mStorage.getReferenceFromUrl(VALID_GS_URL)).thenReturn(mRef);
+    }
+
+    // handles()
+
+    @Test
+    public void handles_gsUrl_returnsTrue() {
+        assertTrue(new FirebaseImageLoader.StringLoader(mStorage).handles(VALID_GS_URL));
+    }
+
+    @Test
+    public void handles_httpsUrl_returnsFalse() {
+        assertFalse(new FirebaseImageLoader.StringLoader(mStorage).handles("https://example.com/image.png"));
+    }
+
+    @Test
+    public void handles_emptyString_returnsFalse() {
+        assertFalse(new FirebaseImageLoader.StringLoader(mStorage).handles(""));
+    }
+
+    // buildLoadData()
+
+    @Test
+    public void buildLoadData_validUrl_returnsLoadData() {
+        LoadData<InputStream> result = loaderWithMockStorage().buildLoadData(VALID_GS_URL, 0, 0, new Options());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void buildLoadData_illegalArgumentException_returnsNull() {
+        when(mStorage.getReferenceFromUrl(INVALID_GS_URL)).thenThrow(new IllegalArgumentException());
+        LoadData<InputStream> result = loaderWithMockStorage().buildLoadData(INVALID_GS_URL, 0, 0, new Options());
+        assertNull(result);
+    }
+
+    @Test
+    public void buildLoadData_illegalStateException_returnsNull() {
+        when(mStorage.getReferenceFromUrl(VALID_GS_URL)).thenThrow(new IllegalStateException());
+        LoadData<InputStream> result = loaderWithMockStorage().buildLoadData(VALID_GS_URL, 0, 0, new Options());
+        assertNull(result);
+    }
+
+    // Factory
+
+    @Test
+    public void factory_noArg_buildsStringLoader() {
+        // Verify the no-arg Factory produces a non-null loader without throwing
+        FirebaseImageLoader.StringLoader loader =
+                (FirebaseImageLoader.StringLoader) new FirebaseImageLoader.StringLoader.Factory().build(null);
+        assertNotNull(loader);
+    }
+
+    @Test
+    public void factory_withStorage_buildsStringLoaderUsingProvidedInstance() {
+        FirebaseImageLoader.StringLoader loader =
+                (FirebaseImageLoader.StringLoader) new FirebaseImageLoader.StringLoader.Factory(mStorage).build(null);
+        // The provided storage instance should be used — valid URL resolves without exception
+        LoadData<InputStream> result = loader.buildLoadData(VALID_GS_URL, 0, 0, new Options());
+        assertNotNull(result);
+    }
+
+    private FirebaseImageLoader.StringLoader loaderWithMockStorage() {
+        return new FirebaseImageLoader.StringLoader(mStorage);
+    }
+}


### PR DESCRIPTION
Closes #1842 .

## Changes
`FirebaseImageLoader` previously only accepted a `StorageReference` as the Glide model, meaning callers who stored image paths as `gs://` strings (e.g. retrieved from Firestore) had to manually convert them before loading. `StringLoader` eliminates that conversion by intercepting any string starting with `gs://` and delegating to the existing `FirebaseStorageFetcher`.

## Usage
Register `StringLoader.Factory` alongside the existing loader in your `AppGlideModule`:

```java
@GlideModule
public class MyAppGlideModule extends AppGlideModule {

    @Override
    public void registerComponents(Context context, Glide glide, Registry registry) {
        registry.append(StorageReference.class, InputStream.class,
                new FirebaseImageLoader.Factory());
        registry.append(String.class, InputStream.class,
                new FirebaseImageLoader.StringLoader.Factory());
    }
}
```

You can then pass a `gs://` URL string directly to Glide:

```java
GlideApp.with(context)
        .load("gs://my-bucket.appspot.com/images/photo.png")
        .into(imageView);
```

## Preview
<img width="300" alt="Screenshot_1781696578" src="https://github.com/user-attachments/assets/df1aac31-d186-45fc-93dd-6bc911c82b9d" />