### PR TITLE
sample(app): add Firestore, Database & Storage demos to sample app

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,7 +54,9 @@ kotlin {
 
 dependencies {
     implementation(project(":auth"))
+    implementation(project(":database"))
     implementation(project(":storage"))
+    implementation(Config.Libs.Androidx.paging)
     kapt(Config.Libs.Misc.glideCompiler)
 
     implementation(libs.kotlin.stdlib)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,6 +55,7 @@ kotlin {
 dependencies {
     implementation(project(":auth"))
     implementation(project(":database"))
+    implementation(project(":firestore"))
     implementation(project(":storage"))
     implementation(Config.Libs.Androidx.paging)
     kapt(Config.Libs.Misc.glideCompiler)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,8 +57,8 @@ dependencies {
     implementation(project(":database"))
     implementation(project(":firestore"))
     implementation(project(":storage"))
-    implementation(Config.Libs.Androidx.paging)
-    kapt(Config.Libs.Misc.glideCompiler)
+    implementation(libs.androidx.paging)
+    kapt(libs.glide.compiler)
 
     implementation(libs.kotlin.stdlib)
     implementation(libs.androidx.lifecycle.runtime)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
     id("com.google.gms.google-services")
+    id("kotlin-kapt")
 }
 
 android {
@@ -53,6 +54,8 @@ kotlin {
 
 dependencies {
     implementation(project(":auth"))
+    implementation(project(":storage"))
+    kapt(Config.Libs.Misc.glideCompiler)
 
     implementation(libs.kotlin.stdlib)
     implementation(libs.androidx.lifecycle.runtime)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -95,6 +95,13 @@
             android:exported="false"
             android:theme="@style/Theme.FirebaseUIAndroid" />
 
+        <!-- Firestore -->
+        <activity
+            android:name="com.firebaseui.android.demo.firestore.FirestoreDemoActivity"
+            android:label="Firestore Demo"
+            android:exported="false"
+            android:theme="@style/Theme.FirebaseUIAndroid" />
+
         <!-- Storage -->
         <activity
             android:name="com.firebaseui.android.demo.storage.StorageDemoActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,31 +59,31 @@
             android:theme="@style/Theme.FirebaseUIAndroid" />
 
         <activity
-            android:name=".CredentialLinkingDemoActivity"
+            android:name=".auth.CredentialLinkingDemoActivity"
             android:label="Credential Linking Demo"
             android:exported="false"
             android:theme="@style/Theme.FirebaseUIAndroid" />
 
         <activity
-            android:name=".EmailAuthSlotDemoActivity"
+            android:name=".auth.EmailAuthSlotDemoActivity"
             android:label="Email Auth — Custom Slot"
             android:exported="false"
             android:theme="@style/Theme.FirebaseUIAndroid" />
 
         <activity
-            android:name=".PhoneAuthSlotDemoActivity"
+            android:name=".auth.PhoneAuthSlotDemoActivity"
             android:label="Phone Auth — Custom Slot"
             android:exported="false"
             android:theme="@style/Theme.FirebaseUIAndroid" />
 
         <activity
-            android:name=".ShapeCustomizationDemoActivity"
+            android:name=".auth.ShapeCustomizationDemoActivity"
             android:label="Shape Customization"
             android:exported="false"
             android:theme="@style/Theme.FirebaseUIAndroid" />
 
         <activity
-            android:name=".CustomMethodPickerDemoActivity"
+            android:name=".auth.CustomMethodPickerDemoActivity"
             android:label="Custom Method Picker Layout"
             android:exported="false"
             android:theme="@style/Theme.FirebaseUIAndroid" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -88,6 +88,13 @@
             android:exported="false"
             android:theme="@style/Theme.FirebaseUIAndroid" />
 
+        <!-- Database -->
+        <activity
+            android:name="com.firebaseui.android.demo.database.DatabaseDemoActivity"
+            android:label="Database Demo"
+            android:exported="false"
+            android:theme="@style/Theme.FirebaseUIAndroid" />
+
         <!-- Storage -->
         <activity
             android:name="com.firebaseui.android.demo.storage.StorageDemoActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,31 +59,31 @@
             android:theme="@style/Theme.FirebaseUIAndroid" />
 
         <activity
-            android:name=".auth.CredentialLinkingDemoActivity"
+            android:name="com.firebaseui.android.demo.auth.CredentialLinkingDemoActivity"
             android:label="Credential Linking Demo"
             android:exported="false"
             android:theme="@style/Theme.FirebaseUIAndroid" />
 
         <activity
-            android:name=".auth.EmailAuthSlotDemoActivity"
+            android:name="com.firebaseui.android.demo.auth.EmailAuthSlotDemoActivity"
             android:label="Email Auth — Custom Slot"
             android:exported="false"
             android:theme="@style/Theme.FirebaseUIAndroid" />
 
         <activity
-            android:name=".auth.PhoneAuthSlotDemoActivity"
+            android:name="com.firebaseui.android.demo.auth.PhoneAuthSlotDemoActivity"
             android:label="Phone Auth — Custom Slot"
             android:exported="false"
             android:theme="@style/Theme.FirebaseUIAndroid" />
 
         <activity
-            android:name=".auth.ShapeCustomizationDemoActivity"
+            android:name="com.firebaseui.android.demo.auth.ShapeCustomizationDemoActivity"
             android:label="Shape Customization"
             android:exported="false"
             android:theme="@style/Theme.FirebaseUIAndroid" />
 
         <activity
-            android:name=".auth.CustomMethodPickerDemoActivity"
+            android:name="com.firebaseui.android.demo.auth.CustomMethodPickerDemoActivity"
             android:label="Custom Method Picker Layout"
             android:exported="false"
             android:theme="@style/Theme.FirebaseUIAndroid" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,14 +19,9 @@
             android:theme="@style/Theme.FirebaseUIAndroid">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
-            <!-- Email Link Sign-In Handler Activity for Compose -->
-            <!-- This activity handles deep links for passwordless email authentication -->
-            <!-- The host is automatically read from firebase_web_host in config.xml -->
-            <!-- NOTE: firebase_web_host must be lowercase (e.g., project-id.firebaseapp.com) -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -38,20 +33,27 @@
             </intent-filter>
         </activity>
 
+        <!-- Auth -->
         <activity
-            android:name=".HighLevelApiDemoActivity"
+            android:name="com.firebaseui.android.demo.auth.AuthChooserActivity"
+            android:label="Auth Demos"
+            android:exported="false"
+            android:theme="@style/Theme.FirebaseUIAndroid" />
+
+        <activity
+            android:name="com.firebaseui.android.demo.auth.HighLevelApiDemoActivity"
             android:label="High-Level API Demo"
             android:exported="false"
             android:theme="@style/Theme.FirebaseUIAndroid" />
 
         <activity
-            android:name=".AuthFlowControllerDemoActivity"
+            android:name="com.firebaseui.android.demo.auth.AuthFlowControllerDemoActivity"
             android:label="Low-Level API Demo"
             android:exported="false"
             android:theme="@style/Theme.FirebaseUIAndroid" />
 
         <activity
-            android:name=".CustomSlotsThemingDemoActivity"
+            android:name="com.firebaseui.android.demo.auth.CustomSlotsThemingDemoActivity"
             android:label="Custom Slots &amp; Theming Demo"
             android:exported="false"
             android:theme="@style/Theme.FirebaseUIAndroid" />
@@ -86,6 +88,12 @@
             android:exported="false"
             android:theme="@style/Theme.FirebaseUIAndroid" />
 
+        <!-- Storage -->
+        <activity
+            android:name="com.firebaseui.android.demo.storage.StorageDemoActivity"
+            android:label="Storage Demo"
+            android:exported="false"
+            android:theme="@style/Theme.FirebaseUIAndroid" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/firebaseui/android/demo/MainActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/MainActivity.kt
@@ -27,6 +27,7 @@ import com.firebase.ui.auth.FirebaseAuthUI
 import com.firebase.ui.auth.util.EmailLinkConstants
 import com.firebaseui.android.demo.auth.AuthChooserActivity
 import com.firebaseui.android.demo.auth.HighLevelApiDemoActivity
+import com.firebaseui.android.demo.database.DatabaseDemoActivity
 import com.firebaseui.android.demo.storage.StorageDemoActivity
 import com.google.firebase.FirebaseApp
 
@@ -81,6 +82,9 @@ class MainActivity : ComponentActivity() {
                         onAuthClick = {
                             startActivity(Intent(this, AuthChooserActivity::class.java))
                         },
+                        onDatabaseClick = {
+                            startActivity(Intent(this, DatabaseDemoActivity::class.java))
+                        },
                         onStorageClick = {
                             startActivity(Intent(this, StorageDemoActivity::class.java))
                         }
@@ -94,6 +98,7 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun ChooserScreen(
     onAuthClick: () -> Unit,
+    onDatabaseClick: () -> Unit,
     onStorageClick: () -> Unit,
 ) {
     Column(
@@ -125,6 +130,24 @@ fun ChooserScreen(
                 )
                 Text(
                     text = "High-Level API, Low-Level API, Custom Slots & Theming",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        Card(modifier = Modifier.fillMaxWidth(), onClick = onDatabaseClick) {
+            Column(
+                modifier = Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = "Database",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = "Paginated list with FirebaseRecyclerPagingAdapter and orderByChild",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/com/firebaseui/android/demo/MainActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/MainActivity.kt
@@ -28,6 +28,7 @@ import com.firebase.ui.auth.util.EmailLinkConstants
 import com.firebaseui.android.demo.auth.AuthChooserActivity
 import com.firebaseui.android.demo.auth.HighLevelApiDemoActivity
 import com.firebaseui.android.demo.database.DatabaseDemoActivity
+import com.firebaseui.android.demo.firestore.FirestoreDemoActivity
 import com.firebaseui.android.demo.storage.StorageDemoActivity
 import com.google.firebase.FirebaseApp
 
@@ -85,6 +86,9 @@ class MainActivity : ComponentActivity() {
                         onDatabaseClick = {
                             startActivity(Intent(this, DatabaseDemoActivity::class.java))
                         },
+                        onFirestoreClick = {
+                            startActivity(Intent(this, FirestoreDemoActivity::class.java))
+                        },
                         onStorageClick = {
                             startActivity(Intent(this, StorageDemoActivity::class.java))
                         }
@@ -99,6 +103,7 @@ class MainActivity : ComponentActivity() {
 fun ChooserScreen(
     onAuthClick: () -> Unit,
     onDatabaseClick: () -> Unit,
+    onFirestoreClick: () -> Unit,
     onStorageClick: () -> Unit,
 ) {
     Column(
@@ -148,6 +153,24 @@ fun ChooserScreen(
                 )
                 Text(
                     text = "Paginated list with FirebaseRecyclerPagingAdapter and orderByChild",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        Card(modifier = Modifier.fillMaxWidth(), onClick = onFirestoreClick) {
+            Column(
+                modifier = Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = "Firestore",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = "Paginated list with FirestorePagingAdapter and orderBy",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/com/firebaseui/android/demo/MainActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/MainActivity.kt
@@ -31,12 +31,18 @@ import com.firebaseui.android.demo.database.DatabaseDemoActivity
 import com.firebaseui.android.demo.firestore.FirestoreDemoActivity
 import com.firebaseui.android.demo.storage.StorageDemoActivity
 import com.google.firebase.FirebaseApp
+import com.google.firebase.firestore.FirebaseFirestore
 
 class MainActivity : ComponentActivity() {
     companion object {
-        private const val USE_AUTH_EMULATOR = false
+        private const val USE_AUTH_EMULATOR = true
         private const val AUTH_EMULATOR_HOST = "10.0.2.2"
         private const val AUTH_EMULATOR_PORT = 9099
+
+        // 10.0.2.2 is the Android emulator's alias for the host machine's localhost.
+        private const val USE_FIRESTORE_EMULATOR = true
+        private const val FIRESTORE_EMULATOR_HOST = "10.0.2.2"
+        private const val FIRESTORE_EMULATOR_PORT = 8080
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -48,6 +54,11 @@ class MainActivity : ComponentActivity() {
 
         if (USE_AUTH_EMULATOR) {
             authUI.auth.useEmulator(AUTH_EMULATOR_HOST, AUTH_EMULATOR_PORT)
+        }
+
+        if (USE_FIRESTORE_EMULATOR) {
+            FirebaseFirestore.getInstance()
+                .useEmulator(FIRESTORE_EMULATOR_HOST, FIRESTORE_EMULATOR_PORT)
         }
 
         var pendingEmailLink = intent.getStringExtra(EmailLinkConstants.EXTRA_EMAIL_LINK)

--- a/app/src/main/java/com/firebaseui/android/demo/MainActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/MainActivity.kt
@@ -31,11 +31,12 @@ import com.firebaseui.android.demo.database.DatabaseDemoActivity
 import com.firebaseui.android.demo.firestore.FirestoreDemoActivity
 import com.firebaseui.android.demo.storage.StorageDemoActivity
 import com.google.firebase.FirebaseApp
+import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.firestore.FirebaseFirestore
 
 class MainActivity : ComponentActivity() {
     companion object {
-        private const val USE_AUTH_EMULATOR = true
+        internal const val USE_AUTH_EMULATOR = true
         private const val AUTH_EMULATOR_HOST = "10.0.2.2"
         private const val AUTH_EMULATOR_PORT = 9099
 
@@ -43,6 +44,10 @@ class MainActivity : ComponentActivity() {
         private const val USE_FIRESTORE_EMULATOR = true
         private const val FIRESTORE_EMULATOR_HOST = "10.0.2.2"
         private const val FIRESTORE_EMULATOR_PORT = 8080
+
+        private const val USE_DATABASE_EMULATOR = true
+        private const val DATABASE_EMULATOR_HOST = "10.0.2.2"
+        private const val DATABASE_EMULATOR_PORT = 8199
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -59,6 +64,11 @@ class MainActivity : ComponentActivity() {
         if (USE_FIRESTORE_EMULATOR) {
             FirebaseFirestore.getInstance()
                 .useEmulator(FIRESTORE_EMULATOR_HOST, FIRESTORE_EMULATOR_PORT)
+        }
+
+        if (USE_DATABASE_EMULATOR) {
+            FirebaseDatabase.getInstance()
+                .useEmulator(DATABASE_EMULATOR_HOST, DATABASE_EMULATOR_PORT)
         }
 
         var pendingEmailLink = intent.getStringExtra(EmailLinkConstants.EXTRA_EMAIL_LINK)
@@ -145,7 +155,7 @@ fun ChooserScreen(
                     color = MaterialTheme.colorScheme.primary
                 )
                 Text(
-                    text = "High-Level API, Low-Level API, Custom Slots & Theming",
+                    text = "High-Level API, Low-Level API, Custom Slots & Theming, Credential Linking",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/com/firebaseui/android/demo/MainActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/MainActivity.kt
@@ -48,6 +48,10 @@ class MainActivity : ComponentActivity() {
         private const val USE_DATABASE_EMULATOR = true
         private const val DATABASE_EMULATOR_HOST = "10.0.2.2"
         private const val DATABASE_EMULATOR_PORT = 8199
+
+        // useEmulator() throws once the Firestore/Database client has been used elsewhere in
+        // the process, so this must only run once per process, not on every onCreate().
+        private var emulatorsConfigured = false
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -57,18 +61,21 @@ class MainActivity : ComponentActivity() {
         FirebaseApp.initializeApp(applicationContext)
         val authUI = FirebaseAuthUI.getInstance()
 
-        if (USE_AUTH_EMULATOR) {
-            authUI.auth.useEmulator(AUTH_EMULATOR_HOST, AUTH_EMULATOR_PORT)
-        }
+        if (!emulatorsConfigured) {
+            if (USE_AUTH_EMULATOR) {
+                authUI.auth.useEmulator(AUTH_EMULATOR_HOST, AUTH_EMULATOR_PORT)
+            }
 
-        if (USE_FIRESTORE_EMULATOR) {
-            FirebaseFirestore.getInstance()
-                .useEmulator(FIRESTORE_EMULATOR_HOST, FIRESTORE_EMULATOR_PORT)
-        }
+            if (USE_FIRESTORE_EMULATOR) {
+                FirebaseFirestore.getInstance()
+                    .useEmulator(FIRESTORE_EMULATOR_HOST, FIRESTORE_EMULATOR_PORT)
+            }
 
-        if (USE_DATABASE_EMULATOR) {
-            FirebaseDatabase.getInstance()
-                .useEmulator(DATABASE_EMULATOR_HOST, DATABASE_EMULATOR_PORT)
+            if (USE_DATABASE_EMULATOR) {
+                FirebaseDatabase.getInstance()
+                    .useEmulator(DATABASE_EMULATOR_HOST, DATABASE_EMULATOR_PORT)
+            }
+            emulatorsConfigured = true
         }
 
         var pendingEmailLink = intent.getStringExtra(EmailLinkConstants.EXTRA_EMAIL_LINK)

--- a/app/src/main/java/com/firebaseui/android/demo/MainActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/MainActivity.kt
@@ -17,23 +17,19 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.firebase.ui.auth.FirebaseAuthUI
 import com.firebase.ui.auth.util.EmailLinkConstants
+import com.firebaseui.android.demo.auth.AuthChooserActivity
+import com.firebaseui.android.demo.auth.HighLevelApiDemoActivity
+import com.firebaseui.android.demo.storage.StorageDemoActivity
 import com.google.firebase.FirebaseApp
 
-/**
- * Main launcher activity that allows users to choose between different
- * authentication API demonstrations.
- */
 class MainActivity : ComponentActivity() {
     companion object {
         private const val USE_AUTH_EMULATOR = false
@@ -45,7 +41,6 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        // Initialize Firebase and configure emulator if needed
         FirebaseApp.initializeApp(applicationContext)
         val authUI = FirebaseAuthUI.getInstance()
 
@@ -54,7 +49,6 @@ class MainActivity : ComponentActivity() {
         }
 
         var pendingEmailLink = intent.getStringExtra(EmailLinkConstants.EXTRA_EMAIL_LINK)
-
         if (pendingEmailLink.isNullOrEmpty() && authUI.canHandleIntent(intent)) {
             pendingEmailLink = intent.data?.toString()
         }
@@ -62,10 +56,7 @@ class MainActivity : ComponentActivity() {
         Log.d("MainActivity", "Pending email link: $pendingEmailLink")
 
         fun launchHighLevelDemo() {
-            val demoIntent = Intent(
-                this,
-                HighLevelApiDemoActivity::class.java
-            ).apply {
+            val demoIntent = Intent(this, HighLevelApiDemoActivity::class.java).apply {
                 pendingEmailLink?.let { link ->
                     putExtra(EmailLinkConstants.EXTRA_EMAIL_LINK, link)
                     pendingEmailLink = null
@@ -87,17 +78,12 @@ class MainActivity : ComponentActivity() {
                     color = MaterialTheme.colorScheme.background
                 ) {
                     ChooserScreen(
-                        onHighLevelApiClick = ::launchHighLevelDemo,
-                        onLowLevelApiClick = {
-                            startActivity(Intent(this, AuthFlowControllerDemoActivity::class.java))
+                        onAuthClick = {
+                            startActivity(Intent(this, AuthChooserActivity::class.java))
                         },
-                        onCustomSlotsClick = {
-                            startActivity(Intent(this, CustomSlotsThemingDemoActivity::class.java))
-                        },
-                        onCredentialLinkingClick = {
-                            startActivity(Intent(this, CredentialLinkingDemoActivity::class.java))
-                        },
-                        isEmulatorMode = USE_AUTH_EMULATOR
+                        onStorageClick = {
+                            startActivity(Intent(this, StorageDemoActivity::class.java))
+                        }
                     )
                 }
             }
@@ -107,226 +93,62 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun ChooserScreen(
-    onHighLevelApiClick: () -> Unit,
-    onLowLevelApiClick: () -> Unit,
-    onCustomSlotsClick: () -> Unit,
-    onCredentialLinkingClick: () -> Unit = {},
-    isEmulatorMode: Boolean = false
+    onAuthClick: () -> Unit,
+    onStorageClick: () -> Unit,
 ) {
-    val scrollState = rememberScrollState()
-
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .verticalScroll(scrollState)
+            .verticalScroll(rememberScrollState())
             .systemBarsPadding()
             .padding(24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(24.dp)
     ) {
-        Spacer(modifier = Modifier.height(16.dp))
-        // Header
-        Text(
-            text = "Firebase Auth UI Compose",
-            style = MaterialTheme.typography.headlineLarge,
-            textAlign = TextAlign.Center
-        )
+        Spacer(modifier = Modifier.height(8.dp))
 
+        Text("FirebaseUI Android", style = MaterialTheme.typography.headlineLarge)
         Text(
-            text = "Choose a demo to explore different authentication APIs",
+            "Choose a module to explore its demos",
             style = MaterialTheme.typography.bodyLarge,
-            textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
 
-        // Emulator Mode Warning
-        if (isEmulatorMode) {
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.errorContainer
-                )
-            ) {
-                Column(
-                    modifier = Modifier.padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    Text(
-                        text = "⚠️ Emulator Mode",
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.onErrorContainer
-                    )
-                    Text(
-                        text = "Running with Firebase Auth Emulator. Some features like third-party" +
-                                " OAuth providers (Facebook, Twitter, LINE etc.) may not work correctly." +
-                                " Disable Firebase Auth Emulator using" +
-                                " MainActivity.USE_AUTH_EMULATOR = false",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onErrorContainer
-                    )
-                }
-            }
-        }
-
-        // High-Level API Card
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            onClick = onHighLevelApiClick
-        ) {
+        Card(modifier = Modifier.fillMaxWidth(), onClick = onAuthClick) {
             Column(
                 modifier = Modifier.padding(20.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                Text(
-                    text = "🎨 High-Level API",
-                    style = MaterialTheme.typography.titleLarge,
-                    color = MaterialTheme.colorScheme.primary
-                )
-                Text(
-                    text = "FirebaseAuthScreen Composable",
-                    style = MaterialTheme.typography.titleMedium
-                )
-                Text(
-                    text = "Best for: Pure Compose applications that want a complete, ready-to-use authentication UI with minimal setup.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = "Features:",
-                    style = MaterialTheme.typography.labelLarge
-                )
-                Text(
-                    text = "• Drop-in Composable\n• Automatic navigation\n• State management included\n• Customizable content",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
-
-        // Low-Level API Card
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            onClick = onLowLevelApiClick
-        ) {
-            Column(
-                modifier = Modifier.padding(20.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                Text(
-                    text = "⚙️ Low-Level API",
-                    style = MaterialTheme.typography.titleLarge,
-                    color = MaterialTheme.colorScheme.primary
-                )
-                Text(
-                    text = "AuthFlowController",
-                    style = MaterialTheme.typography.titleMedium
-                )
-                Text(
-                    text = "Best for: Applications that need fine-grained control over the authentication flow with ActivityResultLauncher integration.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = "Features:",
-                    style = MaterialTheme.typography.labelLarge
-                )
-                Text(
-                    text = "• Lifecycle-safe controller\n• ActivityResultLauncher\n• Observable state with Flow\n• Manual flow control",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
-
-        // Custom Slots & Theming Card
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            onClick = onCustomSlotsClick
-        ) {
-            Column(
-                modifier = Modifier.padding(20.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                Text(
-                    text = "🎨 Custom Slots & Theming",
-                    style = MaterialTheme.typography.titleLarge,
-                    color = MaterialTheme.colorScheme.primary
-                )
-                Text(
-                    text = "Slot APIs & Theme Customization",
-                    style = MaterialTheme.typography.titleMedium
-                )
-                Text(
-                    text = "Best for: Applications that need fully custom UI while leveraging the authentication logic and state management.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = "Features:",
-                    style = MaterialTheme.typography.labelLarge
-                )
-                Text(
-                    text = "• Custom email auth UI via slots\n• Custom phone auth UI via slots\n• AuthUITheme.fromMaterialTheme()\n• Custom ProviderStyle examples",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
-
-        // Credential Linking Card
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            onClick = onCredentialLinkingClick
-        ) {
-            Column(
-                modifier = Modifier.padding(20.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                Text(
-                    text = "🔗 Credential Linking",
-                    style = MaterialTheme.typography.titleLarge,
-                    color = MaterialTheme.colorScheme.primary
-                )
-                Text(
-                    text = "isCredentialLinkingEnabled",
-                    style = MaterialTheme.typography.titleMedium
-                )
-                Text(
-                    text = "Sign in with one provider, then add another to the same account without losing your UID.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Info card
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.secondaryContainer
-            )
-        ) {
-            Column(
-                modifier = Modifier.padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 Text(
-                    text = "💡 Tip",
-                    style = MaterialTheme.typography.labelLarge
+                    text = "Auth",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.primary
                 )
                 Text(
-                    text = "Both APIs provide the same authentication capabilities. Choose based on your app's architecture and control requirements.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                    text = "High-Level API, Low-Level API, Custom Slots & Theming",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Card(modifier = Modifier.fillMaxWidth(), onClick = onStorageClick) {
+            Column(
+                modifier = Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = "Storage",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = "Loading images from Firebase Storage with Glide",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
     }
 }

--- a/app/src/main/java/com/firebaseui/android/demo/auth/AuthChooserActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/AuthChooserActivity.kt
@@ -1,0 +1,253 @@
+package com.firebaseui.android.demo.auth
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+class AuthChooserActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            MaterialTheme {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    AuthChooserScreen(
+                        onHighLevelApiClick = {
+                            startActivity(Intent(this, HighLevelApiDemoActivity::class.java))
+                        },
+                        onLowLevelApiClick = {
+                            startActivity(Intent(this, AuthFlowControllerDemoActivity::class.java))
+                        },
+                        onCustomSlotsClick = {
+                            startActivity(Intent(this, CustomSlotsThemingDemoActivity::class.java))
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun AuthChooserScreen(
+    onHighLevelApiClick: () -> Unit,
+    onLowLevelApiClick: () -> Unit,
+    onCustomSlotsClick: () -> Unit,
+    isEmulatorMode: Boolean = false
+) {
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(scrollState)
+            .systemBarsPadding()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        Spacer(modifier = Modifier.height(16.dp))
+        // Header
+        Text(
+            text = "Firebase Auth UI Compose",
+            style = MaterialTheme.typography.headlineLarge,
+            textAlign = TextAlign.Center
+        )
+
+        Text(
+            text = "Choose a demo to explore different authentication APIs",
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        // Emulator Mode Warning
+        if (isEmulatorMode) {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer
+                )
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        text = "⚠️ Emulator Mode",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onErrorContainer
+                    )
+                    Text(
+                        text = "Running with Firebase Auth Emulator. Some features like third-party" +
+                                " OAuth providers (Facebook, Twitter, LINE etc.) may not work correctly." +
+                                " Disable Firebase Auth Emulator using" +
+                                " MainActivity.USE_AUTH_EMULATOR = false",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onErrorContainer
+                    )
+                }
+            }
+        }
+
+        // High-Level API Card
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = onHighLevelApiClick
+        ) {
+            Column(
+                modifier = Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(
+                    text = "🎨 High-Level API",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = "FirebaseAuthScreen Composable",
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Text(
+                    text = "Best for: Pure Compose applications that want a complete, ready-to-use authentication UI with minimal setup.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Features:",
+                    style = MaterialTheme.typography.labelLarge
+                )
+                Text(
+                    text = "• Drop-in Composable\n• Automatic navigation\n• State management included\n• Customizable content",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        // Low-Level API Card
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = onLowLevelApiClick
+        ) {
+            Column(
+                modifier = Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(
+                    text = "⚙️ Low-Level API",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = "AuthFlowController",
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Text(
+                    text = "Best for: Applications that need fine-grained control over the authentication flow with ActivityResultLauncher integration.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Features:",
+                    style = MaterialTheme.typography.labelLarge
+                )
+                Text(
+                    text = "• Lifecycle-safe controller\n• ActivityResultLauncher\n• Observable state with Flow\n• Manual flow control",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        // Custom Slots & Theming Card
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = onCustomSlotsClick
+        ) {
+            Column(
+                modifier = Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(
+                    text = "🎨 Custom Slots & Theming",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = "Slot APIs & Theme Customization",
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Text(
+                    text = "Best for: Applications that need fully custom UI while leveraging the authentication logic and state management.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Features:",
+                    style = MaterialTheme.typography.labelLarge
+                )
+                Text(
+                    text = "• Custom email auth UI via slots\n• Custom phone auth UI via slots\n• AuthUITheme.fromMaterialTheme()\n• Custom ProviderStyle examples",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Info card
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer
+            )
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = "💡 Tip",
+                    style = MaterialTheme.typography.labelLarge
+                )
+                Text(
+                    text = "Both APIs provide the same authentication capabilities. Choose based on your app's architecture and control requirements.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}

--- a/app/src/main/java/com/firebaseui/android/demo/auth/AuthChooserActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/AuthChooserActivity.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.firebaseui.android.demo.MainActivity
 
 class AuthChooserActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -45,7 +46,11 @@ class AuthChooserActivity : ComponentActivity() {
                         },
                         onCustomSlotsClick = {
                             startActivity(Intent(this, CustomSlotsThemingDemoActivity::class.java))
-                        }
+                        },
+                        onCredentialLinkingClick = {
+                            startActivity(Intent(this, CredentialLinkingDemoActivity::class.java))
+                        },
+                        isEmulatorMode = MainActivity.USE_AUTH_EMULATOR
                     )
                 }
             }
@@ -58,6 +63,7 @@ fun AuthChooserScreen(
     onHighLevelApiClick: () -> Unit,
     onLowLevelApiClick: () -> Unit,
     onCustomSlotsClick: () -> Unit,
+    onCredentialLinkingClick: () -> Unit = {},
     isEmulatorMode: Boolean = false
 ) {
     val scrollState = rememberScrollState()
@@ -218,6 +224,32 @@ fun AuthChooserScreen(
                 Text(
                     text = "• Custom email auth UI via slots\n• Custom phone auth UI via slots\n• AuthUITheme.fromMaterialTheme()\n• Custom ProviderStyle examples",
                     style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        // Credential Linking Card
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = onCredentialLinkingClick
+        ) {
+            Column(
+                modifier = Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(
+                    text = "🔗 Credential Linking",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = "isCredentialLinkingEnabled",
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Text(
+                    text = "Sign in with one provider, then add another to the same account without losing your UID.",
+                    style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }

--- a/app/src/main/java/com/firebaseui/android/demo/auth/AuthFlowControllerDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/AuthFlowControllerDemoActivity.kt
@@ -1,4 +1,4 @@
-package com.firebaseui.android.demo
+package com.firebaseui.android.demo.auth
 
 import android.app.Activity
 import android.content.Context

--- a/app/src/main/java/com/firebaseui/android/demo/auth/CredentialLinkingDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/CredentialLinkingDemoActivity.kt
@@ -1,4 +1,4 @@
-package com.firebaseui.android.demo
+package com.firebaseui.android.demo.auth
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity

--- a/app/src/main/java/com/firebaseui/android/demo/auth/CustomMethodPickerDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/CustomMethodPickerDemoActivity.kt
@@ -1,7 +1,8 @@
-package com.firebaseui.android.demo
+package com.firebaseui.android.demo.auth
 
 import android.os.Bundle
 import android.util.Log
+import com.firebaseui.android.demo.R
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge

--- a/app/src/main/java/com/firebaseui/android/demo/auth/CustomMethodPickerDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/CustomMethodPickerDemoActivity.kt
@@ -2,7 +2,6 @@ package com.firebaseui.android.demo.auth
 
 import android.os.Bundle
 import android.util.Log
-import com.firebaseui.android.demo.R
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -54,6 +53,7 @@ import com.firebase.ui.auth.configuration.theme.ProviderStyleDefaults
 import com.firebase.ui.auth.ui.components.AuthProviderButton
 import com.firebase.ui.auth.ui.method_picker.MethodPickerTermsConfiguration
 import com.firebase.ui.auth.ui.screens.FirebaseAuthScreen
+import com.firebaseui.android.demo.R
 
 class CustomMethodPickerDemoActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/firebaseui/android/demo/auth/CustomSlotsThemingDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/CustomSlotsThemingDemoActivity.kt
@@ -1,4 +1,4 @@
-package com.firebaseui.android.demo
+package com.firebaseui.android.demo.auth
 
 import android.content.Intent
 import android.os.Bundle

--- a/app/src/main/java/com/firebaseui/android/demo/auth/EmailAuthSlotDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/EmailAuthSlotDemoActivity.kt
@@ -1,4 +1,4 @@
-package com.firebaseui.android.demo
+package com.firebaseui.android.demo.auth
 
 import android.os.Bundle
 import android.util.Log

--- a/app/src/main/java/com/firebaseui/android/demo/auth/HighLevelApiDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/HighLevelApiDemoActivity.kt
@@ -1,4 +1,4 @@
-package com.firebaseui.android.demo
+package com.firebaseui.android.demo.auth
 
 import android.os.Bundle
 import android.util.Log
@@ -60,6 +60,7 @@ import com.firebase.ui.auth.ui.screens.FirebaseAuthScreen
 import com.firebase.ui.auth.util.EmailLinkConstants
 import com.firebase.ui.auth.util.displayIdentifier
 import com.firebase.ui.auth.util.getDisplayEmail
+import com.firebaseui.android.demo.R
 import com.google.firebase.auth.actionCodeSettings
 
 class HighLevelApiDemoActivity : ComponentActivity() {

--- a/app/src/main/java/com/firebaseui/android/demo/auth/PhoneAuthSlotDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/PhoneAuthSlotDemoActivity.kt
@@ -1,4 +1,4 @@
-package com.firebaseui.android.demo
+package com.firebaseui.android.demo.auth
 
 import android.os.Bundle
 import android.util.Log

--- a/app/src/main/java/com/firebaseui/android/demo/auth/ShapeCustomizationDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/ShapeCustomizationDemoActivity.kt
@@ -1,4 +1,4 @@
-package com.firebaseui.android.demo
+package com.firebaseui.android.demo.auth
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity

--- a/app/src/main/java/com/firebaseui/android/demo/database/DatabaseDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/database/DatabaseDemoActivity.kt
@@ -108,7 +108,10 @@ class ScoreViewHolder(parent: ViewGroup) : RecyclerView.ViewHolder(
             RecyclerView.LayoutParams.MATCH_PARENT,
             RecyclerView.LayoutParams.WRAP_CONTENT
         )
-        setPadding(48, 24, 48, 24)
+        val density = context.resources.displayMetrics.density
+        val hPadding = (16 * density).toInt()
+        val vPadding = (8 * density).toInt()
+        setPadding(hPadding, vPadding, hPadding, vPadding)
         textSize = 16f
     }
 )

--- a/app/src/main/java/com/firebaseui/android/demo/database/DatabaseDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/database/DatabaseDemoActivity.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.Button
@@ -18,21 +19,29 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.paging.LoadState
 import androidx.paging.PagingConfig
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.firebase.ui.database.paging.DatabasePagingOptions
 import com.firebase.ui.database.paging.FirebaseRecyclerPagingAdapter
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.FirebaseDatabase
 
 class DatabaseDemoActivity : ComponentActivity() {
 
     private lateinit var adapter: ScoreAdapter
+    private var currentPage by mutableIntStateOf(1)
+    private var prevAppendWasLoading = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -47,12 +56,26 @@ class DatabaseDemoActivity : ComponentActivity() {
 
         adapter = ScoreAdapter(options)
 
+        adapter.addLoadStateListener { states ->
+            if (states.refresh is LoadState.Loading) {
+                currentPage = 1
+                prevAppendWasLoading = false
+                return@addLoadStateListener
+            }
+            val appendLoading = states.append is LoadState.Loading
+            if (prevAppendWasLoading && !appendLoading) {
+                currentPage++
+            }
+            prevAppendWasLoading = appendLoading
+        }
+
         setContent {
             MaterialTheme {
                 Surface(modifier = Modifier.fillMaxSize()) {
                     DatabaseDemoScreen(
                         adapter = adapter,
-                        onSeedData = { seedData(ref) },
+                        currentPage = currentPage,
+                        onSeedData = { signInThenSeed(ref) },
                         onRefresh = { adapter.refresh() }
                     )
                 }
@@ -60,8 +83,18 @@ class DatabaseDemoActivity : ComponentActivity() {
         }
     }
 
+    private fun signInThenSeed(ref: DatabaseReference) {
+        val auth = FirebaseAuth.getInstance()
+        val signIn = if (auth.currentUser != null) {
+            com.google.android.gms.tasks.Tasks.forResult(null)
+        } else {
+            auth.signInAnonymously()
+        }
+        signIn.addOnSuccessListener { seedData(ref) }
+    }
+
     private fun seedData(ref: DatabaseReference) {
-        repeat(20) { i ->
+        repeat(50) { i ->
             ref.push().setValue(ScoreItem("Item ${i + 1}", (1..100).random()))
         }
     }
@@ -93,6 +126,7 @@ class ScoreAdapter(options: DatabasePagingOptions<ScoreItem>) :
 @Composable
 fun DatabaseDemoScreen(
     adapter: ScoreAdapter,
+    currentPage: Int,
     onSeedData: () -> Unit,
     onRefresh: () -> Unit,
 ) {
@@ -111,8 +145,20 @@ fun DatabaseDemoScreen(
         )
 
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Button(onClick = onSeedData) { Text("Seed data") }
+            Button(onClick = onSeedData) { Text("Authenticate & Seed Data") }
             OutlinedButton(onClick = onRefresh) { Text("Refresh") }
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                "Page: $currentPage",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         }
 
         AndroidView(
@@ -125,7 +171,9 @@ fun DatabaseDemoScreen(
                     setAdapter(adapter)
                 }
             },
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
         )
     }
 }

--- a/app/src/main/java/com/firebaseui/android/demo/database/DatabaseDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/database/DatabaseDemoActivity.kt
@@ -1,0 +1,131 @@
+package com.firebaseui.android.demo.database
+
+import android.os.Bundle
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.paging.PagingConfig
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.firebase.ui.database.paging.DatabasePagingOptions
+import com.firebase.ui.database.paging.FirebaseRecyclerPagingAdapter
+import com.google.firebase.database.DatabaseReference
+import com.google.firebase.database.FirebaseDatabase
+
+class DatabaseDemoActivity : ComponentActivity() {
+
+    private lateinit var adapter: ScoreAdapter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+
+        val ref = FirebaseDatabase.getInstance().reference.child("database_demo")
+
+        val options = DatabasePagingOptions.Builder<ScoreItem>()
+            .setLifecycleOwner(this)
+            .setQuery(ref.orderByChild("score"), PagingConfig(pageSize = 10), ScoreItem::class.java)
+            .build()
+
+        adapter = ScoreAdapter(options)
+
+        setContent {
+            MaterialTheme {
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    DatabaseDemoScreen(
+                        adapter = adapter,
+                        onSeedData = { seedData(ref) },
+                        onRefresh = { adapter.refresh() }
+                    )
+                }
+            }
+        }
+    }
+
+    private fun seedData(ref: DatabaseReference) {
+        repeat(20) { i ->
+            ref.push().setValue(ScoreItem("Item ${i + 1}", (1..100).random()))
+        }
+    }
+}
+
+data class ScoreItem(var name: String = "", var score: Int = 0)
+
+class ScoreViewHolder(parent: ViewGroup) : RecyclerView.ViewHolder(
+    TextView(parent.context).apply {
+        layoutParams = RecyclerView.LayoutParams(
+            RecyclerView.LayoutParams.MATCH_PARENT,
+            RecyclerView.LayoutParams.WRAP_CONTENT
+        )
+        setPadding(48, 24, 48, 24)
+        textSize = 16f
+    }
+)
+
+class ScoreAdapter(options: DatabasePagingOptions<ScoreItem>) :
+    FirebaseRecyclerPagingAdapter<ScoreItem, ScoreViewHolder>(options) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = ScoreViewHolder(parent)
+
+    override fun onBindViewHolder(holder: ScoreViewHolder, position: Int, model: ScoreItem) {
+        (holder.itemView as TextView).text = "${model.name}  —  score: ${model.score}"
+    }
+}
+
+@Composable
+fun DatabaseDemoScreen(
+    adapter: ScoreAdapter,
+    onSeedData: () -> Unit,
+    onRefresh: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .systemBarsPadding()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text("Firebase Database Paging", style = MaterialTheme.typography.headlineSmall)
+        Text(
+            "Paginated list using FirebaseRecyclerPagingAdapter with orderByChild(\"score\").",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(onClick = onSeedData) { Text("Seed data") }
+            OutlinedButton(onClick = onRefresh) { Text("Refresh") }
+        }
+
+        AndroidView(
+            factory = { context ->
+                RecyclerView(context).apply {
+                    layoutManager = LinearLayoutManager(context)
+                    addItemDecoration(
+                        DividerItemDecoration(context, DividerItemDecoration.VERTICAL)
+                    )
+                    setAdapter(adapter)
+                }
+            },
+            modifier = Modifier.fillMaxSize()
+        )
+    }
+}

--- a/app/src/main/java/com/firebaseui/android/demo/firestore/FirestoreDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/firestore/FirestoreDemoActivity.kt
@@ -98,9 +98,12 @@ class FirestoreDemoActivity : ComponentActivity() {
     }
 
     private fun seedData(collection: CollectionReference) {
+        val batch = collection.firestore.batch()
         for (i in 1..50) {
-            collection.add(ScoreItem("Item $i", (1..100).random()))
+            val docRef = collection.document()
+            batch.set(docRef, ScoreItem("Item $i", (1..100).random()))
         }
+        batch.commit()
     }
 }
 
@@ -112,7 +115,10 @@ class ScoreViewHolder(parent: ViewGroup) : RecyclerView.ViewHolder(
             RecyclerView.LayoutParams.MATCH_PARENT,
             RecyclerView.LayoutParams.WRAP_CONTENT
         )
-        setPadding(48, 24, 48, 24)
+        val density = context.resources.displayMetrics.density
+        val hPadding = (16 * density).toInt()
+        val vPadding = (8 * density).toInt()
+        setPadding(hPadding, vPadding, hPadding, vPadding)
         textSize = 16f
     }
 )

--- a/app/src/main/java/com/firebaseui/android/demo/firestore/FirestoreDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/firestore/FirestoreDemoActivity.kt
@@ -1,0 +1,199 @@
+package com.firebaseui.android.demo.firestore
+
+import android.os.Bundle
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.paging.LoadState
+import androidx.paging.PagingConfig
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.firebase.ui.firestore.paging.FirestorePagingAdapter
+import com.firebase.ui.firestore.paging.FirestorePagingOptions
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
+
+class FirestoreDemoActivity : ComponentActivity() {
+
+    companion object {
+        // Point the app at a local Firestore emulator (firebase emulators:start).
+        // 10.0.2.2 is the Android emulator's alias for the host machine's localhost.
+        private const val USE_FIRESTORE_EMULATOR = true
+        private const val FIRESTORE_EMULATOR_HOST = "10.0.2.2"
+        private const val FIRESTORE_EMULATOR_PORT = 8080
+
+        private var emulatorConfigured = false
+    }
+
+    private lateinit var adapter: ScoreAdapter
+    private var currentPage by mutableIntStateOf(1)
+    private var prevAppendWasLoading = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+
+        val firestore = FirebaseFirestore.getInstance()
+        if (USE_FIRESTORE_EMULATOR && !emulatorConfigured) {
+            firestore.useEmulator(FIRESTORE_EMULATOR_HOST, FIRESTORE_EMULATOR_PORT)
+            emulatorConfigured = true
+        }
+
+        val collection = firestore.collection("firestore_demo")
+
+        // Query must only contain where()/orderBy() — the paging library adds limit().
+        val query: Query = collection.orderBy("score")
+
+        val options = FirestorePagingOptions.Builder<ScoreItem>()
+            .setLifecycleOwner(this)
+            .setQuery(query, PagingConfig(pageSize = 10), ScoreItem::class.java)
+            .build()
+
+        adapter = ScoreAdapter(options)
+
+        adapter.addLoadStateListener { states ->
+            if (states.refresh is LoadState.Loading) {
+                currentPage = 1
+                prevAppendWasLoading = false
+                return@addLoadStateListener
+            }
+            val appendLoading = states.append is LoadState.Loading
+            if (prevAppendWasLoading && !appendLoading) {
+                currentPage++
+            }
+            prevAppendWasLoading = appendLoading
+        }
+
+        setContent {
+            MaterialTheme {
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    FirestoreDemoScreen(
+                        adapter = adapter,
+                        currentPage = currentPage,
+                        onSeedData = { signInThenSeed(collection) },
+                        onRefresh = { adapter.refresh() }
+                    )
+                }
+            }
+        }
+    }
+
+    private fun signInThenSeed(collection: CollectionReference) {
+        val auth = FirebaseAuth.getInstance()
+        val signIn = if (auth.currentUser != null) {
+            com.google.android.gms.tasks.Tasks.forResult(null)
+        } else {
+            auth.signInAnonymously()
+        }
+        signIn.addOnSuccessListener { seedData(collection) }
+    }
+
+    private fun seedData(collection: CollectionReference) {
+        for (i in 1..50) {
+            collection.add(ScoreItem("Item $i", (1..100).random()))
+        }
+    }
+}
+
+data class ScoreItem(var name: String = "", var score: Int = 0)
+
+class ScoreViewHolder(parent: ViewGroup) : RecyclerView.ViewHolder(
+    TextView(parent.context).apply {
+        layoutParams = RecyclerView.LayoutParams(
+            RecyclerView.LayoutParams.MATCH_PARENT,
+            RecyclerView.LayoutParams.WRAP_CONTENT
+        )
+        setPadding(48, 24, 48, 24)
+        textSize = 16f
+    }
+)
+
+class ScoreAdapter(options: FirestorePagingOptions<ScoreItem>) :
+    FirestorePagingAdapter<ScoreItem, ScoreViewHolder>(options) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = ScoreViewHolder(parent)
+
+    override fun onBindViewHolder(holder: ScoreViewHolder, position: Int, model: ScoreItem) {
+        (holder.itemView as TextView).text = "${model.name}  —  score: ${model.score}"
+    }
+}
+
+@Composable
+fun FirestoreDemoScreen(
+    adapter: ScoreAdapter,
+    currentPage: Int,
+    onSeedData: () -> Unit,
+    onRefresh: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .systemBarsPadding()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text("Firebase Firestore Paging", style = MaterialTheme.typography.headlineSmall)
+        Text(
+            "Paginated list using FirestorePagingAdapter with orderBy(\"score\").",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(onClick = onSeedData) { Text("Authenticate & Seed Data") }
+            OutlinedButton(onClick = onRefresh) { Text("Refresh") }
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                "Page: $currentPage",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        AndroidView(
+            factory = { context ->
+                RecyclerView(context).apply {
+                    layoutManager = LinearLayoutManager(context)
+                    addItemDecoration(
+                        DividerItemDecoration(context, DividerItemDecoration.VERTICAL)
+                    )
+                    setAdapter(adapter)
+                }
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+        )
+    }
+}

--- a/app/src/main/java/com/firebaseui/android/demo/firestore/FirestoreDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/firestore/FirestoreDemoActivity.kt
@@ -40,16 +40,6 @@ import com.google.firebase.firestore.Query
 
 class FirestoreDemoActivity : ComponentActivity() {
 
-    companion object {
-        // Point the app at a local Firestore emulator (firebase emulators:start).
-        // 10.0.2.2 is the Android emulator's alias for the host machine's localhost.
-        private const val USE_FIRESTORE_EMULATOR = true
-        private const val FIRESTORE_EMULATOR_HOST = "10.0.2.2"
-        private const val FIRESTORE_EMULATOR_PORT = 8080
-
-        private var emulatorConfigured = false
-    }
-
     private lateinit var adapter: ScoreAdapter
     private var currentPage by mutableIntStateOf(1)
     private var prevAppendWasLoading = false
@@ -58,13 +48,7 @@ class FirestoreDemoActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        val firestore = FirebaseFirestore.getInstance()
-        if (USE_FIRESTORE_EMULATOR && !emulatorConfigured) {
-            firestore.useEmulator(FIRESTORE_EMULATOR_HOST, FIRESTORE_EMULATOR_PORT)
-            emulatorConfigured = true
-        }
-
-        val collection = firestore.collection("firestore_demo")
+        val collection = FirebaseFirestore.getInstance().collection("firestore_demo")
 
         // Query must only contain where()/orderBy() — the paging library adds limit().
         val query: Query = collection.orderBy("score")

--- a/app/src/main/java/com/firebaseui/android/demo/storage/StorageDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/storage/StorageDemoActivity.kt
@@ -52,7 +52,7 @@ class StorageDemoActivity : ComponentActivity() {
 
 @Composable
 fun StorageDemoScreen() {
-    var gsUrl by remember { mutableStateOf("gs://your-project.appspot.com/path/to/image.png") }
+    var gsUrl by remember { mutableStateOf("") }
     var stringStatus by remember { mutableStateOf("Not loaded") }
     var stringLoadKey by remember { mutableIntStateOf(0) }
     var refStatus by remember { mutableStateOf("Not loaded") }
@@ -77,6 +77,7 @@ fun StorageDemoScreen() {
             value = gsUrl,
             onValueChange = { gsUrl = it },
             label = { Text("gs:// URL") },
+            placeholder = { Text("gs://your-project.appspot.com/path/to/image.png") },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true
         )

--- a/app/src/main/java/com/firebaseui/android/demo/storage/StorageDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/storage/StorageDemoActivity.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -54,9 +53,9 @@ class StorageDemoActivity : ComponentActivity() {
 fun StorageDemoScreen() {
     var gsUrl by remember { mutableStateOf("") }
     var stringStatus by remember { mutableStateOf("Not loaded") }
-    var stringLoadKey by remember { mutableIntStateOf(0) }
+    var stringUrlToLoad by remember { mutableStateOf("") }
     var refStatus by remember { mutableStateOf("Not loaded") }
-    var refLoadKey by remember { mutableIntStateOf(0) }
+    var refUrlToLoad by remember { mutableStateOf("") }
 
     Column(
         modifier = Modifier
@@ -96,16 +95,18 @@ fun StorageDemoScreen() {
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Button(onClick = {
-                    stringStatus = "Loading..."
-                    stringLoadKey++
+                    if (gsUrl.isNotEmpty()) {
+                        stringStatus = "Loading..."
+                        stringUrlToLoad = gsUrl
+                    }
                 }) { Text("Load") }
                 StatusText(stringStatus)
                 AndroidView(
                     factory = { ImageView(it) },
                     update = { view ->
-                        if (stringLoadKey > 0) {
+                        if (stringUrlToLoad.isNotEmpty()) {
                             GlideApp.with(view)
-                                .load(gsUrl)
+                                .load(stringUrlToLoad)
                                 .listener(glideListener { success, error ->
                                     stringStatus = if (success) "Loaded" else "Error: $error"
                                 })
@@ -133,16 +134,18 @@ fun StorageDemoScreen() {
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Button(onClick = {
-                    refStatus = "Loading..."
-                    refLoadKey++
+                    if (gsUrl.isNotEmpty()) {
+                        refStatus = "Loading..."
+                        refUrlToLoad = gsUrl
+                    }
                 }) { Text("Load") }
                 StatusText(refStatus)
                 AndroidView(
                     factory = { ImageView(it) },
                     update = { view ->
-                        if (refLoadKey > 0) {
+                        if (refUrlToLoad.isNotEmpty()) {
                             runCatching {
-                                FirebaseStorage.getInstance().getReferenceFromUrl(gsUrl)
+                                FirebaseStorage.getInstance().getReferenceFromUrl(refUrlToLoad)
                             }.onSuccess { ref ->
                                 GlideApp.with(view)
                                     .load(ref)

--- a/app/src/main/java/com/firebaseui/android/demo/storage/StorageDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/storage/StorageDemoActivity.kt
@@ -1,0 +1,200 @@
+package com.firebaseui.android.demo.storage
+
+import android.graphics.drawable.Drawable
+import android.os.Bundle
+import android.widget.ImageView
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.request.RequestListener
+import com.bumptech.glide.request.target.Target
+import com.google.firebase.storage.FirebaseStorage
+
+class StorageDemoActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            MaterialTheme {
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    StorageDemoScreen()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun StorageDemoScreen() {
+    var gsUrl by remember { mutableStateOf("gs://your-project.appspot.com/path/to/image.png") }
+    var stringStatus by remember { mutableStateOf("Not loaded") }
+    var stringLoadKey by remember { mutableIntStateOf(0) }
+    var refStatus by remember { mutableStateOf("Not loaded") }
+    var refLoadKey by remember { mutableIntStateOf(0) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .systemBarsPadding()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text("Firebase Storage + Glide", style = MaterialTheme.typography.headlineSmall)
+        Text(
+            "Enter a gs:// URL and load it using either approach below.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        OutlinedTextField(
+            value = gsUrl,
+            onValueChange = { gsUrl = it },
+            label = { Text("gs:// URL") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true
+        )
+
+        // Approach 1: gs:// string via StringLoader
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text("Via gs:// String", style = MaterialTheme.typography.titleMedium)
+                Text(
+                    "Uses FirebaseImageLoader.StringLoader, registered in StorageGlideModule. " +
+                        "Pass the gs:// URL string directly to Glide.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Button(onClick = {
+                    stringStatus = "Loading..."
+                    stringLoadKey++
+                }) { Text("Load") }
+                StatusText(stringStatus)
+                AndroidView(
+                    factory = { ImageView(it) },
+                    update = { view ->
+                        if (stringLoadKey > 0) {
+                            GlideApp.with(view)
+                                .load(gsUrl)
+                                .listener(glideListener { success, error ->
+                                    stringStatus = if (success) "Loaded" else "Error: $error"
+                                })
+                                .into(view)
+                        }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp)
+                )
+            }
+        }
+
+        // Approach 2: StorageReference
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text("Via StorageReference", style = MaterialTheme.typography.titleMedium)
+                Text(
+                    "Converts the gs:// URL to a StorageReference first, then passes it to Glide. " +
+                        "Handled by FirebaseImageLoader.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Button(onClick = {
+                    refStatus = "Loading..."
+                    refLoadKey++
+                }) { Text("Load") }
+                StatusText(refStatus)
+                AndroidView(
+                    factory = { ImageView(it) },
+                    update = { view ->
+                        if (refLoadKey > 0) {
+                            runCatching {
+                                FirebaseStorage.getInstance().getReferenceFromUrl(gsUrl)
+                            }.onSuccess { ref ->
+                                GlideApp.with(view)
+                                    .load(ref)
+                                    .listener(glideListener { success, error ->
+                                        refStatus = if (success) "Loaded" else "Error: $error"
+                                    })
+                                    .into(view)
+                            }.onFailure { e ->
+                                refStatus = "Invalid URL: ${e.message}"
+                            }
+                        }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusText(status: String) {
+    Text(
+        text = "Status: $status",
+        style = MaterialTheme.typography.bodySmall,
+        color = if (status.startsWith("Error") || status.startsWith("Invalid"))
+            MaterialTheme.colorScheme.error
+        else
+            MaterialTheme.colorScheme.onSurface
+    )
+}
+
+private fun glideListener(onResult: (success: Boolean, error: String?) -> Unit) =
+    object : RequestListener<Drawable> {
+        override fun onLoadFailed(
+            e: GlideException?,
+            model: Any?,
+            target: Target<Drawable>,
+            isFirstResource: Boolean
+        ): Boolean {
+            onResult(false, e?.message ?: "Unknown error")
+            return false
+        }
+
+        override fun onResourceReady(
+            resource: Drawable,
+            model: Any,
+            target: Target<Drawable>,
+            dataSource: DataSource,
+            isFirstResource: Boolean
+        ): Boolean {
+            onResult(true, null)
+            return false
+        }
+    }

--- a/app/src/main/java/com/firebaseui/android/demo/storage/StorageGlideModule.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/storage/StorageGlideModule.kt
@@ -1,0 +1,26 @@
+package com.firebaseui.android.demo.storage
+
+import android.content.Context
+import com.bumptech.glide.Glide
+import com.bumptech.glide.Registry
+import com.bumptech.glide.annotation.GlideModule
+import com.bumptech.glide.module.AppGlideModule
+import com.firebase.ui.storage.images.FirebaseImageLoader
+import com.google.firebase.storage.StorageReference
+import java.io.InputStream
+
+@GlideModule
+class StorageGlideModule : AppGlideModule() {
+    override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
+        registry.append(
+            StorageReference::class.java,
+            InputStream::class.java,
+            FirebaseImageLoader.Factory()
+        )
+        registry.append(
+            String::class.java,
+            InputStream::class.java,
+            FirebaseImageLoader.StringLoader.Factory()
+        )
+    }
+}

--- a/e2eTest/.firebaserc
+++ b/e2eTest/.firebaserc
@@ -1,5 +1,5 @@
 {
   "projects": {
-    "default": "fake-project-id"
+    "default": "flutterfire-e2e-tests"
   }
 }

--- a/e2eTest/.firebaserc
+++ b/e2eTest/.firebaserc
@@ -1,5 +1,5 @@
 {
   "projects": {
-    "default": "flutterfire-e2e-tests"
+    "default": "fake-project-id"
   }
 }

--- a/e2eTest/database.rules.json
+++ b/e2eTest/database.rules.json
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    ".read": true,
+    ".write": true,
+    "database_demo": {
+      ".indexOn": "score"
+    }
+  }
+}

--- a/e2eTest/firebase.json
+++ b/e2eTest/firebase.json
@@ -1,4 +1,7 @@
 {
+  "database": {
+    "rules": "database.rules.json"
+  },
   "emulators": {
     "auth": {
       "port": 9099

--- a/e2eTest/firebase.json
+++ b/e2eTest/firebase.json
@@ -1,7 +1,10 @@
 {
-  "database": {
-    "rules": "database.rules.json"
-  },
+  "database": [
+    {
+      "instance": "flutterfire-e2e-tests-default-rtdb",
+      "rules": "database.rules.json"
+    }
+  ],
   "emulators": {
     "auth": {
       "port": 9099

--- a/e2eTest/firebase.json
+++ b/e2eTest/firebase.json
@@ -3,6 +3,12 @@
     "auth": {
       "port": 9099
     },
+    "firestore": {
+      "port": 8080
+    },
+    "database": {
+      "port": 8199
+    },
     "ui": {
       "enabled": true
     },

--- a/firestore/src/androidTest/java/com/firebase/ui/firestore/paging/FirestorePagingSourceTest.java
+++ b/firestore/src/androidTest/java/com/firebase/ui/firestore/paging/FirestorePagingSourceTest.java
@@ -1,5 +1,6 @@
 package com.firebase.ui.firestore.paging;
 
+import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.Query;
@@ -14,12 +15,15 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import androidx.paging.PagingSource;
 import androidx.paging.PagingSource.LoadParams.Append;
 import androidx.paging.PagingSource.LoadParams.Refresh;
 import androidx.paging.PagingSource.LoadResult.Page;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -103,6 +107,33 @@ public class FirestorePagingSourceTest {
                 pagingSource.loadSingle(appendRequest).blockingGet();
 
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testLoadSingle_interruptedWhileDisposed_doesNotThrowUndeliverableException()
+            throws InterruptedException {
+        FirestorePagingSource pagingSource = new FirestorePagingSource(mMockQuery, Source.DEFAULT);
+        TaskCompletionSource<QuerySnapshot> taskCompletionSource = new TaskCompletionSource<>();
+        when(mMockQuery.get(Source.DEFAULT)).thenReturn(taskCompletionSource.getTask());
+
+        List<Throwable> undeliverableErrors = new CopyOnWriteArrayList<>();
+        RxJavaPlugins.setErrorHandler(undeliverableErrors::add);
+        try {
+            Refresh<PageKey> refreshRequest = new Refresh<>(null, 2, false);
+            Disposable disposable = pagingSource.loadSingle(refreshRequest)
+                    .subscribe(result -> { }, error -> { });
+
+            Thread.sleep(300);
+            disposable.dispose();
+            Thread.sleep(300);
+
+            assertTrue(
+                    "Interruption during an in-flight load must not surface as an "
+                            + "undeliverable RxJava exception: " + undeliverableErrors,
+                    undeliverableErrors.isEmpty());
+        } finally {
+            RxJavaPlugins.setErrorHandler(null);
+        }
     }
 
     private void initMockQuery() {

--- a/firestore/src/main/java/com/firebase/ui/firestore/paging/FirestorePagingSource.java
+++ b/firestore/src/main/java/com/firebase/ui/firestore/paging/FirestorePagingSource.java
@@ -60,6 +60,7 @@ public class FirestorePagingSource extends RxPagingSource<PageKey, DocumentSnaps
                 throw new Exception(e);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+                Log.w(TAG, "FirestorePagingSource load interrupted", e);
                 return new LoadResult.Error<PageKey, DocumentSnapshot>(e);
             }
         }).subscribeOn(Schedulers.io()).onErrorReturn(e -> {

--- a/firestore/src/main/java/com/firebase/ui/firestore/paging/FirestorePagingSource.java
+++ b/firestore/src/main/java/com/firebase/ui/firestore/paging/FirestorePagingSource.java
@@ -1,5 +1,7 @@
 package com.firebase.ui.firestore.paging;
 
+import android.util.Log;
+
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.firestore.DocumentSnapshot;
@@ -18,6 +20,8 @@ import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
 public class FirestorePagingSource extends RxPagingSource<PageKey, DocumentSnapshot> {
+
+    private static final String TAG = "FirestorePagingSource";
 
     private final Query mQuery;
     private final Source mSource;
@@ -54,8 +58,14 @@ public class FirestorePagingSource extends RxPagingSource<PageKey, DocumentSnaps
                 // Only throw a new Exception when the original
                 // Throwable cannot be cast to Exception
                 throw new Exception(e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return new LoadResult.Error<PageKey, DocumentSnapshot>(e);
             }
-        }).subscribeOn(Schedulers.io()).onErrorReturn(LoadResult.Error::new);
+        }).subscribeOn(Schedulers.io()).onErrorReturn(e -> {
+            Log.e(TAG, "FirestorePagingSource load failed", e);
+            return new LoadResult.Error<>(e);
+        });
     }
 
     private LoadResult<PageKey, DocumentSnapshot> toLoadResult(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ material = "1.14.0"
 paging = "3.5.0"
 recyclerview = "1.4.0"
 
-glide = "5.0.9"
+glide = "5.0.7"
 lint = "30.0.0"
 
 junit = "4.13.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -105,6 +105,7 @@ facebook-login = { module = "com.facebook.android:facebook-login", version.ref =
 
 # Misc
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
+glide-compiler = { module = "com.github.bumptech.glide:compiler", version.ref = "glide" }
 googleid = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "googleid" }
 libphonenumber = { module = "com.googlecode.libphonenumber:libphonenumber", version.ref = "libphonenumber" }
 zxing-core = { module = "com.google.zxing:core", version.ref = "zxing" }


### PR DESCRIPTION
Adds demo activities for Realtime Database, Firestore, and Storage to the sample app.

- Move Auth demo activities into an `auth/` subpackage; add `database/`, `firestore/`, `storage/` subpackages
- Add `DatabaseDemoActivity` — paginated list via `FirebaseRecyclerPagingAdapter` + `orderByChild`
- Add `FirestoreDemoActivity` — paginated list via `FirestorePagingAdapter` + `orderBy`, seeded with a `WriteBatch`
- Add `StorageDemoActivity` — loads `gs://` URLs via Glide, both as a raw string (`StringLoader`) and via `StorageReference`
- Wire up Realtime Database, Firestore, and Auth emulator toggles in `MainActivity`

## Preview

[sample-demo.webm](https://github.com/user-attachments/assets/bc19b935-45a1-4413-906f-e4753e55d203)
