### PR TITLE
fix(auth): pre-fill email when "Continue as" button is tapped (#2423)

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/method_picker/AuthMethodPicker.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/method_picker/AuthMethodPicker.kt
@@ -82,6 +82,9 @@ class MethodPickerTermsConfiguration(
  * @param providers The list of providers to display.
  * @param logo An optional logo to display.
  * @param onProviderSelected A callback when a provider is selected.
+ * @param onContinueAsSelected A callback when the "Continue as..." button is selected, with the
+ * provider and saved identifier (email, phone number, etc.). Falls back to [onProviderSelected]
+ * if not provided.
  * @param customLayout An optional custom layout composable for the provider buttons.
  * @param termsOfServiceUrl The URL for the Terms of Service.
  * @param privacyPolicyUrl The URL for the Privacy Policy.
@@ -97,12 +100,15 @@ fun AuthMethodPicker(
     providers: List<AuthProvider>,
     logo: AuthUIAsset? = null,
     onProviderSelected: (AuthProvider) -> Unit,
+    onContinueAsSelected: ((AuthProvider, String?) -> Unit)? = null,
     termsOfServiceUrl: String? = null,
     privacyPolicyUrl: String? = null,
     lastSignInPreference: SignInPreferenceManager.SignInPreference? = null,
     customLayout: (@Composable (List<AuthProvider>, (AuthProvider) -> Unit) -> Unit)? = null,
     termsConfiguration: MethodPickerTermsConfiguration? = null,
 ) {
+    val continueAsHandler: (AuthProvider, String?) -> Unit =
+        onContinueAsSelected ?: { provider, _ -> onProviderSelected(provider) }
     val context = LocalContext.current
     val inPreview = LocalInspectionMode.current
     val stringProvider = LocalAuthUIStringProvider.current
@@ -148,7 +154,7 @@ fun AuthMethodPicker(
                                     provider = lastProvider,
                                     identifier = preference.identifier,
                                     enabled = providerButtonsEnabled,
-                                    onClick = { onProviderSelected(lastProvider) }
+                                    onClick = { continueAsHandler(lastProvider, preference.identifier) }
                                 )
                                 Spacer(modifier = Modifier.height(24.dp))
 

--- a/auth/src/main/java/com/firebase/ui/auth/ui/method_picker/AuthMethodPicker.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/method_picker/AuthMethodPicker.kt
@@ -89,7 +89,7 @@ class MethodPickerTermsConfiguration(
  * @param termsConfiguration Optional configuration for a custom ToS/Privacy Policy footer.
  * When provided, replaces the default "By continuing..." text. See [MethodPickerTermsConfiguration].
  * @param onContinueAsSelected A callback when the "Continue as..." button is selected, with the
- * provider and saved identifier (email, phone number, etc.). Falls back to [onProviderSelected]
+ * provider and saved identifier (email address). Falls back to [onProviderSelected]
  * if not provided.
  *
  * @since 10.0.0
@@ -224,7 +224,7 @@ fun AuthMethodPicker(
  * A prominent "Continue as..." button that shows the last-used provider and identifier.
  *
  * @param provider The authentication provider
- * @param identifier The user identifier (email, phone number, etc.)
+ * @param identifier The user identifier (email address)
  * @param onClick Callback when the button is clicked
  */
 @Composable

--- a/auth/src/main/java/com/firebase/ui/auth/ui/method_picker/AuthMethodPicker.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/method_picker/AuthMethodPicker.kt
@@ -82,15 +82,15 @@ class MethodPickerTermsConfiguration(
  * @param providers The list of providers to display.
  * @param logo An optional logo to display.
  * @param onProviderSelected A callback when a provider is selected.
- * @param onContinueAsSelected A callback when the "Continue as..." button is selected, with the
- * provider and saved identifier (email, phone number, etc.). Falls back to [onProviderSelected]
- * if not provided.
  * @param customLayout An optional custom layout composable for the provider buttons.
  * @param termsOfServiceUrl The URL for the Terms of Service.
  * @param privacyPolicyUrl The URL for the Privacy Policy.
  * @param lastSignInPreference The last sign-in preference to show a "Continue as..." button.
  * @param termsConfiguration Optional configuration for a custom ToS/Privacy Policy footer.
  * When provided, replaces the default "By continuing..." text. See [MethodPickerTermsConfiguration].
+ * @param onContinueAsSelected A callback when the "Continue as..." button is selected, with the
+ * provider and saved identifier (email, phone number, etc.). Falls back to [onProviderSelected]
+ * if not provided.
  *
  * @since 10.0.0
  */
@@ -100,12 +100,12 @@ fun AuthMethodPicker(
     providers: List<AuthProvider>,
     logo: AuthUIAsset? = null,
     onProviderSelected: (AuthProvider) -> Unit,
-    onContinueAsSelected: ((AuthProvider, String?) -> Unit)? = null,
     termsOfServiceUrl: String? = null,
     privacyPolicyUrl: String? = null,
     lastSignInPreference: SignInPreferenceManager.SignInPreference? = null,
     customLayout: (@Composable (List<AuthProvider>, (AuthProvider) -> Unit) -> Unit)? = null,
     termsConfiguration: MethodPickerTermsConfiguration? = null,
+    onContinueAsSelected: ((AuthProvider, String?) -> Unit)? = null,
 ) {
     val continueAsHandler: (AuthProvider, String?) -> Unit =
         onContinueAsSelected ?: { provider, _ -> onProviderSelected(provider) }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
@@ -147,6 +147,7 @@ fun FirebaseAuthScreen(
     val pendingReauthState = remember { mutableStateOf<AuthState.ReauthenticationRequired?>(null) }
     val pendingReauthOperation = remember { mutableStateOf<(suspend (android.content.Context) -> Unit)?>(null) }
     val emailLinkFromDifferentDevice = remember { mutableStateOf<String?>(null) }
+    val prefillEmail = remember { mutableStateOf<String?>(null) }
     val lastSignInPreference =
         remember { mutableStateOf<SignInPreferenceManager.SignInPreference?>(null) }
     val startRoute = remember(configuration.providers, configuration.isProviderChoiceAlwaysShown) {
@@ -218,7 +219,14 @@ fun FirebaseAuthScreen(
                             lastSignInPreference = lastSignInPreference.value,
                             customLayout = customMethodPickerLayout,
                             termsConfiguration = customMethodPickerTermsConfiguration,
-                            onProviderSelected = onProviderSelected,
+                            onProviderSelected = { provider ->
+                                prefillEmail.value = null
+                                onProviderSelected(provider)
+                            },
+                            onContinueAsSelected = { provider, identifier ->
+                                prefillEmail.value = identifier
+                                onProviderSelected(provider)
+                            },
                         )
                     }
                 }
@@ -228,6 +236,7 @@ fun FirebaseAuthScreen(
                         context = context,
                         configuration = configuration,
                         authUI = authUI,
+                        prefillEmail = prefillEmail.value,
                         credentialForLinking = pendingLinkingCredential.value,
                         emailLinkFromDifferentDevice = emailLinkFromDifferentDevice.value,
                         onContinueWithProvider = continueWithProvider,

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
@@ -224,7 +224,7 @@ fun FirebaseAuthScreen(
                                 onProviderSelected(provider)
                             },
                             onContinueAsSelected = { provider, identifier ->
-                                prefillEmail.value = identifier
+                                prefillEmail.value = if (provider is AuthProvider.Email) identifier else null
                                 onProviderSelected(provider)
                             },
                         )

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
@@ -129,13 +129,13 @@ fun EmailAuthScreen(
     context: Context,
     configuration: AuthUIConfiguration,
     authUI: FirebaseAuthUI,
-    prefillEmail: String? = null,
     credentialForLinking: AuthCredential? = null,
     emailLinkFromDifferentDevice: String? = null,
     onContinueWithProvider: (String) -> Unit = {},
     onSuccess: (AuthResult) -> Unit,
     onError: (AuthException) -> Unit,
     onCancel: () -> Unit,
+    prefillEmail: String? = null,
     content: @Composable ((EmailAuthContentState) -> Unit)? = null,
 ) {
     val provider = configuration.providers.filterIsInstance<AuthProvider.Email>().first()

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
@@ -129,6 +129,7 @@ fun EmailAuthScreen(
     context: Context,
     configuration: AuthUIConfiguration,
     authUI: FirebaseAuthUI,
+    prefillEmail: String? = null,
     credentialForLinking: AuthCredential? = null,
     emailLinkFromDifferentDevice: String? = null,
     onContinueWithProvider: (String) -> Unit = {},
@@ -150,7 +151,7 @@ fun EmailAuthScreen(
     }
     val mode = rememberSaveable { mutableStateOf(initialMode) }
     val displayNameValue = rememberSaveable { mutableStateOf("") }
-    val emailTextValue = rememberSaveable { mutableStateOf("") }
+    val emailTextValue = rememberSaveable { mutableStateOf(prefillEmail ?: "") }
     val passwordTextValue = rememberSaveable { mutableStateOf("") }
     val confirmPasswordTextValue = rememberSaveable { mutableStateOf("") }
 

--- a/auth/src/test/java/com/firebase/ui/auth/ui/method_picker/AuthMethodPickerTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/method_picker/AuthMethodPickerTest.kt
@@ -24,6 +24,7 @@ import com.firebase.ui.auth.ui.method_picker.MethodPickerTermsConfiguration
 import com.firebase.ui.auth.configuration.string_provider.DefaultAuthUIStringProvider
 import com.firebase.ui.auth.configuration.string_provider.LocalAuthUIStringProvider
 import com.firebase.ui.auth.configuration.theme.AuthUIAsset
+import com.firebase.ui.auth.util.SignInPreferenceManager
 import com.google.common.truth.Truth
 import org.junit.Before
 import org.junit.Rule
@@ -467,5 +468,119 @@ class AuthMethodPickerTest {
         composeTestRule
             .onNodeWithText(context.getString(R.string.fui_sign_in_anonymously))
             .assertIsDisplayed()
+    }
+
+    // =============================================================================================
+    // Continue As Tests
+    // =============================================================================================
+
+    @Test
+    fun `AuthMethodPicker shows ContinueAsButton when lastSignInPreference matches a provider`() {
+        val emailProvider = AuthProvider.Email(
+            emailLinkActionCodeSettings = null,
+            passwordValidationRules = emptyList()
+        )
+        val preference = SignInPreferenceManager.SignInPreference(
+            providerId = emailProvider.providerId,
+            identifier = "user@example.com",
+            timestamp = 0L
+        )
+
+        setContentWithStringProvider {
+            AuthMethodPicker(
+                providers = listOf(emailProvider),
+                onProviderSelected = { selectedProvider = it },
+                lastSignInPreference = preference
+            )
+        }
+
+        composeTestRule
+            .onNodeWithTag("ContinueAsButton")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `AuthMethodPicker hides ContinueAsButton when lastSignInPreference has no matching provider`() {
+        val preference = SignInPreferenceManager.SignInPreference(
+            providerId = "some.unlisted.provider",
+            identifier = "user@example.com",
+            timestamp = 0L
+        )
+
+        setContentWithStringProvider {
+            AuthMethodPicker(
+                providers = listOf(
+                    AuthProvider.Google(scopes = emptyList(), serverClientId = null)
+                ),
+                onProviderSelected = { selectedProvider = it },
+                lastSignInPreference = preference
+            )
+        }
+
+        composeTestRule
+            .onNodeWithTag("ContinueAsButton")
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `AuthMethodPicker calls onContinueAsSelected with provider and identifier when ContinueAsButton is clicked`() {
+        val emailProvider = AuthProvider.Email(
+            emailLinkActionCodeSettings = null,
+            passwordValidationRules = emptyList()
+        )
+        val preference = SignInPreferenceManager.SignInPreference(
+            providerId = emailProvider.providerId,
+            identifier = "user@example.com",
+            timestamp = 0L
+        )
+        var continueAsProvider: AuthProvider? = null
+        var continueAsIdentifier: String? = null
+
+        setContentWithStringProvider {
+            AuthMethodPicker(
+                providers = listOf(emailProvider),
+                onProviderSelected = { selectedProvider = it },
+                lastSignInPreference = preference,
+                onContinueAsSelected = { provider, identifier ->
+                    continueAsProvider = provider
+                    continueAsIdentifier = identifier
+                }
+            )
+        }
+
+        composeTestRule
+            .onNodeWithTag("ContinueAsButton")
+            .performClick()
+
+        Truth.assertThat(continueAsProvider).isEqualTo(emailProvider)
+        Truth.assertThat(continueAsIdentifier).isEqualTo("user@example.com")
+        Truth.assertThat(selectedProvider).isNull()
+    }
+
+    @Test
+    fun `AuthMethodPicker falls back to onProviderSelected when onContinueAsSelected is not provided`() {
+        val emailProvider = AuthProvider.Email(
+            emailLinkActionCodeSettings = null,
+            passwordValidationRules = emptyList()
+        )
+        val preference = SignInPreferenceManager.SignInPreference(
+            providerId = emailProvider.providerId,
+            identifier = "user@example.com",
+            timestamp = 0L
+        )
+
+        setContentWithStringProvider {
+            AuthMethodPicker(
+                providers = listOf(emailProvider),
+                onProviderSelected = { selectedProvider = it },
+                lastSignInPreference = preference
+            )
+        }
+
+        composeTestRule
+            .onNodeWithTag("ContinueAsButton")
+            .performClick()
+
+        Truth.assertThat(selectedProvider).isEqualTo(emailProvider)
     }
 }

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/SignInUITest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/SignInUITest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens.email
+
+import android.content.Context
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import com.firebase.ui.auth.configuration.authUIConfiguration
+import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.configuration.string_provider.AuthUIStringProvider
+import com.firebase.ui.auth.configuration.string_provider.DefaultAuthUIStringProvider
+import com.firebase.ui.auth.configuration.string_provider.LocalAuthUIStringProvider
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(sdk = [34])
+@RunWith(RobolectricTestRunner::class)
+class SignInUITest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var applicationContext: Context
+    private lateinit var stringProvider: AuthUIStringProvider
+
+    @Before
+    fun setUp() {
+        applicationContext = ApplicationProvider.getApplicationContext()
+        stringProvider = DefaultAuthUIStringProvider(applicationContext)
+    }
+
+    @Test
+    fun `email field is pre-filled when initial email value is provided`() {
+        val prefillEmail = "user@example.com"
+        val provider = AuthProvider.Email(
+            isDisplayNameRequired = false,
+            emailLinkActionCodeSettings = null,
+            passwordValidationRules = emptyList()
+        )
+        val configuration = authUIConfiguration {
+            context = applicationContext
+            providers { provider(provider) }
+        }
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalAuthUIStringProvider provides stringProvider) {
+                SignInUI(
+                    configuration = configuration,
+                    isLoading = false,
+                    emailSignInLinkSent = false,
+                    email = prefillEmail,
+                    password = "",
+                    onEmailChange = { },
+                    onPasswordChange = { },
+                    onRetrievedCredential = { },
+                    onSignInClick = { },
+                    onGoToSignUp = { },
+                    onGoToResetPassword = { },
+                    onGoToEmailLinkSignIn = { },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(prefillEmail).assertExists()
+    }
+
+    @Test
+    fun `email field is empty when no initial email value is provided`() {
+        val provider = AuthProvider.Email(
+            isDisplayNameRequired = false,
+            emailLinkActionCodeSettings = null,
+            passwordValidationRules = emptyList()
+        )
+        val configuration = authUIConfiguration {
+            context = applicationContext
+            providers { provider(provider) }
+        }
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalAuthUIStringProvider provides stringProvider) {
+                SignInUI(
+                    configuration = configuration,
+                    isLoading = false,
+                    emailSignInLinkSent = false,
+                    email = "",
+                    password = "",
+                    onEmailChange = { },
+                    onPasswordChange = { },
+                    onRetrievedCredential = { },
+                    onSignInClick = { },
+                    onGoToSignUp = { },
+                    onGoToResetPassword = { },
+                    onGoToEmailLinkSignIn = { },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("user@example.com").assertDoesNotExist()
+    }
+}


### PR DESCRIPTION
## Summary

- The "Continue as…" button in `AuthMethodPicker` displayed the saved email/identifier but discarded it on click — the user landed on a blank email form identical to tapping the regular provider button.
- Added an `onContinueAsSelected` callback to `AuthMethodPicker` that carries the saved identifier through to `EmailAuthScreen`, which now pre-fills the email field with the saved address.
- Regular provider button taps clear the pre-fill so the two paths remain distinct.

Fixes #2423

https://github.com/user-attachments/assets/07467e54-b7e5-4a98-8488-0e8c5323310a
 
## Test plan

- [ ] Sign in with email, sign out, return to the auth method picker
- [ ] Tap the "Continue as <email>" button — verify the email field is pre-filled with the saved address
- [ ] Tap the regular "Sign in with email" button below the divider — verify the email field is empty
- [ ] Verify federated providers (Google, Facebook, etc.) are unaffected by the change
- [ ] Verify custom layouts via `customLayout` still work (they don't receive `onContinueAsSelected`)