### PR TITLE
fix(auth): handle system back press in phone auth flow

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreen.kt
@@ -16,6 +16,7 @@ package com.firebase.ui.auth.ui.screens.phone
 
 import android.content.Context
 import android.util.Log
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -359,6 +360,7 @@ private fun DefaultPhoneAuthContent(
 ) {
     when (state.step) {
         PhoneAuthStep.EnterPhoneNumber -> {
+            BackHandler { onCancel() }
             EnterPhoneNumberUI(
                 configuration = configuration,
                 isLoading = state.isLoading,
@@ -372,6 +374,7 @@ private fun DefaultPhoneAuthContent(
         }
 
         PhoneAuthStep.EnterVerificationCode -> {
+            BackHandler { state.onChangeNumberClick() }
             EnterVerificationCodeUI(
                 configuration = configuration,
                 isLoading = state.isLoading,

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreen.kt
@@ -341,6 +341,8 @@ fun PhoneAuthScreen(
         }
     )
 
+    BackHandler { onCancel() }
+
     if (content != null) {
         content(state)
     } else {
@@ -360,7 +362,6 @@ private fun DefaultPhoneAuthContent(
 ) {
     when (state.step) {
         PhoneAuthStep.EnterPhoneNumber -> {
-            BackHandler { onCancel() }
             EnterPhoneNumberUI(
                 configuration = configuration,
                 isLoading = state.isLoading,


### PR DESCRIPTION
## Summary
- Adds `BackHandler` to `PhoneAuthScreen` so the system back button is handled consistently for both default and custom phone content
- The base handler delegates to `onCancel()`, which navigates to the method picker or prevents premature activity finish in phone-only flows
- The default UI adds a step-specific override on the verification code screen: system back returns to phone number entry instead of cancelling
- Custom `phoneContent` slots inherit the base behavior and can override with their own `BackHandler`

Fixes #2058

## Test plan
- [ ] Launch phone auth as the only provider — verify system back does not finish the activity
- [ ] Launch phone auth with multiple providers — verify system back returns to method picker
- [ ] On verification code screen — verify system back returns to phone number entry
- [ ] With custom `phoneContent` slot — verify consumer `BackHandler` overrides the default