### PR TITLE
ci: add needs-attention labeling automation

### DIFF
--- a/.github/workflows/issue-labels.yaml
+++ b/.github/workflows/issue-labels.yaml
@@ -16,7 +16,7 @@ jobs:
       issues: write
     steps:
       - name: Add needs-attention label on creation
-        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             await github.rest.issues.addLabels({
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Check if the comment is from the issue author
         id: check-op
-        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const isOpComment =
@@ -44,7 +44,7 @@ jobs:
 
       - name: Update labels when the issue author responded on an open item
         if: steps.check-op.outputs.op_comment == 'true' && github.event.issue.state == 'open'
-        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const issueNumber = context.payload.issue.number;
@@ -69,7 +69,7 @@ jobs:
 
       - name: Comment when the issue author responded on a closed item
         if: steps.check-op.outputs.op_comment == 'true' && github.event.issue.state == 'closed'
-        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             await github.rest.issues.createComment({

--- a/.github/workflows/issue-labels.yaml
+++ b/.github/workflows/issue-labels.yaml
@@ -5,17 +5,15 @@ on:
     types: [created]
   issues:
     types: [opened]
-  pull_request_target:
-    types: [opened]
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
-  label-new-item:
-    if: github.event_name == 'issues' || github.event_name == 'pull_request_target'
+  label-new-issue:
+    if: github.event_name == 'issues'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Add needs-attention label on creation
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -31,6 +29,8 @@ jobs:
   label-op-response:
     if: github.event_name == 'issue_comment'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Check if the comment is from the issue author
         id: check-op

--- a/.github/workflows/issue-labels.yaml
+++ b/.github/workflows/issue-labels.yaml
@@ -1,0 +1,84 @@
+name: Update labels on issues and pull requests
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  label-new-item:
+    if: github.event_name == 'issues' || github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add needs-attention label on creation
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['needs-attention'],
+            });
+
+  label-op-response:
+    if: github.event_name == 'issue_comment'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if the comment is from the issue author
+        id: check-op
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        with:
+          script: |
+            const isOpComment =
+              context.payload.comment.user.login ===
+              context.payload.issue.user.login;
+            core.setOutput('op_comment', isOpComment ? 'true' : 'false');
+
+      - name: Update labels when the issue author responded on an open item
+        if: steps.check-op.outputs.op_comment == 'true' && github.event.issue.state == 'open'
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        with:
+          script: |
+            const issueNumber = context.payload.issue.number;
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: ['needs-attention'],
+            });
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                name: 'blocked: await customer response',
+              });
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+
+      - name: Comment when the issue author responded on a closed item
+        if: steps.check-op.outputs.op_comment == 'true' && github.event.issue.state == 'closed'
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: [
+                'This item is closed, so it may not receive regular attention.',
+                '',
+                'If it is still relevant, please open a new issue with an up-to-date reproduction, or open a new pull request.',
+              ].join('\n'),
+            });


### PR DESCRIPTION
## Summary
- Adds an `issue_comment` + `issues:opened` workflow, mirroring the same automation added to [react-native-firebase](https://github.com/invertase/react-native-firebase/blob/main/.github/workflows/issue-labels.yaml), [firebaseui-web#1426](https://github.com/firebase/firebaseui-web/pull/1426), and [FirebaseUI-iOS#1380](https://github.com/firebase/FirebaseUI-iOS/pull/1380):
  - **On creation**: newly opened issues immediately get the existing `needs-attention` label.
  - **On an OP comment, open item** (issue or PR): (re-)adds `needs-attention` and removes `blocked: await customer response` (if present).
  - **On an OP comment, closed item**: posts a short comment noting the item is closed and suggesting a new issue/PR if still relevant.
- Uses only the default `GITHUB_TOKEN`, with `permissions: {}` at the workflow level and `issues: write` scoped per-job (no `pull-requests: write` — every call here goes through the Issues API regardless of whether the target is an issue or PR). No repository/org settings changes required.
- `actions/github-script` is pinned to the underlying commit SHA for `v9.0.0` rather than the annotated tag object's SHA (which 422s on a plain commit lookup and trips zizmor's impostor-commit check).

## Notes
- This repo already has both `needs-attention` and `blocked: await customer response` labels, so no manual label setup is needed.
- An earlier revision of this PR also labeled newly opened PRs immediately via `pull_request_target`, but this repo's mandatory `zizmor` security scan flags `pull_request_target` as a fundamentally insecure trigger — it can't be made safe enough for that gate, so it was dropped. New PRs still get labeled as soon as the OP comments, via the existing `issue_comment` flow.

## Test plan
- [ ] Merge to `master`, then open a new issue and confirm it's immediately labeled `needs-attention`.
- [ ] Comment as the issue/PR author on an open issue/PR and confirm labels swap as expected.
- [ ] Comment as the author on a closed issue and confirm the explanatory comment is posted.