### PR TITLE
fix(internal): append CHAR_LIMIT to translation descriptions in export script

### DIFF
--- a/scripts/translations/export_translations.py
+++ b/scripts/translations/export_translations.py
@@ -14,11 +14,24 @@ CHAR_LIMIT_PATTERN = re.compile(r'\[CHAR_LIMIT=\d+\]')
 TRANSLATION_DESC_PATTERN = re.compile(r'(translation_description="[^"]*?)(")')
 XML_TAG_PATTERN = re.compile(r'<[^>]+>')
 STRING_VALUE_PATTERN = re.compile(r'>([^<]*(?:<xliff:g[^>]*>[^<]*</xliff:g>[^<]*)*)</string>')
+ITEM_VALUE_PATTERN = re.compile(r'>([^<]*(?:<xliff:g[^>]*>[^<]*</xliff:g>[^<]*)*)</item>')
+
+XML_ENTITIES = {'&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"', '&apos;': "'"}
+ESCAPE_PATTERN = re.compile(r'\\(u[0-9A-Fa-f]{4}|n|t|\'|")')
+
+
+def _decode_entities(text):
+    """Decode XML entities and Android escape sequences to get true visible length."""
+    for entity, char in XML_ENTITIES.items():
+        text = text.replace(entity, char)
+    text = ESCAPE_PATTERN.sub('X', text)
+    return text
 
 
 def _extract_visible_text(value):
-    """Strip XML tags to get the visible text length."""
-    return XML_TAG_PATTERN.sub('', value).strip()
+    """Strip XML tags and decode entities to get the visible text length."""
+    text = XML_TAG_PATTERN.sub('', value).strip()
+    return _decode_entities(text)
 
 
 def _calculate_char_limit(english_text):
@@ -26,6 +39,23 @@ def _calculate_char_limit(english_text):
     length = len(english_text)
     limit = math.ceil(length * 1.5)
     return int(math.ceil(limit / 5.0) * 5)
+
+
+def _add_char_limit(text, value_pattern):
+    """Add [CHAR_LIMIT=xxx] to translation_description if missing."""
+    if 'translation_description=' not in text:
+        return text
+    if CHAR_LIMIT_PATTERN.search(text):
+        return text
+    match = value_pattern.search(text)
+    if not match:
+        return text
+    visible = _extract_visible_text(match.group(1))
+    if not visible:
+        return text
+    limit = _calculate_char_limit(visible)
+    return TRANSLATION_DESC_PATTERN.sub(
+        r'\1 [CHAR_LIMIT=%d]\2' % limit, text, count=1)
 
 
 class ExportTranslationsScript(BaseStringScript):
@@ -36,14 +66,15 @@ class ExportTranslationsScript(BaseStringScript):
         if PREFIXED_NAME_START in joined:
             joined = joined.replace(PREFIXED_NAME_START, UNPREFIXED_NAME_START)
 
-        if 'translation_description=' in joined and not CHAR_LIMIT_PATTERN.search(joined):
-            match = STRING_VALUE_PATTERN.search(joined)
-            if match:
-                visible = _extract_visible_text(match.group(1))
-                if visible:
-                    limit = _calculate_char_limit(visible)
-                    joined = TRANSLATION_DESC_PATTERN.sub(
-                        r'\1 [CHAR_LIMIT=%d]\2' % limit, joined, count=1)
+        if type == self.TYPE_STR:
+            joined = _add_char_limit(joined, STRING_VALUE_PATTERN)
+        elif type == self.TYPE_PLUR:
+            result_lines = []
+            for l in joined.split('\n'):
+                if '<item ' in l and '</item>' in l:
+                    l = _add_char_limit(l, ITEM_VALUE_PATTERN)
+                result_lines.append(l)
+            joined = '\n'.join(result_lines)
 
         return joined.split('\n')
 

--- a/scripts/translations/export_translations.py
+++ b/scripts/translations/export_translations.py
@@ -1,5 +1,6 @@
 # coding=UTF-8
 
+import math
 import os
 import re
 import sys
@@ -9,6 +10,24 @@ from base_string_script import BaseStringScript
 PREFIXED_NAME_START = 'name="fui_'
 UNPREFIXED_NAME_START = 'name="'
 
+CHAR_LIMIT_PATTERN = re.compile(r'\[CHAR_LIMIT=\d+\]')
+TRANSLATION_DESC_PATTERN = re.compile(r'(translation_description="[^"]*?)(")')
+XML_TAG_PATTERN = re.compile(r'<[^>]+>')
+STRING_VALUE_PATTERN = re.compile(r'>([^<]*(?:<xliff:g[^>]*>[^<]*</xliff:g>[^<]*)*)</string>')
+
+
+def _extract_visible_text(value):
+    """Strip XML tags to get the visible text length."""
+    return XML_TAG_PATTERN.sub('', value).strip()
+
+
+def _calculate_char_limit(english_text):
+    """Return ~1.5x the English text length, rounded up to the nearest 5."""
+    length = len(english_text)
+    limit = math.ceil(length * 1.5)
+    return int(math.ceil(limit / 5.0) * 5)
+
+
 class ExportTranslationsScript(BaseStringScript):
 
     def ProcessTag(self, line, type):
@@ -16,13 +35,20 @@ class ExportTranslationsScript(BaseStringScript):
 
         if PREFIXED_NAME_START in joined:
             joined = joined.replace(PREFIXED_NAME_START, UNPREFIXED_NAME_START)
-            return joined.split('\n')
-        else:
-            return line
+
+        if 'translation_description=' in joined and not CHAR_LIMIT_PATTERN.search(joined):
+            match = STRING_VALUE_PATTERN.search(joined)
+            if match:
+                visible = _extract_visible_text(match.group(1))
+                if visible:
+                    limit = _calculate_char_limit(visible)
+                    joined = TRANSLATION_DESC_PATTERN.sub(
+                        r'\1 [CHAR_LIMIT=%d]\2' % limit, joined, count=1)
+
+        return joined.split('\n')
 
     def WriteFile(self, file_name, file_contents):
-        # Override to just print the contents
-        print file_contents
+        print(file_contents)
 
 if __name__ == '__main__':
     ets = ExportTranslationsScript()

--- a/scripts/translations/export_translations.py
+++ b/scripts/translations/export_translations.py
@@ -17,13 +17,15 @@ STRING_VALUE_PATTERN = re.compile(r'>([^<]*(?:<xliff:g[^>]*>[^<]*</xliff:g>[^<]*
 ITEM_VALUE_PATTERN = re.compile(r'>([^<]*(?:<xliff:g[^>]*>[^<]*</xliff:g>[^<]*)*)</item>')
 
 XML_ENTITIES = {'&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"', '&apos;': "'"}
+ENTITY_PATTERN = re.compile('|'.join(
+    re.escape(k) for k in sorted(XML_ENTITIES, key=len, reverse=True)
+))
 ESCAPE_PATTERN = re.compile(r'\\(u[0-9A-Fa-f]{4}|n|t|\'|")')
 
 
 def _decode_entities(text):
     """Decode XML entities and Android escape sequences to get true visible length."""
-    for entity, char in XML_ENTITIES.items():
-        text = text.replace(entity, char)
+    text = ENTITY_PATTERN.sub(lambda m: XML_ENTITIES[m.group()], text)
     text = ESCAPE_PATTERN.sub('X', text)
     return text
 
@@ -31,7 +33,9 @@ def _decode_entities(text):
 def _extract_visible_text(value):
     """Strip XML tags and decode entities to get the visible text length."""
     text = XML_TAG_PATTERN.sub('', value).strip()
-    return _decode_entities(text)
+    text = _decode_entities(text)
+    text = re.sub(r'\s+', ' ', text).strip()
+    return text
 
 
 def _calculate_char_limit(english_text):
@@ -45,7 +49,8 @@ def _add_char_limit(text, value_pattern):
     """Add [CHAR_LIMIT=xxx] to translation_description if missing."""
     if 'translation_description=' not in text:
         return text
-    if CHAR_LIMIT_PATTERN.search(text):
+    desc_match = TRANSLATION_DESC_PATTERN.search(text)
+    if desc_match and CHAR_LIMIT_PATTERN.search(desc_match.group(1)):
         return text
     match = value_pattern.search(text)
     if not match:

--- a/scripts/translations/export_translations.py
+++ b/scripts/translations/export_translations.py
@@ -69,12 +69,12 @@ class ExportTranslationsScript(BaseStringScript):
         if type == self.TYPE_STR:
             joined = _add_char_limit(joined, STRING_VALUE_PATTERN)
         elif type == self.TYPE_PLUR:
-            result_lines = []
-            for l in joined.split('\n'):
-                if '<item ' in l and '</item>' in l:
-                    l = _add_char_limit(l, ITEM_VALUE_PATTERN)
-                result_lines.append(l)
-            joined = '\n'.join(result_lines)
+            joined = re.sub(
+                r'(<item\s+[^>]*>.*?</item>)',
+                lambda m: _add_char_limit(m.group(1), ITEM_VALUE_PATTERN),
+                joined,
+                flags=re.DOTALL
+            )
 
         return joined.split('\n')
 


### PR DESCRIPTION
## Summary
- Updates `export_translations.py` to automatically append `[CHAR_LIMIT=xxx]` to each `translation_description` that doesn't already have one
- Limit defaults to ~1.5x the English string length, rounded up to the nearest 5
- Handles plurals `<item>` tags individually (each item gets its own limit)
- Decodes XML entities (`&amp;` → `&`) and Android escape sequences (`\'`, `\n`, ` `) before calculating visible text length
- Preserves existing manually-set `[CHAR_LIMIT=...]` values
- Fixes Python 2 `print` statement for Python 3 compatibility

Fixes #1613

## Test plan
- [ ] Run `python3 scripts/translations/export_translations.py` and verify CHAR_LIMIT is appended to all descriptions with visible text
- [ ] Verify strings with existing `[CHAR_LIMIT=...]` are not modified
- [ ] Verify empty override strings (e.g. `fui_error_invalid_credentials`) are correctly skipped
- [ ] Verify plurals items each get their own CHAR_LIMIT