### PR TITLE
fix(auth): prevent MFA code input from triggering password manager save (#2405)

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/components/VerificationCodeInputField.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/components/VerificationCodeInputField.kt
@@ -292,7 +292,8 @@ private fun SingleDigitField(
                 lineHeight = 24.sp,
             ),
             keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.NumberPassword
+                keyboardType = KeyboardType.Number,
+                autoCorrect = false
             ),
             decorationBox = { innerTextField ->
                 Box(

--- a/auth/src/main/java/com/firebase/ui/auth/ui/components/VerificationCodeInputField.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/components/VerificationCodeInputField.kt
@@ -292,8 +292,7 @@ private fun SingleDigitField(
                 lineHeight = 24.sp,
             ),
             keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Number,
-                autoCorrect = false
+                keyboardType = KeyboardType.Number
             ),
             decorationBox = { innerTextField ->
                 Box(


### PR DESCRIPTION
## Summary

- The `VerificationCodeInputField` component used `KeyboardType.NumberPassword` for each digit's `BasicTextField`. This told Android's autofill framework the field was a password input, causing the password manager to capture an MFA code digit instead of the user's actual account password.
- Changed to `KeyboardType.Number` which continues requesting a numeric keyboard without triggering password-manager save behavior.

Fixes #2405

https://github.com/user-attachments/assets/0e2b0e76-a1d5-4c90-bdab-2c6c2afea89f


## Test plan

- [ ] Enter email/password on the sign-in screen, then proceed to MFA code entry
- [ ] Complete the 6-digit MFA code — verify the password manager does **not** prompt to save/update with a single digit
- [ ] Verify the numeric keyboard still appears when each digit field is focused
- [ ] Verify the TOTP enrollment flow (`VerifyTotpUI`) is unaffected (it already uses `KeyboardType.Number`)
- [ ] Verify phone number verification code entry still works correctly (`EnterVerificationCodeUI` shares `VerificationCodeInputField`)