### PR TITLE
fix(auth): replace hardcoded loading state strings with translatable string resources

### DIFF
--- a/app/src/main/java/com/firebaseui/android/demo/HighLevelApiDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/HighLevelApiDemoActivity.kt
@@ -50,6 +50,9 @@ import com.firebase.ui.auth.configuration.AuthUITransitions
 import com.firebase.ui.auth.configuration.PasswordRule
 import com.firebase.ui.auth.configuration.authUIConfiguration
 import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.configuration.string_provider.AuthUIStringProvider
+import com.firebase.ui.auth.configuration.string_provider.AuthUIStringProviderSample.CustomAuthUIStringProvider
+import com.firebase.ui.auth.configuration.string_provider.DefaultAuthUIStringProvider
 import com.firebase.ui.auth.configuration.theme.AuthUIAsset
 import com.firebase.ui.auth.configuration.theme.AuthUITheme
 import com.firebase.ui.auth.ui.screens.AuthSuccessUiContext
@@ -71,6 +74,17 @@ class HighLevelApiDemoActivity : ComponentActivity() {
             providerButtonShape = ShapeDefaults.ExtraLarge
         )
 
+        class CustomAuthUIStringProvider(
+            private val defaultProvider: AuthUIStringProvider
+        ) : AuthUIStringProvider by defaultProvider {
+
+            override val loadingSigningInAnonymously: String
+                get() = "Overriding signing in anonymously loading message..."
+        }
+
+        val customStringProvider =
+            CustomAuthUIStringProvider(DefaultAuthUIStringProvider(applicationContext))
+
         val configuration = authUIConfiguration {
             context = applicationContext
             theme = customTheme
@@ -79,6 +93,7 @@ class HighLevelApiDemoActivity : ComponentActivity() {
             privacyPolicyUrl = "https://policies.google.com/privacy"
             isAnonymousUpgradeEnabled = false
             isMfaEnabled = false
+            stringProvider = customStringProvider
             transitions = AuthUITransitions(
                 enterTransition = { slideInHorizontally { it } },
                 exitTransition = { slideOutHorizontally { -it } },
@@ -197,7 +212,10 @@ class HighLevelApiDemoActivity : ComponentActivity() {
                         authUI = authUI,
                         emailLink = emailLink,
                         onSignInSuccess = { result ->
-                            Log.d("HighLevelApiDemoActivity", "Authentication success: ${result.user?.uid}")
+                            Log.d(
+                                "HighLevelApiDemoActivity",
+                                "Authentication success: ${result.user?.uid}"
+                            )
                         },
                         onSignInFailure = { exception: AuthException ->
                             Log.e("HighLevelApiDemoActivity", "Authentication failed", exception)
@@ -327,7 +345,8 @@ private fun AppAuthenticatedContent(
         }
 
         is AuthState.RequiresEmailVerification -> {
-            val email = uiContext.authUI.getCurrentUser().getDisplayEmail(stringProvider.emailProvider)
+            val email =
+                uiContext.authUI.getCurrentUser().getDisplayEmail(stringProvider.emailProvider)
             Column(
                 modifier = Modifier.fillMaxSize(),
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -489,7 +508,8 @@ private fun ChangePasswordDialog(
     var updateError by remember { mutableStateOf<String?>(null) }
 
     val emailProvider = remember(configuration) {
-        configuration.providers.filterIsInstance<com.firebase.ui.auth.configuration.auth_provider.AuthProvider.Email>().firstOrNull()
+        configuration.providers.filterIsInstance<com.firebase.ui.auth.configuration.auth_provider.AuthProvider.Email>()
+            .firstOrNull()
     }
     val passwordValidator = remember(emailProvider, stringProvider) {
         com.firebase.ui.auth.configuration.validators.PasswordValidator(

--- a/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthUI.kt
@@ -426,7 +426,7 @@ class FirebaseAuthUI private constructor(
     suspend fun signOut(context: Context) {
         try {
             // Update state to loading
-            updateAuthState(AuthState.Loading("Signing out..."))
+            updateAuthState(AuthState.Loading(context.getString(R.string.fui_loading_signing_out)))
 
             // Sign out from Firebase Auth
             auth.signOut()
@@ -555,7 +555,7 @@ class FirebaseAuthUI private constructor(
                 )
 
             // Update state to loading
-            updateAuthState(AuthState.Loading("Deleting account..."))
+            updateAuthState(AuthState.Loading(context.getString(R.string.fui_loading_deleting_account)))
 
             // Delete the user account
             currentUser.delete().await()

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProvider+FirebaseAuthUI.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.FirebaseAuthUI
-import com.firebase.ui.auth.R
+import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
@@ -20,14 +20,14 @@ import kotlinx.coroutines.tasks.await
  * @see createOrLinkUserWithEmailAndPassword for upgrading anonymous accounts
  */
 @Composable
-internal fun FirebaseAuthUI.rememberAnonymousSignInHandler(): () -> Unit {
+internal fun FirebaseAuthUI.rememberAnonymousSignInHandler(config: AuthUIConfiguration): () -> Unit {
     val context = androidx.compose.ui.platform.LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     return remember(this) {
         {
             coroutineScope.launch {
                 try {
-                    signInAnonymously()
+                    signInAnonymously(config)
                 } catch (e: AuthException) {
                     // Already an AuthException, don't re-wrap it
                     updateAuthState(AuthState.Error(e))
@@ -108,9 +108,9 @@ internal fun FirebaseAuthUI.rememberAnonymousSignInHandler(): () -> Unit {
  * @see createOrLinkUserWithEmailAndPassword for email/password upgrade
  * @see signInWithPhoneAuthCredential for phone authentication upgrade
  */
-internal suspend fun FirebaseAuthUI.signInAnonymously() {
+internal suspend fun FirebaseAuthUI.signInAnonymously(config: AuthUIConfiguration) {
     try {
-        updateAuthState(AuthState.Loading(app.applicationContext.getString(R.string.fui_loading_signing_in_anonymously)))
+        updateAuthState(AuthState.Loading(config.stringProvider.loadingSigningInAnonymously))
         val result = auth.signInAnonymously().await()
         updateAuthStateWithResult(result, defaultIsNewUser = true)
     } catch (e: CancellationException) {

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProvider+FirebaseAuthUI.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.R
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
@@ -109,7 +110,7 @@ internal fun FirebaseAuthUI.rememberAnonymousSignInHandler(): () -> Unit {
  */
 internal suspend fun FirebaseAuthUI.signInAnonymously() {
     try {
-        updateAuthState(AuthState.Loading("Signing in anonymously..."))
+        updateAuthState(AuthState.Loading(app.applicationContext.getString(R.string.fui_loading_signing_in_anonymously)))
         val result = auth.signInAnonymously().await()
         updateAuthStateWithResult(result, defaultIsNewUser = true)
     } catch (e: CancellationException) {

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/EmailAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/EmailAuthProvider+FirebaseAuthUI.kt
@@ -1256,10 +1256,11 @@ private suspend fun FirebaseAuthUI.handleEmailLinkCredentialLinkingFlow(
  */
 internal suspend fun FirebaseAuthUI.sendPasswordResetEmail(
     email: String,
+    config: AuthUIConfiguration,
     actionCodeSettings: ActionCodeSettings? = null,
 ) {
     try {
-        updateAuthState(AuthState.Loading(app.applicationContext.getString(R.string.fui_loading_sending_password_reset)))
+        updateAuthState(AuthState.Loading(config.stringProvider.loadingSendingPasswordResetEmail))
         auth.sendPasswordResetEmail(email, actionCodeSettings).await()
         updateAuthState(AuthState.PasswordResetLinkSent())
     } catch (e: CancellationException) {

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/EmailAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/EmailAuthProvider+FirebaseAuthUI.kt
@@ -178,7 +178,7 @@ internal suspend fun FirebaseAuthUI.createOrLinkUserWithEmailAndPassword(
             }
         }
 
-        updateAuthState(AuthState.Loading("Creating user..."))
+        updateAuthState(AuthState.Loading(context.getString(R.string.fui_loading_creating_user)))
         val result = if (shouldLinkCredential) {
             auth.currentUser?.linkWithCredential(requireNotNull(pendingCredential))?.await()
         } else {
@@ -344,7 +344,7 @@ internal suspend fun FirebaseAuthUI.signInWithEmailAndPassword(
     skipCredentialSave: Boolean = false,
 ): AuthResult? {
     try {
-        updateAuthState(AuthState.Loading("Signing in..."))
+        updateAuthState(AuthState.Loading(context.getString(R.string.fui_loading_signing_in)))
         // In reauth mode build a credential and go through signInAndLinkWithCredential so
         // signInOrReauth routes to FirebaseUser.reauthenticate() instead of signInWithCredential().
         if (config.isReauthenticationMode) {
@@ -645,7 +645,7 @@ internal suspend fun FirebaseAuthUI.signInAndLinkWithCredential(
     photoUrl: Uri? = null,
 ): AuthResult? {
     try {
-        updateAuthState(AuthState.Loading("Signing in user..."))
+        updateAuthState(AuthState.Loading(app.applicationContext.getString(R.string.fui_loading_linking_credential)))
         val result = if (canUpgradeAnonymous(config, auth) || canLinkCredential(config, auth)) {
             auth.currentUser?.linkWithCredential(credential)?.await()
         } else {
@@ -830,7 +830,7 @@ internal suspend fun FirebaseAuthUI.sendSignInLinkToEmail(
     persistenceManager: PersistenceManager = EmailLinkPersistenceManager.default,
 ) {
     try {
-        updateAuthState(AuthState.Loading("Sending sign in email link..."))
+        updateAuthState(AuthState.Loading(context.getString(R.string.fui_loading_sending_email_link)))
 
         // Get anonymousUserId if can upgrade anonymously else default to empty string.
         // NOTE: check for empty string instead of null to validate anonymous user ID matches
@@ -988,7 +988,7 @@ internal suspend fun FirebaseAuthUI.signInWithEmailLink(
     persistenceManager: PersistenceManager = EmailLinkPersistenceManager.default,
 ): AuthResult? {
     try {
-        updateAuthState(AuthState.Loading("Signing in with email link..."))
+        updateAuthState(AuthState.Loading(context.getString(R.string.fui_loading_signing_in_with_email_link)))
 
         // Validate link format
         if (!auth.isSignInWithEmailLink(emailLink)) {
@@ -1259,7 +1259,7 @@ internal suspend fun FirebaseAuthUI.sendPasswordResetEmail(
     actionCodeSettings: ActionCodeSettings? = null,
 ) {
     try {
-        updateAuthState(AuthState.Loading("Sending password reset email..."))
+        updateAuthState(AuthState.Loading(app.applicationContext.getString(R.string.fui_loading_sending_password_reset)))
         auth.sendPasswordResetEmail(email, actionCodeSettings).await()
         updateAuthState(AuthState.PasswordResetLinkSent())
     } catch (e: CancellationException) {

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/EmailAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/EmailAuthProvider+FirebaseAuthUI.kt
@@ -178,7 +178,7 @@ internal suspend fun FirebaseAuthUI.createOrLinkUserWithEmailAndPassword(
             }
         }
 
-        updateAuthState(AuthState.Loading(context.getString(R.string.fui_loading_creating_user)))
+        updateAuthState(AuthState.Loading(config.stringProvider.loadingCreatingUser))
         val result = if (shouldLinkCredential) {
             auth.currentUser?.linkWithCredential(requireNotNull(pendingCredential))?.await()
         } else {
@@ -344,7 +344,7 @@ internal suspend fun FirebaseAuthUI.signInWithEmailAndPassword(
     skipCredentialSave: Boolean = false,
 ): AuthResult? {
     try {
-        updateAuthState(AuthState.Loading(context.getString(R.string.fui_loading_signing_in)))
+        updateAuthState(AuthState.Loading(config.stringProvider.loadingSigningIn))
         // In reauth mode build a credential and go through signInAndLinkWithCredential so
         // signInOrReauth routes to FirebaseUser.reauthenticate() instead of signInWithCredential().
         if (config.isReauthenticationMode) {
@@ -645,7 +645,7 @@ internal suspend fun FirebaseAuthUI.signInAndLinkWithCredential(
     photoUrl: Uri? = null,
 ): AuthResult? {
     try {
-        updateAuthState(AuthState.Loading(app.applicationContext.getString(R.string.fui_loading_linking_credential)))
+        updateAuthState(AuthState.Loading(config.stringProvider.loadingLinkingCredential))
         val result = if (canUpgradeAnonymous(config, auth) || canLinkCredential(config, auth)) {
             auth.currentUser?.linkWithCredential(credential)?.await()
         } else {
@@ -830,7 +830,7 @@ internal suspend fun FirebaseAuthUI.sendSignInLinkToEmail(
     persistenceManager: PersistenceManager = EmailLinkPersistenceManager.default,
 ) {
     try {
-        updateAuthState(AuthState.Loading(context.getString(R.string.fui_loading_sending_email_link)))
+        updateAuthState(AuthState.Loading(config.stringProvider.loadingSendingEmailLink))
 
         // Get anonymousUserId if can upgrade anonymously else default to empty string.
         // NOTE: check for empty string instead of null to validate anonymous user ID matches
@@ -988,7 +988,7 @@ internal suspend fun FirebaseAuthUI.signInWithEmailLink(
     persistenceManager: PersistenceManager = EmailLinkPersistenceManager.default,
 ): AuthResult? {
     try {
-        updateAuthState(AuthState.Loading(context.getString(R.string.fui_loading_signing_in_with_email_link)))
+        updateAuthState(AuthState.Loading(config.stringProvider.loadingSigningInWithEmailLink))
 
         // Validate link format
         if (!auth.isSignInWithEmailLink(emailLink)) {

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/FacebookAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/FacebookAuthProvider+FirebaseAuthUI.kt
@@ -30,7 +30,6 @@ import com.facebook.login.LoginResult
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.FirebaseAuthUI
-import com.firebase.ui.auth.R
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.util.EmailLinkPersistenceManager
 import com.firebase.ui.auth.util.SignInPreferenceManager
@@ -115,7 +114,7 @@ internal fun FirebaseAuthUI.rememberSignInWithFacebookLauncher(
 
     return {
         updateAuthState(
-            AuthState.Loading(context.getString(R.string.fui_loading_signing_in_with_facebook))
+            AuthState.Loading(config.stringProvider.loadingSigningInWithFacebook)
         )
         try {
             (testLoginManagerProvider ?: loginManagerProvider).logOut()
@@ -156,7 +155,7 @@ internal suspend fun FirebaseAuthUI.signInWithFacebook(
 ) {
     try {
         updateAuthState(
-            AuthState.Loading(context.getString(R.string.fui_loading_signing_in_with_facebook))
+            AuthState.Loading(config.stringProvider.loadingSigningInWithFacebook)
         )
         val profileData = provider.fetchFacebookProfile(accessToken)
         val credential = credentialProvider.getCredential(accessToken.token)

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/FacebookAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/FacebookAuthProvider+FirebaseAuthUI.kt
@@ -30,6 +30,7 @@ import com.facebook.login.LoginResult
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.R
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.util.EmailLinkPersistenceManager
 import com.firebase.ui.auth.util.SignInPreferenceManager
@@ -114,7 +115,7 @@ internal fun FirebaseAuthUI.rememberSignInWithFacebookLauncher(
 
     return {
         updateAuthState(
-            AuthState.Loading("Signing in with facebook...")
+            AuthState.Loading(context.getString(R.string.fui_loading_signing_in_with_facebook))
         )
         try {
             (testLoginManagerProvider ?: loginManagerProvider).logOut()
@@ -155,7 +156,7 @@ internal suspend fun FirebaseAuthUI.signInWithFacebook(
 ) {
     try {
         updateAuthState(
-            AuthState.Loading("Signing in with facebook...")
+            AuthState.Loading(context.getString(R.string.fui_loading_signing_in_with_facebook))
         )
         val profileData = provider.fetchFacebookProfile(accessToken)
         val credential = credentialProvider.getCredential(accessToken.token)

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProvider+FirebaseAuthUI.kt
@@ -11,6 +11,7 @@ import androidx.credentials.exceptions.NoCredentialException
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.R
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.util.EmailLinkPersistenceManager
 import com.firebase.ui.auth.util.SignInPreferenceManager
@@ -119,7 +120,7 @@ internal suspend fun FirebaseAuthUI.signInWithGoogle(
 ) {
     var idTokenFromResult: String? = null
     try {
-        updateAuthState(AuthState.Loading("Signing in with google..."))
+        updateAuthState(AuthState.Loading(context.getString(R.string.fui_loading_signing_in_with_google)))
 
         // Request OAuth scopes if specified (before sign-in)
         if (provider.scopes.isNotEmpty()) {

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProvider+FirebaseAuthUI.kt
@@ -11,7 +11,6 @@ import androidx.credentials.exceptions.NoCredentialException
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.FirebaseAuthUI
-import com.firebase.ui.auth.R
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.util.EmailLinkPersistenceManager
 import com.firebase.ui.auth.util.SignInPreferenceManager
@@ -120,7 +119,7 @@ internal suspend fun FirebaseAuthUI.signInWithGoogle(
 ) {
     var idTokenFromResult: String? = null
     try {
-        updateAuthState(AuthState.Loading(context.getString(R.string.fui_loading_signing_in_with_google)))
+        updateAuthState(AuthState.Loading(config.stringProvider.loadingSigningInWithGoogle))
 
         // Request OAuth scopes if specified (before sign-in)
         if (provider.scopes.isNotEmpty()) {

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.R
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.configuration.auth_provider.AuthProvider.Companion.canUpgradeAnonymous
 import com.firebase.ui.auth.util.SignInPreferenceManager
@@ -129,7 +130,7 @@ internal suspend fun FirebaseAuthUI.signInWithProvider(
     provider: AuthProvider.OAuth,
 ) {
     try {
-        updateAuthState(AuthState.Loading("Signing in with ${provider.providerName}..."))
+        updateAuthState(AuthState.Loading(context.getString(R.string.fui_loading_signing_in_with_provider, provider.providerName)))
 
         // Build OAuth provider with scopes and custom parameters
         val oauthProvider = OAuthProvider

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.FirebaseAuthUI
-import com.firebase.ui.auth.R
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.configuration.auth_provider.AuthProvider.Companion.canUpgradeAnonymous
 import com.firebase.ui.auth.util.SignInPreferenceManager
@@ -130,7 +129,7 @@ internal suspend fun FirebaseAuthUI.signInWithProvider(
     provider: AuthProvider.OAuth,
 ) {
     try {
-        updateAuthState(AuthState.Loading(context.getString(R.string.fui_loading_signing_in_with_provider, provider.providerName)))
+        updateAuthState(AuthState.Loading(config.stringProvider.loadingSigningInWithProvider(provider.providerName)))
 
         // Build OAuth provider with scopes and custom parameters
         val oauthProvider = OAuthProvider

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/PhoneAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/PhoneAuthProvider+FirebaseAuthUI.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.FirebaseAuthUI
-import com.firebase.ui.auth.R
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.util.SignInPreferenceManager
 import com.google.firebase.auth.AuthResult
@@ -107,12 +106,13 @@ internal suspend fun FirebaseAuthUI.verifyPhoneNumber(
     provider: AuthProvider.Phone,
     activity: Activity?,
     phoneNumber: String,
+    config: AuthUIConfiguration,
     multiFactorSession: MultiFactorSession? = null,
     forceResendingToken: PhoneAuthProvider.ForceResendingToken? = null,
     verifier: AuthProvider.Phone.Verifier = AuthProvider.Phone.DefaultVerifier(),
 ) {
     try {
-        updateAuthState(AuthState.Loading((activity ?: app.applicationContext).getString(R.string.fui_loading_verifying_phone_number)))
+        updateAuthState(AuthState.Loading(config.stringProvider.loadingVerifyingPhoneNumber))
         val result = provider.verifyPhoneNumberAwait(
             auth = auth,
             activity = activity,

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/PhoneAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/PhoneAuthProvider+FirebaseAuthUI.kt
@@ -207,7 +207,7 @@ internal suspend fun FirebaseAuthUI.submitVerificationCode(
     credentialProvider: AuthProvider.Phone.CredentialProvider = AuthProvider.Phone.DefaultCredentialProvider(),
 ): AuthResult? {
     try {
-        updateAuthState(AuthState.Loading(context.getString(R.string.fui_loading_submitting_verification_code)))
+        updateAuthState(AuthState.Loading(config.stringProvider.loadingSubmittingVerificationCode))
         val credential = credentialProvider.getCredential(verificationId, code)
         return signInWithPhoneAuthCredential(
             context = context,
@@ -298,7 +298,7 @@ internal suspend fun FirebaseAuthUI.signInWithPhoneAuthCredential(
     credential: PhoneAuthCredential,
 ): AuthResult? {
     try {
-        updateAuthState(AuthState.Loading(context.getString(R.string.fui_loading_signing_in_with_phone)))
+        updateAuthState(AuthState.Loading(config.stringProvider.loadingSigningInWithPhone))
         val result = signInAndLinkWithCredential(
             config = config,
             credential = credential,

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/PhoneAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/PhoneAuthProvider+FirebaseAuthUI.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.R
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.util.SignInPreferenceManager
 import com.google.firebase.auth.AuthResult
@@ -111,7 +112,7 @@ internal suspend fun FirebaseAuthUI.verifyPhoneNumber(
     verifier: AuthProvider.Phone.Verifier = AuthProvider.Phone.DefaultVerifier(),
 ) {
     try {
-        updateAuthState(AuthState.Loading("Verifying phone number..."))
+        updateAuthState(AuthState.Loading((activity ?: app.applicationContext).getString(R.string.fui_loading_verifying_phone_number)))
         val result = provider.verifyPhoneNumberAwait(
             auth = auth,
             activity = activity,
@@ -206,7 +207,7 @@ internal suspend fun FirebaseAuthUI.submitVerificationCode(
     credentialProvider: AuthProvider.Phone.CredentialProvider = AuthProvider.Phone.DefaultCredentialProvider(),
 ): AuthResult? {
     try {
-        updateAuthState(AuthState.Loading("Submitting verification code..."))
+        updateAuthState(AuthState.Loading(context.getString(R.string.fui_loading_submitting_verification_code)))
         val credential = credentialProvider.getCredential(verificationId, code)
         return signInWithPhoneAuthCredential(
             context = context,
@@ -297,7 +298,7 @@ internal suspend fun FirebaseAuthUI.signInWithPhoneAuthCredential(
     credential: PhoneAuthCredential,
 ): AuthResult? {
     try {
-        updateAuthState(AuthState.Loading("Signing in with phone..."))
+        updateAuthState(AuthState.Loading(context.getString(R.string.fui_loading_signing_in_with_phone)))
         val result = signInAndLinkWithCredential(
             config = config,
             credential = credential,

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/string_provider/AuthUIStringProvider.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/string_provider/AuthUIStringProvider.kt
@@ -49,6 +49,51 @@ interface AuthUIStringProvider {
     /** Loading text displayed during initialization or processing states */
     val initializing: String
 
+    /** Progress dialog message shown while signing in anonymously */
+    val loadingSigningInAnonymously: String
+
+    /** Progress dialog message shown while signing in with Google */
+    val loadingSigningInWithGoogle: String
+
+    /** Progress dialog message shown while signing in with Facebook */
+    val loadingSigningInWithFacebook: String
+
+    /** Progress dialog message shown while signing in with a named OAuth provider. [providerName] is the display name of the provider. */
+    fun loadingSigningInWithProvider(providerName: String): String
+
+    /** Progress dialog message shown while verifying a phone number */
+    val loadingVerifyingPhoneNumber: String
+
+    /** Progress dialog message shown while submitting an SMS verification code */
+    val loadingSubmittingVerificationCode: String
+
+    /** Progress dialog message shown while completing phone number sign-in */
+    val loadingSigningInWithPhone: String
+
+    /** Progress dialog message shown while creating a new user account */
+    val loadingCreatingUser: String
+
+    /** Progress dialog message shown while signing in with email and password */
+    val loadingSigningIn: String
+
+    /** Progress dialog message shown while linking a credential to the current account */
+    val loadingLinkingCredential: String
+
+    /** Progress dialog message shown while sending the sign-in email link */
+    val loadingSendingEmailLink: String
+
+    /** Progress dialog message shown while completing an email link sign-in */
+    val loadingSigningInWithEmailLink: String
+
+    /** Progress dialog message shown while sending the password reset email */
+    val loadingSendingPasswordResetEmail: String
+
+    /** Progress dialog message shown while signing the user out */
+    val loadingSigningOut: String
+
+    /** Progress dialog message shown while deleting the user's account */
+    val loadingDeletingAccount: String
+
     /** Text for Google Provider */
     val googleProvider: String
 

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/string_provider/DefaultAuthUIStringProvider.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/string_provider/DefaultAuthUIStringProvider.kt
@@ -38,7 +38,41 @@ class DefaultAuthUIStringProvider(
      * Common Strings
      */
     override val initializing: String
-        get() = "Initializing"
+        get() = localizedContext.getString(R.string.fui_initializing)
+
+    /**
+     * Loading State Strings
+     */
+    override val loadingSigningInAnonymously: String
+        get() = localizedContext.getString(R.string.fui_loading_signing_in_anonymously)
+    override val loadingSigningInWithGoogle: String
+        get() = localizedContext.getString(R.string.fui_loading_signing_in_with_google)
+    override val loadingSigningInWithFacebook: String
+        get() = localizedContext.getString(R.string.fui_loading_signing_in_with_facebook)
+    override fun loadingSigningInWithProvider(providerName: String): String =
+        localizedContext.getString(R.string.fui_loading_signing_in_with_provider, providerName)
+    override val loadingVerifyingPhoneNumber: String
+        get() = localizedContext.getString(R.string.fui_loading_verifying_phone_number)
+    override val loadingSubmittingVerificationCode: String
+        get() = localizedContext.getString(R.string.fui_loading_submitting_verification_code)
+    override val loadingSigningInWithPhone: String
+        get() = localizedContext.getString(R.string.fui_loading_signing_in_with_phone)
+    override val loadingCreatingUser: String
+        get() = localizedContext.getString(R.string.fui_loading_creating_user)
+    override val loadingSigningIn: String
+        get() = localizedContext.getString(R.string.fui_loading_signing_in)
+    override val loadingLinkingCredential: String
+        get() = localizedContext.getString(R.string.fui_loading_linking_credential)
+    override val loadingSendingEmailLink: String
+        get() = localizedContext.getString(R.string.fui_loading_sending_email_link)
+    override val loadingSigningInWithEmailLink: String
+        get() = localizedContext.getString(R.string.fui_loading_signing_in_with_email_link)
+    override val loadingSendingPasswordResetEmail: String
+        get() = localizedContext.getString(R.string.fui_loading_sending_password_reset)
+    override val loadingSigningOut: String
+        get() = localizedContext.getString(R.string.fui_loading_signing_out)
+    override val loadingDeletingAccount: String
+        get() = localizedContext.getString(R.string.fui_loading_deleting_account)
 
     /**
      * Auth Provider strings
@@ -278,7 +312,7 @@ class DefaultAuthUIStringProvider(
      * Multi-Factor Authentication Strings
      */
     override val enterTOTPCode: String
-        get() = "Enter TOTP Code"
+        get() = localizedContext.getString(R.string.fui_enter_totp_code)
 
     /**
      * Provider Picker Strings

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
@@ -986,7 +986,7 @@ private fun FirebaseAuthUI.rememberOnProviderSelected(
     val twitterProvider = config.providers.filterIsInstance<AuthProvider.Twitter>().firstOrNull()
     val genericOAuthProviders = config.providers.filterIsInstance<AuthProvider.GenericOAuth>()
 
-    val onSignInAnonymously = anonymousProvider?.let { rememberAnonymousSignInHandler() }
+    val onSignInAnonymously = anonymousProvider?.let { rememberAnonymousSignInHandler(config) }
     val onSignInWithGoogle = googleProvider?.let { rememberGoogleSignInHandler(context, config, it) }
     val onSignInWithFacebook = facebookProvider?.let { rememberSignInWithFacebookLauncher(context, config, it) }
     val onSignInWithApple = appleProvider?.let { rememberOAuthSignInHandler(context, activity, config, it) }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
@@ -331,6 +331,7 @@ fun EmailAuthScreen(
                 try {
                     authUI.sendPasswordResetEmail(
                         email = emailTextValue.value,
+                        config = configuration,
                         actionCodeSettings = configuration.passwordResetActionCodeSettings,
                     )
                 } catch (e: Exception) {

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreen.kt
@@ -284,6 +284,7 @@ fun PhoneAuthScreen(
                         provider = provider,
                         activity = activity,
                         phoneNumber = fullPhoneNumber,
+                        config = configuration,
                     )
                 } catch (e: Exception) {
                     // Error will be handled by authState flow
@@ -319,6 +320,7 @@ fun PhoneAuthScreen(
                             activity = activity,
                             provider = provider,
                             phoneNumber = fullPhoneNumber,
+                            config = configuration,
                             forceResendingToken = forceResendingToken.value,
                         )
                         resendTimerSeconds.intValue = provider.timeout.toInt() // Restart timer

--- a/auth/src/main/res/values/strings.xml
+++ b/auth/src/main/res/values/strings.xml
@@ -3,25 +3,25 @@
 
     <!-- Common -->
     <string name="fui_default_toolbar_title" translatable="false">@string/app_name</string>
-    <string name="fui_progress_dialog_loading" translation_description="Loading text in dialog">Loading…</string>
+    <string name="fui_progress_dialog_loading" translation_description="Loading text in dialog">Loading...</string>
     <string name="fui_initializing" translation_description="Text shown while the auth UI is initializing">Initializing</string>
 
     <!-- Loading state messages shown in the progress dialog during auth operations -->
-    <string name="fui_loading_signing_in_anonymously" translation_description="Progress message while signing in as a guest">Signing in as guest…</string>
-    <string name="fui_loading_signing_in_with_google" translation_description="Progress message while signing in with Google">Signing in with Google…</string>
-    <string name="fui_loading_signing_in_with_facebook" translation_description="Progress message while signing in with Facebook">Signing in with Facebook…</string>
-    <string name="fui_loading_signing_in_with_provider" translation_description="Progress message while signing in with a named provider. %1$s is the provider name.">Signing in with <xliff:g example="Twitter" id="provider_name">%1$s</xliff:g>…</string>
-    <string name="fui_loading_verifying_phone_number" translation_description="Progress message while verifying the user\'s phone number">Verifying phone number…</string>
-    <string name="fui_loading_submitting_verification_code" translation_description="Progress message while submitting the SMS verification code">Submitting verification code…</string>
-    <string name="fui_loading_signing_in_with_phone" translation_description="Progress message while completing phone number sign-in">Signing in with phone…</string>
-    <string name="fui_loading_creating_user" translation_description="Progress message while creating a new user account">Creating account…</string>
-    <string name="fui_loading_signing_in" translation_description="Progress message while signing in with email and password">Signing in…</string>
-    <string name="fui_loading_linking_credential" translation_description="Progress message while linking a credential to the current account">Signing in…</string>
-    <string name="fui_loading_sending_email_link" translation_description="Progress message while sending the sign-in email link">Sending sign-in link…</string>
-    <string name="fui_loading_signing_in_with_email_link" translation_description="Progress message while completing email link sign-in">Signing in with email link…</string>
-    <string name="fui_loading_sending_password_reset" translation_description="Progress message while sending the password reset email">Sending password reset email…</string>
-    <string name="fui_loading_signing_out" translation_description="Progress message while signing the user out">Signing out…</string>
-    <string name="fui_loading_deleting_account" translation_description="Progress message while deleting the user\'s account">Deleting account…</string>
+    <string name="fui_loading_signing_in_anonymously" translation_description="Progress message while signing in as a guest">Signing in as guest...</string>
+    <string name="fui_loading_signing_in_with_google" translation_description="Progress message while signing in with Google">Signing in with Google...</string>
+    <string name="fui_loading_signing_in_with_facebook" translation_description="Progress message while signing in with Facebook">Signing in with Facebook...</string>
+    <string name="fui_loading_signing_in_with_provider" translation_description="Progress message while signing in with a named provider. %1$s is the provider name.">Signing in with <xliff:g example="Twitter" id="provider_name">%1$s</xliff:g>...</string>
+    <string name="fui_loading_verifying_phone_number" translation_description="Progress message while verifying the user\'s phone number">Verifying phone number...</string>
+    <string name="fui_loading_submitting_verification_code" translation_description="Progress message while submitting the SMS verification code">Submitting verification code...</string>
+    <string name="fui_loading_signing_in_with_phone" translation_description="Progress message while completing phone number sign-in">Signing in with phone...</string>
+    <string name="fui_loading_creating_user" translation_description="Progress message while creating a new user account">Creating account...</string>
+    <string name="fui_loading_signing_in" translation_description="Progress message while signing in with email and password">Signing in...</string>
+    <string name="fui_loading_linking_credential" translation_description="Progress message while linking a credential to the current account">Signing in...</string>
+    <string name="fui_loading_sending_email_link" translation_description="Progress message while sending the sign-in email link">Sending sign-in link...</string>
+    <string name="fui_loading_signing_in_with_email_link" translation_description="Progress message while completing email link sign-in">Signing in with email link...</string>
+    <string name="fui_loading_sending_password_reset" translation_description="Progress message while sending the password reset email">Sending password reset email...</string>
+    <string name="fui_loading_signing_out" translation_description="Progress message while signing the user out">Signing out...</string>
+    <string name="fui_loading_deleting_account" translation_description="Progress message while deleting the user\'s account">Deleting account...</string>
     <string name="fui_sign_in_default" translation_description="Button text to sign in">Sign in</string>
     <string name="fui_continue" translation_description="Button text to continue">Continue</string>
     <string name="fui_tos_and_pp" translation_description="Global ToS and privacy policy message">By continuing, you are indicating that you accept our <xliff:g example="https://google.com/terms" id="tos" translation_description="Terms of service text">%1$s</xliff:g> and <xliff:g example="https://google.com/privacy" id="pp" translation_description="Privacy policy text">%2$s</xliff:g>.</string>
@@ -131,13 +131,13 @@
     <string name="fui_invalid_email_address" translation_description="Inline error for invalid email address">That email address isn\'t correct</string>
     <string name="fui_missing_email_address" translation_description="Inline error for empty email address in input field">Enter your email address to continue</string>
     <string name="fui_missing_first_and_last_name" translation_description="Inline error for empty email address in input field. [CHAR_LIMIT=60]">Please enter a first and last name.</string>
-    <string name="fui_progress_dialog_checking_accounts" translation_description="Progress dialog text while checking for existing accounts">Checking for existing accounts…</string>
+    <string name="fui_progress_dialog_checking_accounts" translation_description="Progress dialog text while checking for existing accounts">Checking for existing accounts...</string>
 
     <!-- Email sign up -->
     <string name="fui_title_register_email" translation_description="Title for signup form">Sign up</string>
     <string name="fui_name_hint" translation_description="Hint for last name input field">First &amp; last name</string>
     <string name="fui_button_text_save" translation_description="Button text to save input form">Save</string>
-    <string name="fui_progress_dialog_signing_up" translation_description="Dialog text while waiting for server's signup response">Signing up…</string>
+    <string name="fui_progress_dialog_signing_up" translation_description="Dialog text while waiting for server's signup response">Signing up...</string>
     <plurals name="fui_error_weak_password" translation_description="Inline error for weak password">
         <item quantity="one" translation_description="Inline error for weak password">Password not strong enough. Use at least %1$d character and a mix of letters and numbers</item>
         <item quantity="other" translation_description="Inline error for weak password">Password not strong enough. Use at least %1$d characters and a mix of letters and numbers</item>
@@ -166,7 +166,7 @@
         You\'ve already used <xliff:g example="jane.doe@example.com" id="email_addr" translation_description="">%1$s</xliff:g>.
         You can connect your %2$s account with %1$s by signing in with email link below.\n\nFor this flow to successfully connect your %2$s account with this email, you have to open the link on the same device or browser.
     </string>
-    <string name="fui_progress_dialog_signing_in" translation_description="Progress dialog text">Signing in…</string>
+    <string name="fui_progress_dialog_signing_in" translation_description="Progress dialog text">Signing in...</string>
     <string name="fui_trouble_signing_in" translation_description="Link leading to forgot password flow">Trouble signing in?</string>
 
     <!-- Password recovery -->
@@ -176,7 +176,7 @@
         reset your password.</string>
     <string name="fui_button_text_send" translation_description="Button text to send recovery email">Send</string>
     <string name="fui_confirm_recovery_body" translation_description="Alert dialog displayed after password recovery email is sent">Follow the instructions sent to %1$s to recover your password.</string>
-    <string name="fui_progress_dialog_sending" translation_description="Progress dialog while password recovery email or email link is being sent">Sending…</string>
+    <string name="fui_progress_dialog_sending" translation_description="Progress dialog while password recovery email or email link is being sent">Sending...</string>
     <string name="fui_error_email_does_not_exist" translation_description="Inline error when user attempt signin with invalid account">That email address doesn\'t match an existing account</string>
 
     <!-- Other error messages -->
@@ -222,7 +222,7 @@
     <string name="fui_enter_confirmation_code" translation_description="Phone number verification code entry form title">Enter the 6-digit code we sent to</string>
     <string name="fui_resend_code_in" translation_description="Countdown timer text that the user needs to wait for before attempting to resend verification sms">Resend code in %1$s</string>
     <string name="fui_verify_your_phone_title" translation_description="Button text to complete phone number verification">Verify your phone number</string>
-    <string name="fui_verifying" translation_description="Progress dialog text while phone number is being verified">Verifying…</string>
+    <string name="fui_verifying" translation_description="Progress dialog text while phone number is being verified">Verifying...</string>
     <string name="fui_incorrect_code_dialog_body" translation_description="Inline error when incorrect sms verification code is being used to verify">Wrong code. Try again.</string>
     <string name="fui_error_too_many_attempts" translation_description="Error message when the phone number has been used too many times">This phone number has been used too many times</string>
     <string name="fui_error_quota_exceeded" translation_description="Error message when the Firebase project's quota has been exceeded.">There was a problem verifying your phone number</string>

--- a/auth/src/main/res/values/strings.xml
+++ b/auth/src/main/res/values/strings.xml
@@ -4,6 +4,24 @@
     <!-- Common -->
     <string name="fui_default_toolbar_title" translatable="false">@string/app_name</string>
     <string name="fui_progress_dialog_loading" translation_description="Loading text in dialog">Loading…</string>
+    <string name="fui_initializing" translation_description="Text shown while the auth UI is initializing">Initializing</string>
+
+    <!-- Loading state messages shown in the progress dialog during auth operations -->
+    <string name="fui_loading_signing_in_anonymously" translation_description="Progress message while signing in as a guest">Signing in as guest…</string>
+    <string name="fui_loading_signing_in_with_google" translation_description="Progress message while signing in with Google">Signing in with Google…</string>
+    <string name="fui_loading_signing_in_with_facebook" translation_description="Progress message while signing in with Facebook">Signing in with Facebook…</string>
+    <string name="fui_loading_signing_in_with_provider" translation_description="Progress message while signing in with a named provider. %1$s is the provider name.">Signing in with <xliff:g example="Twitter" id="provider_name">%1$s</xliff:g>…</string>
+    <string name="fui_loading_verifying_phone_number" translation_description="Progress message while verifying the user\'s phone number">Verifying phone number…</string>
+    <string name="fui_loading_submitting_verification_code" translation_description="Progress message while submitting the SMS verification code">Submitting verification code…</string>
+    <string name="fui_loading_signing_in_with_phone" translation_description="Progress message while completing phone number sign-in">Signing in with phone…</string>
+    <string name="fui_loading_creating_user" translation_description="Progress message while creating a new user account">Creating account…</string>
+    <string name="fui_loading_signing_in" translation_description="Progress message while signing in with email and password">Signing in…</string>
+    <string name="fui_loading_linking_credential" translation_description="Progress message while linking a credential to the current account">Signing in…</string>
+    <string name="fui_loading_sending_email_link" translation_description="Progress message while sending the sign-in email link">Sending sign-in link…</string>
+    <string name="fui_loading_signing_in_with_email_link" translation_description="Progress message while completing email link sign-in">Signing in with email link…</string>
+    <string name="fui_loading_sending_password_reset" translation_description="Progress message while sending the password reset email">Sending password reset email…</string>
+    <string name="fui_loading_signing_out" translation_description="Progress message while signing the user out">Signing out…</string>
+    <string name="fui_loading_deleting_account" translation_description="Progress message while deleting the user\'s account">Deleting account…</string>
     <string name="fui_sign_in_default" translation_description="Button text to sign in">Sign in</string>
     <string name="fui_continue" translation_description="Button text to continue">Continue</string>
     <string name="fui_tos_and_pp" translation_description="Global ToS and privacy policy message">By continuing, you are indicating that you accept our <xliff:g example="https://google.com/terms" id="tos" translation_description="Terms of service text">%1$s</xliff:g> and <xliff:g example="https://google.com/privacy" id="pp" translation_description="Privacy policy text">%2$s</xliff:g>.</string>
@@ -69,6 +87,7 @@
     <string name="fui_mfa_label_totp_authentication" translation_description="Label for the authenticator app MFA factor.">Authenticator app</string>
     <string name="fui_mfa_label_unknown_method" translation_description="Label for an unknown MFA factor.">Unknown method</string>
     <string name="fui_mfa_enrolled_on" translation_description="Label indicating the enrollment date of an MFA factor.">Enrolled on %1$s</string>
+    <string name="fui_enter_totp_code" translation_description="Prompt asking the user to enter a TOTP verification code">Enter TOTP code</string>
     <string name="fui_mfa_setup_authenticator_description" translation_description="Description displayed during authenticator app setup.">Scan the QR code or enter the secret key in your authenticator app</string>
     <string name="fui_mfa_choose_method_instruction" translation_description="Instruction to choose an MFA verification method.">Choose a verification method</string>
     <string name="fui_mfa_enrollment_instruction" translation_description="Instruction to enroll in MFA.">Add an extra layer of security</string>

--- a/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthUITest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthUITest.kt
@@ -366,6 +366,7 @@ class FirebaseAuthUITest {
     }
 
     @Test
+    @Config(qualifiers = "es")
     fun `delete() emits Loading state with translated message`() = runTest {
         val mockAuth = mock(FirebaseAuth::class.java)
         val mockUser = mock(FirebaseUser::class.java)

--- a/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthUITest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthUITest.kt
@@ -18,6 +18,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
+import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
 import com.firebase.ui.auth.configuration.authUIConfiguration
 import com.google.android.gms.tasks.TaskCompletionSource
@@ -30,6 +31,8 @@ import com.google.firebase.auth.FirebaseAuthRecentLoginRequiredException
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.UserInfo
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
@@ -360,6 +363,27 @@ class FirebaseAuthUITest {
 
         // Verify signOut was called on Firebase Auth
         verify(mockAuth).signOut()
+    }
+
+    @Test
+    fun `delete() emits Loading state with translated message`() = runTest {
+        val mockAuth = mock(FirebaseAuth::class.java)
+        val mockUser = mock(FirebaseUser::class.java)
+        `when`(mockAuth.currentUser).thenReturn(mockUser)
+        val taskCompletionSource = TaskCompletionSource<Void>()
+        `when`(mockUser.delete()).thenReturn(taskCompletionSource.task)
+
+        val instance = FirebaseAuthUI.create(defaultApp, mockAuth)
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        // Queue delete first; first{} suspends and lets the scheduler run it
+        val job = launch { runCatching { instance.delete(context) } }
+        val loadingState = instance.authStateFlow().first { it is AuthState.Loading }
+
+        assertThat((loadingState as AuthState.Loading).message)
+            .isEqualTo("test_loading_deleting_account")
+
+        job.cancel()
     }
 
     @Test

--- a/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProviderFirebaseAuthUITest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProviderFirebaseAuthUITest.kt
@@ -19,6 +19,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.configuration.authUIConfiguration
 import com.google.android.gms.tasks.TaskCompletionSource
 import com.google.common.truth.Truth.assertThat
@@ -58,6 +59,7 @@ class AnonymousAuthProviderFirebaseAuthUITest {
 
     private lateinit var firebaseApp: FirebaseApp
     private lateinit var applicationContext: Context
+    private lateinit var config: AuthUIConfiguration
 
     @Before
     fun setUp() {
@@ -79,6 +81,14 @@ class AnonymousAuthProviderFirebaseAuthUITest {
                 .setProjectId("fake-project-id")
                 .build()
         )
+
+        config = authUIConfiguration {
+            context = applicationContext
+            providers {
+                provider(AuthProvider.Anonymous)
+                provider(AuthProvider.Email(emailLinkActionCodeSettings = null, passwordValidationRules = emptyList()))
+            }
+        }
     }
 
     @After
@@ -108,7 +118,7 @@ class AnonymousAuthProviderFirebaseAuthUITest {
 
         val instance = FirebaseAuthUI.create(firebaseApp, mockFirebaseAuth)
 
-        instance.signInAnonymously()
+        instance.signInAnonymously(config)
 
         verify(mockFirebaseAuth).signInAnonymously()
 
@@ -124,7 +134,7 @@ class AnonymousAuthProviderFirebaseAuthUITest {
         val instance = FirebaseAuthUI.create(firebaseApp, mockFirebaseAuth)
 
         // Queue signInAnonymously first; first{} suspends and lets the scheduler run it
-        val job = launch { runCatching { instance.signInAnonymously() } }
+        val job = launch { runCatching { instance.signInAnonymously(config) } }
         val loadingState = instance.authStateFlow().first { it is AuthState.Loading }
 
         assertThat((loadingState as AuthState.Loading).message)
@@ -144,7 +154,7 @@ class AnonymousAuthProviderFirebaseAuthUITest {
         val instance = FirebaseAuthUI.create(firebaseApp, mockFirebaseAuth)
 
         try {
-            instance.signInAnonymously()
+            instance.signInAnonymously(config)
             assertThat(false).isTrue() // Should not reach here
         } catch (e: AuthException.NetworkException) {
             assertThat(e.cause).isEqualTo(networkException)
@@ -167,7 +177,7 @@ class AnonymousAuthProviderFirebaseAuthUITest {
         val instance = FirebaseAuthUI.create(firebaseApp, mockFirebaseAuth)
 
         try {
-            instance.signInAnonymously()
+            instance.signInAnonymously(config)
             assertThat(false).isTrue() // Should not reach here
         } catch (e: AuthException.AuthCancelledException) {
             assertThat(e.message).contains("cancelled")
@@ -191,7 +201,7 @@ class AnonymousAuthProviderFirebaseAuthUITest {
         val instance = FirebaseAuthUI.create(firebaseApp, mockFirebaseAuth)
 
         try {
-            instance.signInAnonymously()
+            instance.signInAnonymously(config)
             assertThat(false).isTrue() // Should not reach here
         } catch (e: AuthException.UnknownException) {
             assertThat(e.cause).isEqualTo(genericException)

--- a/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProviderFirebaseAuthUITest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProviderFirebaseAuthUITest.kt
@@ -127,6 +127,7 @@ class AnonymousAuthProviderFirebaseAuthUITest {
     }
 
     @Test
+    @Config(qualifiers = "es")
     fun `signInAnonymously - emits Loading state with translated message`() = runTest {
         val taskCompletionSource = TaskCompletionSource<AuthResult>()
         `when`(mockFirebaseAuth.signInAnonymously()).thenReturn(taskCompletionSource.task)

--- a/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProviderFirebaseAuthUITest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProviderFirebaseAuthUITest.kt
@@ -33,6 +33,7 @@ import com.google.firebase.auth.FirebaseAuthUserCollisionException
 import com.google.firebase.auth.FirebaseUser
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
@@ -113,6 +114,23 @@ class AnonymousAuthProviderFirebaseAuthUITest {
 
         val finalState = instance.authStateFlow().first { it is AuthState.Success }
         assertThat(finalState).isEqualTo(AuthState.Success(result = mockAuthResult, user = mockUser, isNewUser = true))
+    }
+
+    @Test
+    fun `signInAnonymously - emits Loading state with translated message`() = runTest {
+        val taskCompletionSource = TaskCompletionSource<AuthResult>()
+        `when`(mockFirebaseAuth.signInAnonymously()).thenReturn(taskCompletionSource.task)
+
+        val instance = FirebaseAuthUI.create(firebaseApp, mockFirebaseAuth)
+
+        // Queue signInAnonymously first; first{} suspends and lets the scheduler run it
+        val job = launch { runCatching { instance.signInAnonymously() } }
+        val loadingState = instance.authStateFlow().first { it is AuthState.Loading }
+
+        assertThat((loadingState as AuthState.Loading).message)
+            .isEqualTo("test_loading_signing_in_anonymously")
+
+        job.cancel()
     }
 
     @Test

--- a/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/EmailAuthProviderFirebaseAuthUITest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/EmailAuthProviderFirebaseAuthUITest.kt
@@ -20,6 +20,7 @@ import com.firebase.ui.auth.R
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.configuration.PasswordRule
 import com.firebase.ui.auth.configuration.authUIConfiguration
 import com.firebase.ui.auth.util.EmailLinkPersistenceManager
@@ -82,6 +83,7 @@ class EmailAuthProviderFirebaseAuthUITest {
 
     private lateinit var firebaseApp: FirebaseApp
     private lateinit var applicationContext: Context
+    private lateinit var emailConfig: AuthUIConfiguration
 
     @Before
     fun setUp() {
@@ -103,6 +105,13 @@ class EmailAuthProviderFirebaseAuthUITest {
                 .setProjectId("fake-project-id")
                 .build()
         )
+
+        emailConfig = authUIConfiguration {
+            context = applicationContext
+            providers {
+                provider(AuthProvider.Email(emailLinkActionCodeSettings = null, passwordValidationRules = emptyList()))
+            }
+        }
     }
 
     @After
@@ -817,7 +826,7 @@ class EmailAuthProviderFirebaseAuthUITest {
 
         val instance = FirebaseAuthUI.create(firebaseApp, mockFirebaseAuth)
 
-        instance.sendPasswordResetEmail("test@example.com")
+        instance.sendPasswordResetEmail("test@example.com", emailConfig)
 
         verify(mockFirebaseAuth).sendPasswordResetEmail(
             ArgumentMatchers.eq("test@example.com"),
@@ -841,7 +850,7 @@ class EmailAuthProviderFirebaseAuthUITest {
 
         val instance = FirebaseAuthUI.create(firebaseApp, mockFirebaseAuth)
 
-        instance.sendPasswordResetEmail("test@example.com", actionCodeSettings)
+        instance.sendPasswordResetEmail("test@example.com", emailConfig, actionCodeSettings)
 
         verify(mockFirebaseAuth).sendPasswordResetEmail("test@example.com", actionCodeSettings)
 
@@ -865,7 +874,7 @@ class EmailAuthProviderFirebaseAuthUITest {
         val instance = FirebaseAuthUI.create(firebaseApp, mockFirebaseAuth)
 
         try {
-            instance.sendPasswordResetEmail("test@example.com")
+            instance.sendPasswordResetEmail("test@example.com", emailConfig)
             assertThat(false).isTrue() // Should not reach here
         } catch (e: AuthException.UserNotFoundException) {
             assertThat(e.cause).isEqualTo(userNotFoundException)
@@ -888,7 +897,7 @@ class EmailAuthProviderFirebaseAuthUITest {
         val instance = FirebaseAuthUI.create(firebaseApp, mockFirebaseAuth)
 
         try {
-            instance.sendPasswordResetEmail("test@example.com")
+            instance.sendPasswordResetEmail("test@example.com", emailConfig)
             assertThat(false).isTrue() // Should not reach here
         } catch (e: AuthException.InvalidCredentialsException) {
             assertThat(e.cause).isEqualTo(invalidEmailException)
@@ -908,7 +917,7 @@ class EmailAuthProviderFirebaseAuthUITest {
         val instance = FirebaseAuthUI.create(firebaseApp, mockFirebaseAuth)
 
         try {
-            instance.sendPasswordResetEmail("test@example.com")
+            instance.sendPasswordResetEmail("test@example.com", emailConfig)
             assertThat(false).isTrue() // Should not reach here
         } catch (e: AuthException.AuthCancelledException) {
             assertThat(e.message).contains("cancelled")

--- a/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/PhoneAuthProviderFirebaseAuthUITest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/PhoneAuthProviderFirebaseAuthUITest.kt
@@ -18,6 +18,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.configuration.authUIConfiguration
 import com.google.android.gms.tasks.TaskCompletionSource
 import com.google.common.truth.Truth.assertThat
@@ -71,6 +72,7 @@ class PhoneAuthProviderFirebaseAuthUITest {
 
     private lateinit var firebaseApp: FirebaseApp
     private lateinit var applicationContext: Context
+    private lateinit var phoneConfig: AuthUIConfiguration
 
     @Before
     fun setUp() {
@@ -92,6 +94,13 @@ class PhoneAuthProviderFirebaseAuthUITest {
                 .setProjectId("fake-project-id")
                 .build()
         )
+
+        phoneConfig = authUIConfiguration {
+            context = applicationContext
+            providers {
+                provider(AuthProvider.Phone(defaultNumber = null, defaultCountryCode = null, allowedCountries = null))
+            }
+        }
     }
 
     @After
@@ -136,6 +145,7 @@ class PhoneAuthProviderFirebaseAuthUITest {
             provider = phoneProvider,
             activity = null,
             phoneNumber = "+1234567890",
+            config = phoneConfig,
             verifier = mockPhoneAuthVerifier
         )
 
@@ -179,6 +189,7 @@ class PhoneAuthProviderFirebaseAuthUITest {
                 provider = phoneProvider,
                 activity = null,
                 phoneNumber = "+1234567890",
+                config = phoneConfig,
                 verifier = mockPhoneAuthVerifier
             )
 
@@ -224,6 +235,7 @@ class PhoneAuthProviderFirebaseAuthUITest {
             provider = phoneProvider,
             activity = null,
             phoneNumber = "+1234567890",
+            config = phoneConfig,
             forceResendingToken = mockToken,
             verifier = mockPhoneAuthVerifier
         )
@@ -268,6 +280,7 @@ class PhoneAuthProviderFirebaseAuthUITest {
             provider = phoneProvider,
             activity = null,
             phoneNumber = "+1234567890",
+            config = phoneConfig,
             verifier = mockPhoneAuthVerifier
         )
 

--- a/auth/src/test/res/values-es/strings.xml
+++ b/auth/src/test/res/values-es/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Test overrides for loading state strings. These distinct values ensure tests verify
-         that code reads from string resources rather than using hardcoded English strings. -->
     <string name="fui_loading_signing_in_anonymously" translatable="false">test_loading_signing_in_anonymously</string>
     <string name="fui_loading_deleting_account" translatable="false">test_loading_deleting_account</string>
 </resources>

--- a/auth/src/test/res/values/strings.xml
+++ b/auth/src/test/res/values/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Test overrides for loading state strings. These distinct values ensure tests verify
+         that code reads from string resources rather than using hardcoded English strings. -->
+    <string name="fui_loading_signing_in_anonymously" translatable="false">test_loading_signing_in_anonymously</string>
+    <string name="fui_loading_deleting_account" translatable="false">test_loading_deleting_account</string>
+</resources>


### PR DESCRIPTION
Closes #2338 .

All `AuthState.Loading` messages emitted during auth operations (sign-in, sign-out, delete, phone, email, etc.) were hardcoded English strings. This replaces every instance with a string resource lookup via `Context.getString(R.string.fui_loading_*)`, making them overridable and translatable.

## Usage
You can either override using `strings.xml` or through a custom [AuthUIStringProvider](https://github.com/firebase/FirebaseUI-Android/blob/ac26fac620c7471921a213c1c12762d52aa8bd85/auth/src/main/java/com/firebase/ui/auth/configuration/string_provider/AuthUIStringProvider.kt#L48), see below examples:

**Using strings.xml:**
```xml
<?xml version="1.0" encoding="utf-8"?>
<resources>
    <string name="fui_loading_signing_in_anonymously" translatable="false">some random string here</string>
    <string name="fui_loading_deleting_account" translatable="false">some random string here</string>
</resources>
```

**Using AuthUIStringProvider:**

```kotlin
class CustomAuthUIStringProvider(
    private val defaultProvider: AuthUIStringProvider
) : AuthUIStringProvider by defaultProvider {
    override val loadingSigningInAnonymously: String
        get() = "Overriding signing in anonymously loading message..."
}

val customStringProvider = CustomAuthUIStringProvider(DefaultAuthUIStringProvider(applicationContext))

val configuration = authUIConfiguration {
    // ... (existing params)
    stringProvider = customStringProvider
}
```

## Preview
[override-loading-state-preview.webm](https://github.com/user-attachments/assets/e8d52304-f58c-4150-883f-4a3bf31f12b0)