### PR TITLE
fix(auth): mitigate tapjacking on the auth activity window

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthActivity.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthActivity.kt
@@ -77,6 +77,7 @@ class FirebaseAuthActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        window.decorView.filterTouchesWhenObscured = true
         enableEdgeToEdge()
 
         // Extract configuration and auth instance from cache using UUID key

--- a/auth/src/main/java/com/firebase/ui/auth/ui/components/ErrorRecoveryDialog.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/components/ErrorRecoveryDialog.kt
@@ -19,7 +19,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.window.DialogProperties
 import com.firebase.ui.auth.AuthException
@@ -80,6 +82,8 @@ fun ErrorRecoveryDialog(
     AlertDialog(
         onDismissRequest = onDismiss,
         title = {
+            val view = LocalView.current
+            SideEffect { view.rootView.filterTouchesWhenObscured = true }
             Text(
                 text = stringProvider.errorDialogTitle,
                 style = MaterialTheme.typography.headlineSmall

--- a/auth/src/main/java/com/firebase/ui/auth/ui/components/ReauthenticationDialog.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/components/ReauthenticationDialog.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -39,6 +40,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -75,6 +77,8 @@ fun ReauthenticationDialog(
     AlertDialog(
         onDismissRequest = { if (!isLoading) onDismiss() },
         title = {
+            val view = LocalView.current
+            SideEffect { view.rootView.filterTouchesWhenObscured = true }
             Text(
                 text = stringProvider.reauthDialogTitle,
                 style = MaterialTheme.typography.headlineSmall

--- a/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthActivityTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthActivityTest.kt
@@ -153,6 +153,16 @@ class FirebaseAuthActivityTest {
         assertThat(shadowActivity.resultCode).isEqualTo(Activity.RESULT_CANCELED)
     }
 
+    @Test
+    fun `activity sets filterTouchesWhenObscured on window after onCreate`() {
+        val intent = FirebaseAuthActivity.createIntent(applicationContext, configuration)
+        val controller = Robolectric.buildActivity(FirebaseAuthActivity::class.java, intent)
+
+        val activity = controller.create().get()
+
+        assertThat(activity.window.decorView.filterTouchesWhenObscured).isTrue()
+    }
+
     // =============================================================================================
     // Configuration Extraction Tests
     // =============================================================================================


### PR DESCRIPTION
## Summary
- Adds `window.decorView.filterTouchesWhenObscured = true` in `FirebaseAuthActivity.onCreate()` to mitigate tapjacking/clickjacking attacks where an overlay intercepts user touches on the auth UI.
- `FirebaseAuthActivity` is the only activity in the auth module (v10 is Compose-based), so this single-line change covers the entire auth flow.

Fixes #2041

## Test plan
- [ ] Launch the auth flow and verify touch input works normally without overlays
- [ ] Verify that touches are ignored when another app draws an overlay on top of the auth UI