### PR TITLE
chore: add dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
       semver-major-days: 7
       semver-minor-days: 7
       semver-patch-days: 7
-    target-branch: dependency-updates
     labels:
       - 'dependencies'
 
@@ -22,6 +21,5 @@ updates:
       semver-major-days: 7
       semver-minor-days: 7
       semver-patch-days: 7
-    target-branch: dependency-updates
     labels:
       - 'dependencies'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    cooldown:
-      default-days: 7
-      semver-major-days: 7
-      semver-minor-days: 7
-      semver-patch-days: 7
     labels:
       - 'dependencies'
 
@@ -16,10 +11,5 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    cooldown:
-      default-days: 7
-      semver-major-days: 7
-      semver-minor-days: 7
-      semver-patch-days: 7
     labels:
       - 'dependencies'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: 'gradle'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    cooldown:
+      default-days: 7
+      semver-major-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 7
+    target-branch: dependency-updates
+    labels:
+      - 'dependencies'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    cooldown:
+      default-days: 7
+      semver-major-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 7
+    target-branch: dependency-updates
+    labels:
+      - 'dependencies'


### PR DESCRIPTION
Adds dependabot.yml to keep Gradle dependencies and GitHub Actions up to date on a daily schedule with 7-day cooldown. PRs target the dependency-updates branch.
 