### PR TITLE
refactor(auth)!: hide sign-up button instead of showing disabled state with tooltip. BREAKING - Removed unused `newAccountsDisabledTooltip` from public interface `AuthUIStringProvider`

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/configuration/string_provider/AuthUIStringProvider.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/string_provider/AuthUIStringProvider.kt
@@ -582,9 +582,6 @@ interface AuthUIStringProvider {
     /** ToS and Privacy Policy combined message with placeholders for links */
     fun tosAndPrivacyPolicy(termsOfServiceLabel: String, privacyPolicyLabel: String): String
 
-    /** Tooltip message shown when new account sign-up is disabled */
-    val newAccountsDisabledTooltip: String
-
     /** Tooltip message shown when MFA is disabled */
     val mfaDisabledTooltip: String
 

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/string_provider/DefaultAuthUIStringProvider.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/string_provider/DefaultAuthUIStringProvider.kt
@@ -523,9 +523,6 @@ class DefaultAuthUIStringProvider(
     override fun tosAndPrivacyPolicy(termsOfServiceLabel: String, privacyPolicyLabel: String): String =
         localizedContext.getString(R.string.fui_tos_and_pp, termsOfServiceLabel, privacyPolicyLabel)
 
-    override val newAccountsDisabledTooltip: String
-        get() = localizedContext.getString(R.string.fui_new_accounts_disabled_tooltip)
-
     override val mfaDisabledTooltip: String
         get() = localizedContext.getString(R.string.fui_mfa_disabled_tooltip)
 

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/SignInUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/SignInUI.kt
@@ -36,15 +36,10 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TooltipAnchorPosition
-import androidx.compose.material3.TooltipBox
-import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -228,29 +223,17 @@ fun SignInUI(
                 modifier = Modifier
                     .align(Alignment.End),
             ) {
-                TooltipBox(
-                    positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
-                        TooltipAnchorPosition.Above
-                    ),
-                    tooltip = {
-                        PlainTooltip {
-                            Text(stringProvider.newAccountsDisabledTooltip)
-                        }
-                    },
-                    state = rememberTooltipState(
-                        initialIsVisible = !provider.isNewAccountsAllowed
-                    )
-                ) {
+                if (provider.isNewAccountsAllowed) {
                     Button(
                         onClick = {
                             onGoToSignUp()
                         },
-                        enabled = provider.isNewAccountsAllowed && !isLoading,
+                        enabled = !isLoading,
                     ) {
                         Text(stringProvider.signupPageTitle.uppercase())
                     }
+                    Spacer(modifier = Modifier.width(16.dp))
                 }
-                Spacer(modifier = Modifier.width(16.dp))
                 Button(
                     onClick = {
                         onSignInClick()

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/SignUpUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/SignUpUI.kt
@@ -95,7 +95,7 @@ fun SignUpUI(
     val isFormValid = remember(displayName, email, password, confirmPassword) {
         derivedStateOf {
             listOf(
-                displayNameValidator.validate(displayName),
+                !provider.isDisplayNameRequired || displayNameValidator.validate(displayName),
                 emailValidator.validate(email),
                 passwordValidator.validate(password),
                 confirmPasswordValidator.validate(confirmPassword)

--- a/auth/src/main/res/values-ar/strings.xml
+++ b/auth/src/main/res/values-ar/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">أرسلنا بريدًا للتحقق إلى %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">المصادقة متعددة العوامل معطلة حاليًا</string>
 </resources>

--- a/auth/src/main/res/values-b+es+419/strings.xml
+++ b/auth/src/main/res/values-b+es+419/strings.xml
@@ -196,6 +196,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Multi-factor authentication is currently disabled</string>
 </resources>

--- a/auth/src/main/res/values-bg/strings.xml
+++ b/auth/src/main/res/values-bg/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">Изпратихме имейл за потвърждение до %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Многофакторната автентификация в момента е деактивирана</string>
 </resources>

--- a/auth/src/main/res/values-bn/strings.xml
+++ b/auth/src/main/res/values-bn/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">আমরা %1$s-এ একটি যাচাইকরণ ইমেল পাঠিয়েছি</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">মাল্টি-ফ্যাক্টর প্রমাণীকরণ বর্তমানে নিষ্ক্রিয়</string>
 </resources>

--- a/auth/src/main/res/values-ca/strings.xml
+++ b/auth/src/main/res/values-ca/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">Hem enviat un correu de verificació a %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">L\'autenticació multifactor està desactivada actualment</string>
 </resources>

--- a/auth/src/main/res/values-cs/strings.xml
+++ b/auth/src/main/res/values-cs/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">Odeslali jsme ověřovací e-mail na %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Vícefaktorové ověřování je aktuálně zakázáno</string>
 </resources>

--- a/auth/src/main/res/values-da/strings.xml
+++ b/auth/src/main/res/values-da/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">Vi har sendt en bekræftelsesemail til %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Multifaktorgodkendelse er i øjeblikket deaktiveret</string>
 </resources>

--- a/auth/src/main/res/values-de-rAT/strings.xml
+++ b/auth/src/main/res/values-de-rAT/strings.xml
@@ -196,6 +196,5 @@
     <string name="fui_reauthenticate_action">Erneut authentifizieren</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Die Multi-Faktor-Authentifizierung ist derzeit deaktiviert</string>
 </resources>

--- a/auth/src/main/res/values-de-rCH/strings.xml
+++ b/auth/src/main/res/values-de-rCH/strings.xml
@@ -197,6 +197,5 @@
     <string name="fui_reauthenticate_action">Erneut authentifizieren</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Die Multi-Faktor-Authentifizierung ist derzeit deaktiviert</string>
 </resources>

--- a/auth/src/main/res/values-de/strings.xml
+++ b/auth/src/main/res/values-de/strings.xml
@@ -196,6 +196,5 @@
     <string name="fui_reauthenticate_action">Erneut authentifizieren</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Die Multi-Faktor-Authentifizierung ist derzeit deaktiviert</string>
 </resources>

--- a/auth/src/main/res/values-el/strings.xml
+++ b/auth/src/main/res/values-el/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">Στείλαμε email επαλήθευσης στο %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Ο έλεγχος ταυτότητας πολλαπλών παραγόντων είναι απενεργοποιημένος προς το παρόν</string>
 </resources>

--- a/auth/src/main/res/values-en-rAU/strings.xml
+++ b/auth/src/main/res/values-en-rAU/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">We sent a verification email to %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Multi-factor authentication is currently disabled</string>
 </resources>

--- a/auth/src/main/res/values-en-rCA/strings.xml
+++ b/auth/src/main/res/values-en-rCA/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">We sent a verification email to %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Multi-factor authentication is currently disabled</string>
 </resources>

--- a/auth/src/main/res/values-en-rGB/strings.xml
+++ b/auth/src/main/res/values-en-rGB/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">We sent a verification email to %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Multi-factor authentication is currently disabled</string>
 </resources>

--- a/auth/src/main/res/values-en-rIE/strings.xml
+++ b/auth/src/main/res/values-en-rIE/strings.xml
@@ -171,6 +171,5 @@
     <string name="fui_verify_email_instruction">We sent a verification email to %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Multi-factor authentication is currently disabled</string>
 </resources>

--- a/auth/src/main/res/values-en-rIN/strings.xml
+++ b/auth/src/main/res/values-en-rIN/strings.xml
@@ -171,6 +171,5 @@
     <string name="fui_verify_email_instruction">We sent a verification email to %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Multi-factor authentication is currently disabled</string>
 </resources>

--- a/auth/src/main/res/values-en-rSG/strings.xml
+++ b/auth/src/main/res/values-en-rSG/strings.xml
@@ -171,6 +171,5 @@
     <string name="fui_verify_email_instruction">We sent a verification email to %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Multi-factor authentication is currently disabled</string>
 </resources>

--- a/auth/src/main/res/values-en-rZA/strings.xml
+++ b/auth/src/main/res/values-en-rZA/strings.xml
@@ -171,6 +171,5 @@
     <string name="fui_verify_email_instruction">We sent a verification email to %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Multi-factor authentication is currently disabled</string>
 </resources>

--- a/auth/src/main/res/values-es-rAR/strings.xml
+++ b/auth/src/main/res/values-es-rAR/strings.xml
@@ -189,6 +189,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-es-rBO/strings.xml
+++ b/auth/src/main/res/values-es-rBO/strings.xml
@@ -189,6 +189,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-es-rCL/strings.xml
+++ b/auth/src/main/res/values-es-rCL/strings.xml
@@ -189,6 +189,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-es-rCO/strings.xml
+++ b/auth/src/main/res/values-es-rCO/strings.xml
@@ -189,6 +189,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-es-rCR/strings.xml
+++ b/auth/src/main/res/values-es-rCR/strings.xml
@@ -189,6 +189,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-es-rDO/strings.xml
+++ b/auth/src/main/res/values-es-rDO/strings.xml
@@ -189,6 +189,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-es-rEC/strings.xml
+++ b/auth/src/main/res/values-es-rEC/strings.xml
@@ -189,6 +189,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-es-rGT/strings.xml
+++ b/auth/src/main/res/values-es-rGT/strings.xml
@@ -189,6 +189,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-es-rHN/strings.xml
+++ b/auth/src/main/res/values-es-rHN/strings.xml
@@ -189,6 +189,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-es-rMX/strings.xml
+++ b/auth/src/main/res/values-es-rMX/strings.xml
@@ -189,6 +189,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-es-rNI/strings.xml
+++ b/auth/src/main/res/values-es-rNI/strings.xml
@@ -189,6 +189,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-es-rPA/strings.xml
+++ b/auth/src/main/res/values-es-rPA/strings.xml
@@ -189,6 +189,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-es-rPE/strings.xml
+++ b/auth/src/main/res/values-es-rPE/strings.xml
@@ -189,6 +189,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-es-rPR/strings.xml
+++ b/auth/src/main/res/values-es-rPR/strings.xml
@@ -189,6 +189,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-es-rPY/strings.xml
+++ b/auth/src/main/res/values-es-rPY/strings.xml
@@ -189,6 +189,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-es-rSV/strings.xml
+++ b/auth/src/main/res/values-es-rSV/strings.xml
@@ -189,6 +189,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-es-rUS/strings.xml
+++ b/auth/src/main/res/values-es-rUS/strings.xml
@@ -189,6 +189,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-es-rUY/strings.xml
+++ b/auth/src/main/res/values-es-rUY/strings.xml
@@ -189,6 +189,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-es-rVE/strings.xml
+++ b/auth/src/main/res/values-es-rVE/strings.xml
@@ -189,6 +189,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-es/strings.xml
+++ b/auth/src/main/res/values-es/strings.xml
@@ -196,6 +196,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">La autenticación multifactor está actualmente desactivada</string>
 </resources>

--- a/auth/src/main/res/values-fa/strings.xml
+++ b/auth/src/main/res/values-fa/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">ایمیل تأیید به %1$s ارسال کردیم</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">احراز هویت چند مرحله‌ای در حال حاضر غیرفعال است</string>
 </resources>

--- a/auth/src/main/res/values-fi/strings.xml
+++ b/auth/src/main/res/values-fi/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">Lähetimme vahvistussähköpostin osoitteeseen %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Monivaiheinen todennus on tällä hetkellä poistettu käytöstä</string>
 </resources>

--- a/auth/src/main/res/values-fil/strings.xml
+++ b/auth/src/main/res/values-fil/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">Nagpadala kami ng verification email sa %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Kasalukuyang naka-disable ang multi-factor authentication</string>
 </resources>

--- a/auth/src/main/res/values-fr-rCH/strings.xml
+++ b/auth/src/main/res/values-fr-rCH/strings.xml
@@ -190,6 +190,5 @@
     <string name="fui_reauthenticate_action">Se réauthentifier</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">L\'authentification multifacteur est actuellement désactivée</string>
 </resources>

--- a/auth/src/main/res/values-fr/strings.xml
+++ b/auth/src/main/res/values-fr/strings.xml
@@ -196,6 +196,5 @@
     <string name="fui_reauthenticate_action">Se réauthentifier</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">L\'authentification multifacteur est actuellement désactivée</string>
 </resources>

--- a/auth/src/main/res/values-gsw/strings.xml
+++ b/auth/src/main/res/values-gsw/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">Mir hend e Verifizierigs-E-Mail an %1$s gschickt</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">D\'Multi-Faktor-Authentifizierig isch zurziit deaktiviert</string>
 </resources>

--- a/auth/src/main/res/values-gu/strings.xml
+++ b/auth/src/main/res/values-gu/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">અમે %1$s પર ચકાસણી ઇમેઇલ મોકલ્યો</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">મલ્ટિ-ફેક્ટર પ્રમાણીકરણ હાલમાં અક્ષમ છે</string>
 </resources>

--- a/auth/src/main/res/values-hi/strings.xml
+++ b/auth/src/main/res/values-hi/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">हमने %1$s पर एक सत्यापन ईमेल भेजा</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">मल्टी-फैक्टर प्रमाणीकरण वर्तमान में अक्षम है</string>
 </resources>

--- a/auth/src/main/res/values-hr/strings.xml
+++ b/auth/src/main/res/values-hr/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">Poslali smo e-poštu za provjeru na %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Višefaktorska autentifikacija trenutno je onemogućena</string>
 </resources>

--- a/auth/src/main/res/values-hu/strings.xml
+++ b/auth/src/main/res/values-hu/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">Ellenőrző e-mailt küldtünk a következő címre: %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">A többfaktoros hitelesítés jelenleg le van tiltva</string>
 </resources>

--- a/auth/src/main/res/values-in/strings.xml
+++ b/auth/src/main/res/values-in/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">Kami telah mengirim email verifikasi ke %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Autentikasi multifaktor saat ini dinonaktifkan</string>
 </resources>

--- a/auth/src/main/res/values-it/strings.xml
+++ b/auth/src/main/res/values-it/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">Abbiamo inviato un\'email di verifica a %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">L\'autenticazione a più fattori è attualmente disabilitata</string>
 </resources>

--- a/auth/src/main/res/values-iw/strings.xml
+++ b/auth/src/main/res/values-iw/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">שלחנו אימייל אימות אל %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">אימות רב-גורמי מושבת כעת</string>
 </resources>

--- a/auth/src/main/res/values-ja/strings.xml
+++ b/auth/src/main/res/values-ja/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">%1$s に確認メールを送信しました</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">多要素認証は現在無効になっています</string>
 </resources>

--- a/auth/src/main/res/values-kn/strings.xml
+++ b/auth/src/main/res/values-kn/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">ನಾವು %1$s ಗೆ ಪರಿಶೀಲನೆ ಇಮೇಲ್ ಕಳುಹಿಸಿದ್ದೇವೆ</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">ಮಲ್ಟಿ-ಫ್ಯಾಕ್ಟರ್ ದೃಢೀಕರಣವು ಪ್ರಸ್ತುತ ನಿಷ್ಕ್ರಿಯಗೊಂಡಿದೆ</string>
 </resources>

--- a/auth/src/main/res/values-ko/strings.xml
+++ b/auth/src/main/res/values-ko/strings.xml
@@ -177,6 +177,5 @@
     <string name="fui_verify_email_instruction">%1$s(으)로 확인 이메일을 보냈습니다</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">다단계 인증이 현재 비활성화되어 있습니다</string>
 </resources>

--- a/auth/src/main/res/values-ln/strings.xml
+++ b/auth/src/main/res/values-ln/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">Totindi e-mail ya vérification na %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Bondimisami ya makambo mingi ezali sikoyo te</string>
 </resources>

--- a/auth/src/main/res/values-lt/strings.xml
+++ b/auth/src/main/res/values-lt/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">Išsiuntėme patvirtinimo el. laišką adresu %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Daugiafaktoris tapatybės nustatymas šiuo metu išjungtas</string>
 </resources>

--- a/auth/src/main/res/values-lv/strings.xml
+++ b/auth/src/main/res/values-lv/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">Nosūtījām verifikācijas e-pastu uz %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Daudzfaktoru autentifikācija pašlaik ir atspējota</string>
 </resources>

--- a/auth/src/main/res/values-mo/strings.xml
+++ b/auth/src/main/res/values-mo/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">Am trimis un e-mail de verificare la %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Autentificarea cu mai mulți factori este dezactivată în prezent</string>
 </resources>

--- a/auth/src/main/res/values-mr/strings.xml
+++ b/auth/src/main/res/values-mr/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">आम्ही %1$s वर सत्यापन ईमेल पाठवला</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">मल्टी-फॅक्टर ऑथेंटिकेशन सध्या अक्षम आहे</string>
 </resources>

--- a/auth/src/main/res/values-ms/strings.xml
+++ b/auth/src/main/res/values-ms/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">Kami menghantar e-mel pengesahan ke %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Pengesahan berbilang faktor dilumpuhkan buat masa ini</string>
 </resources>

--- a/auth/src/main/res/values-nb/strings.xml
+++ b/auth/src/main/res/values-nb/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">Vi sendte en bekreftelsese-post til %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Flerfaktorautentisering er for øyeblikket deaktivert</string>
 </resources>

--- a/auth/src/main/res/values-nl/strings.xml
+++ b/auth/src/main/res/values-nl/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">We hebben een verificatie-e-mail verzonden naar %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Multi-factorauthenticatie is momenteel uitgeschakeld</string>
 </resources>

--- a/auth/src/main/res/values-no/strings.xml
+++ b/auth/src/main/res/values-no/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">Vi sendte en bekreftelsese-post til %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Flerfaktorautentisering er for øyeblikket deaktivert</string>
 </resources>

--- a/auth/src/main/res/values-pl/strings.xml
+++ b/auth/src/main/res/values-pl/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">Wysłaliśmy e-mail weryfikacyjny na adres %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Uwierzytelnianie wieloskładnikowe jest obecnie wyłączone</string>
 </resources>

--- a/auth/src/main/res/values-pt-rBR/strings.xml
+++ b/auth/src/main/res/values-pt-rBR/strings.xml
@@ -197,6 +197,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">A autenticação multifator está atualmente desativada</string>
 </resources>

--- a/auth/src/main/res/values-pt-rPT/strings.xml
+++ b/auth/src/main/res/values-pt-rPT/strings.xml
@@ -197,6 +197,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">A autenticação multifator está atualmente desativada</string>
 </resources>

--- a/auth/src/main/res/values-pt/strings.xml
+++ b/auth/src/main/res/values-pt/strings.xml
@@ -196,6 +196,5 @@
     <string name="fui_reauthenticate_action">Reautenticar</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">A autenticação multifator está atualmente desativada</string>
 </resources>

--- a/auth/src/main/res/values-ro/strings.xml
+++ b/auth/src/main/res/values-ro/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">Am trimis un e-mail de verificare la %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Autentificarea cu mai mulți factori este dezactivată în prezent</string>
 </resources>

--- a/auth/src/main/res/values-ru/strings.xml
+++ b/auth/src/main/res/values-ru/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">Мы отправили письмо подтверждения на %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Многофакторная аутентификация в настоящее время отключена</string>
 </resources>

--- a/auth/src/main/res/values-sk/strings.xml
+++ b/auth/src/main/res/values-sk/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">Poslali sme overovací e-mail na adresu %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Viacfaktorové overovanie je momentálne zakázané</string>
 </resources>

--- a/auth/src/main/res/values-sl/strings.xml
+++ b/auth/src/main/res/values-sl/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">Poslali smo e-sporočilo za preverjanje na %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Večfaktorska avtentikacija je trenutno onemogočena</string>
 </resources>

--- a/auth/src/main/res/values-sr/strings.xml
+++ b/auth/src/main/res/values-sr/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">Послали смо имејл за верификацију на %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Вишефакторска аутентификација је тренутно онемогућена</string>
 </resources>

--- a/auth/src/main/res/values-sv/strings.xml
+++ b/auth/src/main/res/values-sv/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">Vi har skickat ett verifieringsmail till %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Multifaktorautentisering är för närvarande inaktiverad</string>
 </resources>

--- a/auth/src/main/res/values-ta/strings.xml
+++ b/auth/src/main/res/values-ta/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">%1$s க்கு சரிபார்ப்பு மின்னஞ்சலை அனுப்பியுள்ளோம்</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">பல-காரணி அங்கீகாரம் தற்போது முடக்கப்பட்டுள்ளது</string>
 </resources>

--- a/auth/src/main/res/values-th/strings.xml
+++ b/auth/src/main/res/values-th/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">เราส่งอีเมลยืนยันไปที่ %1$s แล้ว</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">การรับรองความถูกต้องแบบหลายปัจจัยถูกปิดใช้งานในขณะนี้</string>
 </resources>

--- a/auth/src/main/res/values-tl/strings.xml
+++ b/auth/src/main/res/values-tl/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">Nagpadala kami ng verification email sa %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Kasalukuyang naka-disable ang multi-factor authentication</string>
 </resources>

--- a/auth/src/main/res/values-tr/strings.xml
+++ b/auth/src/main/res/values-tr/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">%1$s adresine bir doğrulama e-postası gönderdik</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Çok faktörlü kimlik doğrulama şu anda devre dışı</string>
 </resources>

--- a/auth/src/main/res/values-uk/strings.xml
+++ b/auth/src/main/res/values-uk/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">Ми надіслали лист підтвердження на %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Багатофакторна автентифікація наразі вимкнена</string>
 </resources>

--- a/auth/src/main/res/values-ur/strings.xml
+++ b/auth/src/main/res/values-ur/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">ہم نے %1$s کو تصدیقی ای میل بھیجی</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">ملٹی فیکٹر تصدیق فی الحال غیر فعال ہے</string>
 </resources>

--- a/auth/src/main/res/values-vi/strings.xml
+++ b/auth/src/main/res/values-vi/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">Chúng tôi đã gửi email xác minh đến %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Xác thực đa yếu tố hiện đang bị vô hiệu hóa</string>
 </resources>

--- a/auth/src/main/res/values-zh-rCN/strings.xml
+++ b/auth/src/main/res/values-zh-rCN/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">我们已向 %1$s 发送了验证邮件</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">多重身份验证当前已禁用</string>
 </resources>

--- a/auth/src/main/res/values-zh-rHK/strings.xml
+++ b/auth/src/main/res/values-zh-rHK/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">我們已向 %1$s 發送了驗證電郵</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">多重身份验证当前已禁用</string>
 </resources>

--- a/auth/src/main/res/values-zh-rTW/strings.xml
+++ b/auth/src/main/res/values-zh-rTW/strings.xml
@@ -179,6 +179,5 @@
     <string name="fui_verify_email_instruction">我們已傳送驗證郵件至 %1$s</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">多重身份验证当前已禁用</string>
 </resources>

--- a/auth/src/main/res/values-zh/strings.xml
+++ b/auth/src/main/res/values-zh/strings.xml
@@ -178,6 +178,5 @@
     <string name="fui_verify_email_instruction">我们已向 %1$s 发送了验证邮件</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">多重身份验证当前已禁用</string>
 </resources>

--- a/auth/src/main/res/values/strings.xml
+++ b/auth/src/main/res/values/strings.xml
@@ -284,6 +284,5 @@
     <string name="fui_mfa_error_generic" translation_description="Generic error message for MFA enrollment failures">An error occurred during enrollment. Please try again.</string>
 
     <!-- Tooltips -->
-    <string name="fui_new_accounts_disabled_tooltip" translation_description="Tooltip shown when sign-up button is disabled because new accounts are not allowed">This button is currently disabled because new accounts are not allowed</string>
     <string name="fui_mfa_disabled_tooltip" translation_description="Tooltip shown when manage MFA button is disabled because MFA is not enabled">Multi-factor authentication is currently disabled</string>
 </resources>

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/SignInUITest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/SignInUITest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens.email
+
+import android.content.Context
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.core.app.ApplicationProvider
+import com.firebase.ui.auth.configuration.authUIConfiguration
+import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.configuration.string_provider.AuthUIStringProvider
+import com.firebase.ui.auth.configuration.string_provider.DefaultAuthUIStringProvider
+import com.firebase.ui.auth.configuration.string_provider.LocalAuthUIStringProvider
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Unit tests for [SignInUI], covering the sign-up button's visibility.
+ *
+ * @suppress Internal test class
+ */
+@Config(sdk = [34])
+@RunWith(RobolectricTestRunner::class)
+class SignInUITest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var applicationContext: Context
+    private lateinit var stringProvider: AuthUIStringProvider
+
+    @Before
+    fun setUp() {
+        applicationContext = ApplicationProvider.getApplicationContext()
+        stringProvider = DefaultAuthUIStringProvider(applicationContext)
+    }
+
+    private fun setSignInUIContent(isNewAccountsAllowed: Boolean) {
+        val provider = AuthProvider.Email(
+            emailLinkActionCodeSettings = null,
+            isNewAccountsAllowed = isNewAccountsAllowed,
+            passwordValidationRules = emptyList()
+        )
+        val configuration = authUIConfiguration {
+            context = applicationContext
+            providers { provider(provider) }
+        }
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalAuthUIStringProvider provides stringProvider) {
+                SignInUI(
+                    configuration = configuration,
+                    isLoading = false,
+                    emailSignInLinkSent = false,
+                    email = "",
+                    password = "",
+                    onEmailChange = { },
+                    onPasswordChange = { },
+                    onSignInClick = { },
+                    onRetrievedCredential = { },
+                    onGoToEmailLinkSignIn = { },
+                    onGoToSignUp = { },
+                    onGoToResetPassword = { },
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `sign up button is hidden when new accounts are not allowed`() {
+        setSignInUIContent(isNewAccountsAllowed = false)
+
+        composeTestRule.onNode(hasText(stringProvider.signupPageTitle.uppercase()) and hasClickAction())
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `sign up button is enabled when new accounts are allowed`() {
+        setSignInUIContent(isNewAccountsAllowed = true)
+
+        composeTestRule.onNode(hasText(stringProvider.signupPageTitle.uppercase()) and hasClickAction())
+            .assertIsEnabled()
+    }
+}

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/SignUpUITest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/SignUpUITest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens.email
+
+import android.content.Context
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import com.firebase.ui.auth.configuration.authUIConfiguration
+import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.configuration.string_provider.AuthUIStringProvider
+import com.firebase.ui.auth.configuration.string_provider.DefaultAuthUIStringProvider
+import com.firebase.ui.auth.configuration.string_provider.LocalAuthUIStringProvider
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Unit tests for [SignUpUI], covering form validity logic.
+ *
+ * @suppress Internal test class
+ */
+@Config(sdk = [34])
+@RunWith(RobolectricTestRunner::class)
+class SignUpUITest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var applicationContext: Context
+    private lateinit var stringProvider: AuthUIStringProvider
+
+    @Before
+    fun setUp() {
+        applicationContext = ApplicationProvider.getApplicationContext()
+        stringProvider = DefaultAuthUIStringProvider(applicationContext)
+    }
+
+    @Test
+    fun `sign up button becomes enabled when display name is not required and hidden`() {
+        val provider = AuthProvider.Email(
+            isDisplayNameRequired = false,
+            emailLinkActionCodeSettings = null,
+            passwordValidationRules = emptyList()
+        )
+        val configuration = authUIConfiguration {
+            context = applicationContext
+            providers { provider(provider) }
+        }
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalAuthUIStringProvider provides stringProvider) {
+                var email by remember { mutableStateOf("") }
+                var password by remember { mutableStateOf("") }
+                var confirmPassword by remember { mutableStateOf("") }
+
+                SignUpUI(
+                    configuration = configuration,
+                    isLoading = false,
+                    displayName = "",
+                    email = email,
+                    password = password,
+                    confirmPassword = confirmPassword,
+                    onDisplayNameChange = { },
+                    onEmailChange = { email = it },
+                    onPasswordChange = { password = it },
+                    onConfirmPasswordChange = { confirmPassword = it },
+                    onGoToSignIn = { },
+                    onSignUpClick = { }
+                )
+            }
+        }
+
+        // Name field should not be rendered since it isn't required.
+        composeTestRule.onNodeWithText(stringProvider.nameHint).assertDoesNotExist()
+
+        composeTestRule.onNodeWithText(stringProvider.emailHint)
+            .performTextInput("test@example.com")
+        composeTestRule.onNodeWithText(stringProvider.passwordHint)
+            .performTextInput("Password123")
+        composeTestRule.onNodeWithText(stringProvider.confirmPasswordHint)
+            .performTextInput("Password123")
+
+        composeTestRule.waitForIdle()
+
+        // With email/password/confirmPassword all valid and no display name required,
+        // the sign up button should be enabled even though displayName is still "".
+        composeTestRule.onNode(hasText(stringProvider.signupPageTitle.uppercase()) and hasClickAction())
+            .assertIsEnabled()
+    }
+}


### PR DESCRIPTION
Fixes #2382.

When `AuthProvider.Email.isNewAccountsAllowed` is false, the sign-up button on the email sign-in screen was shown disabled with a tooltip explaining why — a UX regression from the pre-Compose UI, where the button was hidden entirely. This restores the hidden-button behavior.

- `SignInUI.kt`: sign-up button is now only emitted when `provider.isNewAccountsAllowed` is true; removed the TooltipBox/tooltip wrapper.
- Removed the now-unused `newAccountsDisabledTooltip` property from `AuthUIStringProvider`/`DefaultAuthUIStringProvider` and its string resource from all locale files (breaking change for anyone who overrode this property in a custom string provider).
- Added `SignInUITest.kt `covering both the hidden and enabled states of the sign-up button.