### PR TITLE
fix(auth): use fixed padding for method picker provider buttons (#2424)

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/method_picker/AuthMethodPicker.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/method_picker/AuthMethodPicker.kt
@@ -16,7 +16,6 @@ package com.firebase.ui.auth.ui.method_picker
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -24,6 +23,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.HorizontalDivider
@@ -128,14 +128,15 @@ fun AuthMethodPicker(
                 customLayout(providers, onProviderSelected)
             }
         } else {
-            BoxWithConstraints(
+            Box(
                 modifier = Modifier
                     .weight(1f),
+                contentAlignment = Alignment.TopCenter,
             ) {
-                val paddingWidth = maxWidth.value * 0.23
                 LazyColumn(
                     modifier = Modifier
-                        .padding(horizontal = paddingWidth.dp)
+                        .widthIn(max = 400.dp)
+                        .padding(horizontal = 24.dp)
                         .testTag("AuthMethodPicker LazyColumn"),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {

--- a/auth/src/main/java/com/firebase/ui/auth/ui/method_picker/AuthMethodPicker.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/method_picker/AuthMethodPicker.kt
@@ -130,6 +130,7 @@ fun AuthMethodPicker(
         } else {
             Box(
                 modifier = Modifier
+                    .fillMaxWidth()
                     .weight(1f),
                 contentAlignment = Alignment.TopCenter,
             ) {


### PR DESCRIPTION
## Summary

- Provider button labels (e.g. "Sign in with Facebook") were truncating on standard phone displays because `AuthMethodPicker` used percentage-based horizontal padding (23% of screen width), leaving only ~54% of the screen for button content.
- Replaced with fixed 24dp horizontal padding and a 400dp max-width constraint. This keeps buttons readable on phones while capping width on tablets.



Fixes #2424

<img width="336" height="761" alt="Screenshot 2026-07-27 at 12 22 27" src="https://github.com/user-attachments/assets/0369a36c-0ebb-41ed-be72-3ebec1f25034" />


## Test plan

- [ ] Open the auth method picker on a standard phone (~360dp wide) — verify "Sign in with Facebook" and other labels display fully without ellipsis
- [ ] Open on a tablet or wide screen — verify buttons are capped at a reasonable width and centered
- [ ] Test with larger font-size accessibility settings — verify labels still fit
- [ ] Verify the "Continue as…" button (if present) also benefits from the wider layout
- [ ] Test with localized labels (e.g. German) if possible