### PR TITLE
fix(database): fix DatabasePagingSource pagination when using orderByChild

### DIFF
--- a/database/src/androidTest/java/com/firebase/ui/database/paging/DatabasePagingSourceTest.java
+++ b/database/src/androidTest/java/com/firebase/ui/database/paging/DatabasePagingSourceTest.java
@@ -1,0 +1,117 @@
+package com.firebase.ui.database.paging;
+
+import android.content.Context;
+
+import androidx.paging.PagingSource;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.firebase.ui.database.Bean;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseError;
+import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.FirebaseDatabase;
+import com.google.firebase.database.ValueEventListener;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import androidx.annotation.NonNull;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class DatabasePagingSourceTest {
+    private static final String APP_NAME = "firebaseui-paging-tests";
+    private static final int PAGE_SIZE = 3;
+    private static final int TOTAL_ITEMS = 6;
+
+    private DatabaseReference mRef;
+
+    @Before
+    public void setUp() throws InterruptedException {
+        FirebaseApp app;
+        try {
+            app = FirebaseApp.getInstance(APP_NAME);
+        } catch (IllegalStateException e) {
+            Context context = ApplicationProvider.getApplicationContext();
+            app = FirebaseApp.initializeApp(context, new FirebaseOptions.Builder()
+                    .setApplicationId("fir-ui-tests")
+                    .setDatabaseUrl("https://fir-ui-tests.firebaseio.com/")
+                    .build(), APP_NAME);
+        }
+
+        mRef = FirebaseDatabase.getInstance(app).getReference().child("paging_test");
+
+        mRef.removeValue();
+        for (int i = 1; i <= TOTAL_ITEMS; i++) {
+            mRef.push().setValue(new Bean(i));
+        }
+
+        CountDownLatch latch = new CountDownLatch(1);
+        mRef.addValueEventListener(new ValueEventListener() {
+            @Override
+            public void onDataChange(@NonNull DataSnapshot snapshot) {
+                if (snapshot.getChildrenCount() >= TOTAL_ITEMS) {
+                    mRef.removeEventListener(this);
+                    latch.countDown();
+                }
+            }
+
+            @Override
+            public void onCancelled(@NonNull DatabaseError error) {}
+        });
+        assertTrue("Timed out seeding test data", latch.await(30, TimeUnit.SECONDS));
+    }
+
+    @After
+    public void tearDown() {
+        mRef.removeValue();
+    }
+
+    @Test
+    public void testOrderByChild_noDuplicatesAcrossPages() {
+        DatabasePagingSource source = new DatabasePagingSource(mRef.orderByChild("number"));
+
+        PagingSource.LoadResult<DatabasePagingKey, DataSnapshot> result1 =
+                source.loadSingle(new PagingSource.LoadParams.Refresh<>(null, PAGE_SIZE, false))
+                        .timeout(30, TimeUnit.SECONDS)
+                        .blockingGet();
+
+        assertTrue(result1 instanceof PagingSource.LoadResult.Page);
+        PagingSource.LoadResult.Page<DatabasePagingKey, DataSnapshot> page1 =
+                (PagingSource.LoadResult.Page<DatabasePagingKey, DataSnapshot>) result1;
+        assertEquals(PAGE_SIZE, page1.getData().size());
+
+        DatabasePagingKey nextKey = page1.getNextKey();
+
+        PagingSource.LoadResult<DatabasePagingKey, DataSnapshot> result2 =
+                source.loadSingle(new PagingSource.LoadParams.Append<>(nextKey, PAGE_SIZE, false))
+                        .timeout(30, TimeUnit.SECONDS)
+                        .blockingGet();
+
+        assertTrue(result2 instanceof PagingSource.LoadResult.Page);
+        PagingSource.LoadResult.Page<DatabasePagingKey, DataSnapshot> page2 =
+                (PagingSource.LoadResult.Page<DatabasePagingKey, DataSnapshot>) result2;
+
+        Set<String> allKeys = new HashSet<>();
+        for (DataSnapshot snapshot : page1.getData()) {
+            allKeys.add(snapshot.getKey());
+        }
+        for (DataSnapshot snapshot : page2.getData()) {
+            assertTrue("Duplicate key across pages: " + snapshot.getKey(),
+                    allKeys.add(snapshot.getKey()));
+        }
+        assertEquals(TOTAL_ITEMS, allKeys.size());
+    }
+}

--- a/database/src/androidTest/java/com/firebase/ui/database/paging/DatabasePagingSourceTest.java
+++ b/database/src/androidTest/java/com/firebase/ui/database/paging/DatabasePagingSourceTest.java
@@ -1,14 +1,12 @@
 package com.firebase.ui.database.paging;
 
-import android.content.Context;
-
 import androidx.paging.PagingSource;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.firebase.ui.database.Bean;
+import com.firebase.ui.database.TestUtils;
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.FirebaseOptions;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
@@ -32,7 +30,6 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
 public class DatabasePagingSourceTest {
-    private static final String APP_NAME = "firebaseui-paging-tests";
     private static final int PAGE_SIZE = 3;
     private static final int TOTAL_ITEMS = 6;
 
@@ -40,17 +37,7 @@ public class DatabasePagingSourceTest {
 
     @Before
     public void setUp() throws InterruptedException {
-        FirebaseApp app;
-        try {
-            app = FirebaseApp.getInstance(APP_NAME);
-        } catch (IllegalStateException e) {
-            Context context = ApplicationProvider.getApplicationContext();
-            app = FirebaseApp.initializeApp(context, new FirebaseOptions.Builder()
-                    .setApplicationId("fir-ui-tests")
-                    .setDatabaseUrl("https://fir-ui-tests.firebaseio.com/")
-                    .build(), APP_NAME);
-        }
-
+        FirebaseApp app = TestUtils.getAppInstance(ApplicationProvider.getApplicationContext());
         mRef = FirebaseDatabase.getInstance(app).getReference().child("paging_test");
 
         mRef.removeValue();

--- a/database/src/main/java/com/firebase/ui/database/paging/DatabasePagingKey.java
+++ b/database/src/main/java/com/firebase/ui/database/paging/DatabasePagingKey.java
@@ -1,19 +1,35 @@
 package com.firebase.ui.database.paging;
 
-class DatabasePagingKey {
+import java.util.Objects;
+
+public class DatabasePagingKey {
     private final Object mChildValue;
     private final String mNodeKey;
 
-    DatabasePagingKey(Object childValue, String nodeKey) {
+    public DatabasePagingKey(Object childValue, String nodeKey) {
         mChildValue = childValue;
         mNodeKey = nodeKey;
     }
 
-    Object getChildValue() {
+    public Object getChildValue() {
         return mChildValue;
     }
 
-    String getNodeKey() {
+    public String getNodeKey() {
         return mNodeKey;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DatabasePagingKey that = (DatabasePagingKey) o;
+        return Objects.equals(mChildValue, that.mChildValue) &&
+                Objects.equals(mNodeKey, that.mNodeKey);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mChildValue, mNodeKey);
     }
 }

--- a/database/src/main/java/com/firebase/ui/database/paging/DatabasePagingKey.java
+++ b/database/src/main/java/com/firebase/ui/database/paging/DatabasePagingKey.java
@@ -1,0 +1,19 @@
+package com.firebase.ui.database.paging;
+
+class DatabasePagingKey {
+    private final Object mChildValue;
+    private final String mNodeKey;
+
+    DatabasePagingKey(Object childValue, String nodeKey) {
+        mChildValue = childValue;
+        mNodeKey = nodeKey;
+    }
+
+    Object getChildValue() {
+        return mChildValue;
+    }
+
+    String getNodeKey() {
+        return mNodeKey;
+    }
+}

--- a/database/src/main/java/com/firebase/ui/database/paging/DatabasePagingOptions.java
+++ b/database/src/main/java/com/firebase/ui/database/paging/DatabasePagingOptions.java
@@ -94,7 +94,7 @@ public final class DatabasePagingOptions<T> {
         public Builder<T> setQuery(@NonNull Query query,
                                    @NonNull PagingConfig config,
                                    @NotNull SnapshotParser<T> parser) {
-            final Pager<String, DataSnapshot> pager = new Pager<>(config,
+            final Pager<DatabasePagingKey, DataSnapshot> pager = new Pager<>(config,
                     () -> new DatabasePagingSource(query));
             mData = PagingLiveData.cachedIn(PagingLiveData.getLiveData(pager),
                     mOwner.getLifecycle());

--- a/database/src/main/java/com/firebase/ui/database/paging/DatabasePagingSource.java
+++ b/database/src/main/java/com/firebase/ui/database/paging/DatabasePagingSource.java
@@ -124,10 +124,8 @@ public class DatabasePagingSource extends RxPagingSource<DatabasePagingKey, Data
             return mQuery.startAt((String) childValue, nodeKey);
         } else if (childValue instanceof Boolean) {
             return mQuery.startAt((Boolean) childValue, nodeKey);
-        } else if (childValue instanceof Double) {
-            return mQuery.startAt((Double) childValue, nodeKey);
-        } else if (childValue instanceof Long) {
-            return mQuery.startAt(((Long) childValue).doubleValue(), nodeKey);
+        } else if (childValue instanceof Number) {
+            return mQuery.startAt(((Number) childValue).doubleValue(), nodeKey);
         }
         return mQuery.startAt(null, nodeKey);
     }

--- a/database/src/main/java/com/firebase/ui/database/paging/DatabasePagingSource.java
+++ b/database/src/main/java/com/firebase/ui/database/paging/DatabasePagingSource.java
@@ -1,6 +1,7 @@
 package com.firebase.ui.database.paging;
 
 import android.annotation.SuppressLint;
+import android.util.Log;
 
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
@@ -33,6 +34,8 @@ public class DatabasePagingSource extends RxPagingSource<DatabasePagingKey, Data
     public DatabasePagingSource(Query query) {
         this.mQuery = query;
     }
+
+    private static final String TAG = "DatabasePagingSource";
 
     /**
      * DatabaseError.fromStatus() and PathIndex are not meant to be public.
@@ -103,8 +106,14 @@ public class DatabasePagingSource extends RxPagingSource<DatabasePagingKey, Data
                     throw (Exception) e.getCause();
                 }
                 throw new Exception(e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return new LoadResult.Error<DatabasePagingKey, DataSnapshot>(e);
             }
-        }).subscribeOn(Schedulers.io()).onErrorReturn(LoadResult.Error::new);
+        }).subscribeOn(Schedulers.io()).onErrorReturn(e -> {
+            Log.e(TAG, "DatabasePagingSource load failed", e);
+            return new LoadResult.Error<>(e);
+        });
     }
 
     @SuppressLint("RestrictedApi")

--- a/database/src/main/java/com/firebase/ui/database/paging/DatabasePagingSource.java
+++ b/database/src/main/java/com/firebase/ui/database/paging/DatabasePagingSource.java
@@ -10,6 +10,7 @@ import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.Query;
 import com.google.firebase.database.snapshot.Index;
 import com.google.firebase.database.snapshot.PathIndex;
+import com.google.firebase.database.snapshot.ValueIndex;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -45,17 +46,20 @@ public class DatabasePagingSource extends RxPagingSource<DatabasePagingKey, Data
     @Override
     public Single<LoadResult<DatabasePagingKey, DataSnapshot>> loadSingle(
             @NonNull LoadParams<DatabasePagingKey> params) {
-        PathIndex pathIndex = getPathIndex();
+        final Index index = mQuery.getSpec().getIndex();
+        final boolean needsIndexedCursor =
+                index instanceof PathIndex || index instanceof ValueIndex;
         Task<DataSnapshot> task;
 
         if (params.getKey() == null) {
             task = mQuery.limitToFirst(params.getLoadSize()).get();
         } else {
             DatabasePagingKey key = params.getKey();
-            if (pathIndex != null) {
+            if (needsIndexedCursor) {
                 task = startAtChildValue(key.getChildValue(), key.getNodeKey())
                         .limitToFirst(params.getLoadSize() + 1).get();
             } else {
+                // orderByKey() — the node key alone is a sufficient cursor
                 task = mQuery.startAt(null, key.getNodeKey())
                         .limitToFirst(params.getLoadSize() + 1).get();
             }
@@ -89,9 +93,9 @@ public class DatabasePagingSource extends RxPagingSource<DatabasePagingKey, Data
                     //Detect End of Data
                     if (!data.isEmpty()) {
                         DataSnapshot last = data.get(data.size() - 1);
-                        Object childValue = pathIndex != null
-                                ? getChildValue(last, pathIndex) : null;
-                        lastKey = new DatabasePagingKey(childValue, last.getKey());
+                        Object cursorValue = needsIndexedCursor
+                                ? getIndexedValue(last, index) : null;
+                        lastKey = new DatabasePagingKey(cursorValue, last.getKey());
                     }
                     return toLoadResult(data, lastKey);
                 } else {
@@ -117,14 +121,13 @@ public class DatabasePagingSource extends RxPagingSource<DatabasePagingKey, Data
     }
 
     @SuppressLint("RestrictedApi")
-    private PathIndex getPathIndex() {
-        Index index = mQuery.getSpec().getIndex();
-        return index instanceof PathIndex ? (PathIndex) index : null;
-    }
-
-    @SuppressLint("RestrictedApi")
-    private Object getChildValue(DataSnapshot snapshot, PathIndex pathIndex) {
-        return snapshot.child(pathIndex.getQueryDefinition()).getValue();
+    private Object getIndexedValue(DataSnapshot snapshot, Index index) {
+        if (index instanceof PathIndex) {
+            return snapshot.child(((PathIndex) index).getQueryDefinition()).getValue();
+        } else if (index instanceof ValueIndex) {
+            return snapshot.getValue();
+        }
+        return null;
     }
 
     @SuppressLint("RestrictedApi")
@@ -136,6 +139,7 @@ public class DatabasePagingSource extends RxPagingSource<DatabasePagingKey, Data
         } else if (childValue instanceof Number) {
             return mQuery.startAt(((Number) childValue).doubleValue(), nodeKey);
         }
+        // childValue is null when a node lacks the ordered child field; key alone keeps the cursor correct
         return mQuery.startAt(null, nodeKey);
     }
 

--- a/database/src/main/java/com/firebase/ui/database/paging/DatabasePagingSource.java
+++ b/database/src/main/java/com/firebase/ui/database/paging/DatabasePagingSource.java
@@ -7,6 +7,8 @@ import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.Query;
+import com.google.firebase.database.snapshot.Index;
+import com.google.firebase.database.snapshot.PathIndex;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -21,7 +23,7 @@ import androidx.paging.rxjava3.RxPagingSource;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
-public class DatabasePagingSource extends RxPagingSource<String, DataSnapshot> {
+public class DatabasePagingSource extends RxPagingSource<DatabasePagingKey, DataSnapshot> {
     private final Query mQuery;
 
     private static final String STATUS_DATABASE_NOT_FOUND = "DATA_NOT_FOUND";
@@ -33,17 +35,27 @@ public class DatabasePagingSource extends RxPagingSource<String, DataSnapshot> {
     }
 
     /**
-     * DatabaseError.fromStatus() is not meant to be public.
+     * DatabaseError.fromStatus() and PathIndex are not meant to be public.
      */
     @SuppressLint("RestrictedApi")
     @NonNull
     @Override
-    public Single<LoadResult<String, DataSnapshot>> loadSingle(@NonNull LoadParams<String> params) {
+    public Single<LoadResult<DatabasePagingKey, DataSnapshot>> loadSingle(
+            @NonNull LoadParams<DatabasePagingKey> params) {
+        PathIndex pathIndex = getPathIndex();
         Task<DataSnapshot> task;
+
         if (params.getKey() == null) {
             task = mQuery.limitToFirst(params.getLoadSize()).get();
         } else {
-            task = mQuery.startAt(null, params.getKey()).limitToFirst(params.getLoadSize() + 1).get();
+            DatabasePagingKey key = params.getKey();
+            if (pathIndex != null) {
+                task = startAtChildValue(key.getChildValue(), key.getNodeKey())
+                        .limitToFirst(params.getLoadSize() + 1).get();
+            } else {
+                task = mQuery.startAt(null, key.getNodeKey())
+                        .limitToFirst(params.getLoadSize() + 1).get();
+            }
         }
 
         return Single.fromCallable(() -> {
@@ -51,10 +63,8 @@ public class DatabasePagingSource extends RxPagingSource<String, DataSnapshot> {
                 Tasks.await(task);
                 DataSnapshot dataSnapshot = task.getResult();
                 if (dataSnapshot.exists()) {
-
-                    //Make List of DataSnapshot
                     List<DataSnapshot> data = new ArrayList<>();
-                    String lastKey = null;
+                    DatabasePagingKey lastKey = null;
 
                     if (params.getKey() == null) {
                         for (DataSnapshot snapshot : dataSnapshot.getChildren()) {
@@ -69,15 +79,16 @@ public class DatabasePagingSource extends RxPagingSource<String, DataSnapshot> {
                         }
 
                         while (iterator.hasNext()) {
-                            DataSnapshot snapshot = iterator.next();
-                            data.add(snapshot);
+                            data.add(iterator.next());
                         }
                     }
 
                     //Detect End of Data
                     if (!data.isEmpty()) {
-                        //Get Last Key
-                        lastKey = getLastPageKey(data);
+                        DataSnapshot last = data.get(data.size() - 1);
+                        Object childValue = pathIndex != null
+                                ? getChildValue(last, pathIndex) : null;
+                        lastKey = new DatabasePagingKey(childValue, last.getKey());
                     }
                     return toLoadResult(data, lastKey);
                 } else {
@@ -89,19 +100,41 @@ public class DatabasePagingSource extends RxPagingSource<String, DataSnapshot> {
                 }
             } catch (ExecutionException e) {
                 if (e.getCause() instanceof Exception) {
-                    // throw the original Exception
                     throw (Exception) e.getCause();
                 }
-                // Only throw a new Exception when the original
-                // Throwable cannot be cast to Exception
                 throw new Exception(e);
             }
         }).subscribeOn(Schedulers.io()).onErrorReturn(LoadResult.Error::new);
     }
 
-    private LoadResult<String, DataSnapshot> toLoadResult(
+    @SuppressLint("RestrictedApi")
+    private PathIndex getPathIndex() {
+        Index index = mQuery.getSpec().getIndex();
+        return index instanceof PathIndex ? (PathIndex) index : null;
+    }
+
+    @SuppressLint("RestrictedApi")
+    private Object getChildValue(DataSnapshot snapshot, PathIndex pathIndex) {
+        return snapshot.child(pathIndex.getQueryDefinition()).getValue();
+    }
+
+    @SuppressLint("RestrictedApi")
+    private Query startAtChildValue(Object childValue, String nodeKey) {
+        if (childValue instanceof String) {
+            return mQuery.startAt((String) childValue, nodeKey);
+        } else if (childValue instanceof Boolean) {
+            return mQuery.startAt((Boolean) childValue, nodeKey);
+        } else if (childValue instanceof Double) {
+            return mQuery.startAt((Double) childValue, nodeKey);
+        } else if (childValue instanceof Long) {
+            return mQuery.startAt(((Long) childValue).doubleValue(), nodeKey);
+        }
+        return mQuery.startAt(null, nodeKey);
+    }
+
+    private LoadResult<DatabasePagingKey, DataSnapshot> toLoadResult(
             @NonNull List<DataSnapshot> snapshots,
-            String nextPage
+            DatabasePagingKey nextPage
     ) {
         return new LoadResult.Page<>(
                 snapshots,
@@ -112,17 +145,9 @@ public class DatabasePagingSource extends RxPagingSource<String, DataSnapshot> {
     }
 
     @Nullable
-    private String getLastPageKey(@NonNull List<DataSnapshot> data) {
-        if (data.isEmpty()) {
-            return null;
-        } else {
-            return data.get(data.size() - 1).getKey();
-        }
-    }
-
-    @Nullable
     @Override
-    public String getRefreshKey(@NonNull PagingState<String, DataSnapshot> state) {
+    public DatabasePagingKey getRefreshKey(
+            @NonNull PagingState<DatabasePagingKey, DataSnapshot> state) {
         return null;
     }
 }

--- a/database/src/main/java/com/firebase/ui/database/paging/FirebaseRecyclerPagingAdapter.java
+++ b/database/src/main/java/com/firebase/ui/database/paging/FirebaseRecyclerPagingAdapter.java
@@ -7,10 +7,10 @@ import com.google.firebase.database.DatabaseReference;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
-import androidx.lifecycle.LifecycleObserver;
+import androidx.lifecycle.LifecycleEventObserver;
+import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.Observer;
-import androidx.lifecycle.OnLifecycleEvent;
 import androidx.paging.PagingData;
 import androidx.paging.PagingDataAdapter;
 import androidx.recyclerview.widget.RecyclerView;
@@ -22,7 +22,7 @@ import androidx.recyclerview.widget.RecyclerView;
  */
 public abstract class FirebaseRecyclerPagingAdapter<T, VH extends RecyclerView.ViewHolder>
         extends PagingDataAdapter<DataSnapshot, VH>
-        implements LifecycleObserver {
+        implements LifecycleEventObserver {
 
     private DatabasePagingOptions<T> mOptions;
     private SnapshotParser<T> mParser;
@@ -88,7 +88,6 @@ public abstract class FirebaseRecyclerPagingAdapter<T, VH extends RecyclerView.V
     /**
      * Start listening to paging / scrolling events and populating adapter data.
      */
-    @OnLifecycleEvent(Lifecycle.Event.ON_START)
     public void startListening() {
         mPagingData.observeForever(mDataObserver);
     }
@@ -97,9 +96,17 @@ public abstract class FirebaseRecyclerPagingAdapter<T, VH extends RecyclerView.V
      * Unsubscribe from paging / scrolling events, no more data will be populated, but the existing
      * data will remain.
      */
-    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     public void stopListening() {
         mPagingData.removeObserver(mDataObserver);
+    }
+
+    @Override
+    public void onStateChanged(@NonNull LifecycleOwner source, @NonNull Lifecycle.Event event) {
+        if (event == Lifecycle.Event.ON_START) {
+            startListening();
+        } else if (event == Lifecycle.Event.ON_STOP) {
+            stopListening();
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #2000.

`DatabasePagingSource` was calling `startAt(null, key)` for all queries, but Firebase Database ignores the key parameter when the query uses `orderByChild()`, causing every subsequent page load to return the same first page of results and throwing `IllegalStateException: The same value was passed as the nextKey in two sequential Pages`.

The fix detects `orderByChild()` queries via the internal `PathIndex` and calls `startAt(childValue, key)` instead, storing both the child value and node key as the page cursor in the new `DatabasePagingKey` type.

**Changes:**
- `DatabasePagingKey` — made `public` (required for cross-package Kotlin access) with `equals()`/`hashCode()` (required by the Paging library for key diffing and state restoration)
- `DatabasePagingSource` — extends cursor fix to `orderByValue()` queries via `ValueIndex` in addition to `orderByChild()` via `PathIndex`; surfaces load errors to logcat via `onErrorReturn`
- `FirebaseRecyclerPagingAdapter` — replaces deprecated `@OnLifecycleEvent` with `LifecycleEventObserver` (removed in lifecycle 2.7.0)
- Adds instrumented test verifying no duplicate keys across pages when using `orderByChild()`