### PR TITLE
fix(auth): report Google/Facebook/OAuth/Anonymous sign-in failures via onSignInFailure

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/AuthException.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthException.kt
@@ -513,6 +513,14 @@ abstract class AuthException(
                             cause = firebaseException
                         )
 
+                        // FirebaseAuthWebException code for backing out of the OAuth custom tab
+                        "ERROR_WEB_CONTEXT_CANCELED" -> AuthCancelledException(
+                            message = stringProvider?.errorAuthCancelled.nonEmpty()
+                                ?: firebaseException.message
+                                ?: "Authentication was cancelled",
+                            cause = firebaseException
+                        )
+
                         else -> UnknownException(
                             message = stringProvider?.errorUnknownAuth.nonEmpty()
                                 ?: firebaseException.message

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProvider+FirebaseAuthUI.kt
@@ -1,7 +1,6 @@
 package com.firebase.ui.auth.configuration.auth_provider
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
@@ -28,20 +27,18 @@ internal fun FirebaseAuthUI.rememberAnonymousSignInHandler(
 ): () -> Unit {
     val context = androidx.compose.ui.platform.LocalContext.current
     val coroutineScope = rememberCoroutineScope()
-    return remember(this) {
-        {
-            coroutineScope.launch {
-                try {
-                    signInAnonymously(config)
-                } catch (e: AuthException) {
-                    // Already an AuthException, don't re-wrap it
-                    updateAuthState(AuthState.Error(e))
-                    onSignInFailure(e)
-                } catch (e: Exception) {
-                    val authException = AuthException.from(e, context)
-                    updateAuthState(AuthState.Error(authException))
-                    onSignInFailure(authException)
-                }
+    return {
+        coroutineScope.launch {
+            try {
+                signInAnonymously(config)
+            } catch (e: AuthException) {
+                // Already an AuthException, don't re-wrap it
+                updateAuthState(AuthState.Error(e))
+                onSignInFailure(e)
+            } catch (e: Exception) {
+                val authException = AuthException.from(e, context)
+                updateAuthState(AuthState.Error(authException))
+                onSignInFailure(authException)
             }
         }
     }

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProvider+FirebaseAuthUI.kt
@@ -14,13 +14,18 @@ import kotlinx.coroutines.tasks.await
 /**
  * Creates a remembered launcher function for anonymous sign-in.
  *
+ * @param config Authentication UI configuration
+ * @param onSignInFailure Callback invoked with the resulting [AuthException] on failure
  * @return A launcher function that starts the anonymous sign-in flow when invoked
  *
  * @see signInAnonymously
  * @see createOrLinkUserWithEmailAndPassword for upgrading anonymous accounts
  */
 @Composable
-internal fun FirebaseAuthUI.rememberAnonymousSignInHandler(config: AuthUIConfiguration): () -> Unit {
+internal fun FirebaseAuthUI.rememberAnonymousSignInHandler(
+    config: AuthUIConfiguration,
+    onSignInFailure: (AuthException) -> Unit = {},
+): () -> Unit {
     val context = androidx.compose.ui.platform.LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     return remember(this) {
@@ -31,9 +36,11 @@ internal fun FirebaseAuthUI.rememberAnonymousSignInHandler(config: AuthUIConfigu
                 } catch (e: AuthException) {
                     // Already an AuthException, don't re-wrap it
                     updateAuthState(AuthState.Error(e))
+                    onSignInFailure(e)
                 } catch (e: Exception) {
                     val authException = AuthException.from(e, context)
                     updateAuthState(AuthState.Error(authException))
+                    onSignInFailure(authException)
                 }
             }
         }

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProvider+FirebaseAuthUI.kt
@@ -34,11 +34,11 @@ internal fun FirebaseAuthUI.rememberAnonymousSignInHandler(
             } catch (e: AuthException) {
                 // Already an AuthException, don't re-wrap it
                 updateAuthState(AuthState.Error(e))
-                onSignInFailure(e)
+                if (e !is AuthException.AuthCancelledException) onSignInFailure(e)
             } catch (e: Exception) {
                 val authException = AuthException.from(e, context)
                 updateAuthState(AuthState.Error(authException))
-                onSignInFailure(authException)
+                if (authException !is AuthException.AuthCancelledException) onSignInFailure(authException)
             }
         }
     }

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/FacebookAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/FacebookAuthProvider+FirebaseAuthUI.kt
@@ -116,7 +116,7 @@ internal fun FirebaseAuthUI.rememberSignInWithFacebookLauncher(
                             authException
                         )
                     )
-                    currentOnSignInFailure(authException)
+                    if (authException !is AuthException.AuthCancelledException) currentOnSignInFailure(authException)
                 }
             })
 

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/FacebookAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/FacebookAuthProvider+FirebaseAuthUI.kt
@@ -19,8 +19,10 @@ import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import com.facebook.AccessToken
 import com.facebook.CallbackManager
 import com.facebook.FacebookCallback
@@ -64,6 +66,10 @@ internal fun FirebaseAuthUI.rememberSignInWithFacebookLauncher(
     val coroutineScope = rememberCoroutineScope()
     val callbackManager = remember { CallbackManager.Factory.create() }
     val loginManager = LoginManager.getInstance()
+    val currentContext by rememberUpdatedState(context)
+    val currentConfig by rememberUpdatedState(config)
+    val currentProvider by rememberUpdatedState(provider)
+    val currentOnSignInFailure by rememberUpdatedState(onSignInFailure)
 
     val launcher = rememberLauncherForActivityResult(
         loginManager.createLogInActivityResultContract(
@@ -73,7 +79,7 @@ internal fun FirebaseAuthUI.rememberSignInWithFacebookLauncher(
         onResult = {},
     )
 
-    DisposableEffect(config) {
+    DisposableEffect(Unit) {
         loginManager.registerCallback(
             callbackManager,
             object : FacebookCallback<LoginResult> {
@@ -81,19 +87,19 @@ internal fun FirebaseAuthUI.rememberSignInWithFacebookLauncher(
                     coroutineScope.launch {
                         try {
                             signInWithFacebook(
-                                context = context,
-                                config = config,
-                                provider = provider,
+                                context = currentContext,
+                                config = currentConfig,
+                                provider = currentProvider,
                                 accessToken = result.accessToken,
                             )
                         } catch (e: AuthException) {
                             // Already an AuthException, don't re-wrap it
                             updateAuthState(AuthState.Error(e))
-                            onSignInFailure(e)
+                            currentOnSignInFailure(e)
                         } catch (e: Exception) {
-                            val authException = AuthException.from(e, context)
+                            val authException = AuthException.from(e, currentContext)
                             updateAuthState(AuthState.Error(authException))
-                            onSignInFailure(authException)
+                            currentOnSignInFailure(authException)
                         }
                     }
                 }
@@ -104,13 +110,13 @@ internal fun FirebaseAuthUI.rememberSignInWithFacebookLauncher(
 
                 override fun onError(error: FacebookException) {
                     Log.e("FacebookAuthProvider", "Error during Facebook sign in", error)
-                    val authException = AuthException.from(error, context)
+                    val authException = AuthException.from(error, currentContext)
                     updateAuthState(
                         AuthState.Error(
                             authException
                         )
                     )
-                    onSignInFailure(authException)
+                    currentOnSignInFailure(authException)
                 }
             })
 

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/FacebookAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/FacebookAuthProvider+FirebaseAuthUI.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.launch
  * @param config The [AuthUIConfiguration] containing authentication settings
  * @param provider The [AuthProvider.Facebook] configuration with scopes and credential provider
  * @param loginManagerProvider Provides logout operations to clear stale Facebook sessions
+ * @param onSignInFailure Callback invoked with the resulting [AuthException] on failure
  *
  * @return A launcher function that starts the Facebook sign-in flow when invoked
  *
@@ -58,6 +59,7 @@ internal fun FirebaseAuthUI.rememberSignInWithFacebookLauncher(
     config: AuthUIConfiguration,
     provider: AuthProvider.Facebook,
     loginManagerProvider: AuthProvider.Facebook.LoginManagerProvider = AuthProvider.Facebook.DefaultLoginManagerProvider(),
+    onSignInFailure: (AuthException) -> Unit = {},
 ): () -> Unit {
     val coroutineScope = rememberCoroutineScope()
     val callbackManager = remember { CallbackManager.Factory.create() }
@@ -87,9 +89,11 @@ internal fun FirebaseAuthUI.rememberSignInWithFacebookLauncher(
                         } catch (e: AuthException) {
                             // Already an AuthException, don't re-wrap it
                             updateAuthState(AuthState.Error(e))
+                            onSignInFailure(e)
                         } catch (e: Exception) {
                             val authException = AuthException.from(e, context)
                             updateAuthState(AuthState.Error(authException))
+                            onSignInFailure(authException)
                         }
                     }
                 }
@@ -106,6 +110,7 @@ internal fun FirebaseAuthUI.rememberSignInWithFacebookLauncher(
                             authException
                         )
                     )
+                    onSignInFailure(authException)
                 }
             })
 

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/FacebookAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/FacebookAuthProvider+FirebaseAuthUI.kt
@@ -95,11 +95,11 @@ internal fun FirebaseAuthUI.rememberSignInWithFacebookLauncher(
                         } catch (e: AuthException) {
                             // Already an AuthException, don't re-wrap it
                             updateAuthState(AuthState.Error(e))
-                            currentOnSignInFailure(e)
+                            if (e !is AuthException.AuthCancelledException) currentOnSignInFailure(e)
                         } catch (e: Exception) {
                             val authException = AuthException.from(e, currentContext)
                             updateAuthState(AuthState.Error(authException))
-                            currentOnSignInFailure(authException)
+                            if (authException !is AuthException.AuthCancelledException) currentOnSignInFailure(authException)
                         }
                     }
                 }

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProvider+FirebaseAuthUI.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.launch
  * @param context Android context for Credential Manager
  * @param config Authentication UI configuration
  * @param provider Google provider configuration with server client ID and optional scopes
+ * @param onSignInFailure Callback invoked with the resulting [AuthException] on failure
  * @return A callback function that initiates Google Sign-In when invoked
  *
  * @see signInWithGoogle
@@ -57,6 +58,7 @@ internal fun FirebaseAuthUI.rememberGoogleSignInHandler(
     context: Context,
     config: AuthUIConfiguration,
     provider: AuthProvider.Google,
+    onSignInFailure: (AuthException) -> Unit = {},
 ): () -> Unit {
     val coroutineScope = rememberCoroutineScope()
     return remember(this, config) {
@@ -66,9 +68,11 @@ internal fun FirebaseAuthUI.rememberGoogleSignInHandler(
                     signInWithGoogle(context, config, provider)
                 } catch (e: AuthException) {
                     updateAuthState(AuthState.Error(e))
+                    onSignInFailure(e)
                 } catch (e: Exception) {
                     val authException = AuthException.from(e, context)
                     updateAuthState(AuthState.Error(authException))
+                    onSignInFailure(authException)
                 }
             }
         }

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProvider+FirebaseAuthUI.kt
@@ -3,7 +3,6 @@ package com.firebase.ui.auth.configuration.auth_provider
 import android.content.Context
 import android.util.Log
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.credentials.CredentialManager
 import androidx.credentials.exceptions.GetCredentialException
@@ -61,19 +60,17 @@ internal fun FirebaseAuthUI.rememberGoogleSignInHandler(
     onSignInFailure: (AuthException) -> Unit = {},
 ): () -> Unit {
     val coroutineScope = rememberCoroutineScope()
-    return remember(this, config) {
-        {
-            coroutineScope.launch {
-                try {
-                    signInWithGoogle(context, config, provider)
-                } catch (e: AuthException) {
-                    updateAuthState(AuthState.Error(e))
-                    onSignInFailure(e)
-                } catch (e: Exception) {
-                    val authException = AuthException.from(e, context)
-                    updateAuthState(AuthState.Error(authException))
-                    onSignInFailure(authException)
-                }
+    return {
+        coroutineScope.launch {
+            try {
+                signInWithGoogle(context, config, provider)
+            } catch (e: AuthException) {
+                updateAuthState(AuthState.Error(e))
+                onSignInFailure(e)
+            } catch (e: Exception) {
+                val authException = AuthException.from(e, context)
+                updateAuthState(AuthState.Error(authException))
+                onSignInFailure(authException)
             }
         }
     }

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProvider+FirebaseAuthUI.kt
@@ -66,11 +66,11 @@ internal fun FirebaseAuthUI.rememberGoogleSignInHandler(
                 signInWithGoogle(context, config, provider)
             } catch (e: AuthException) {
                 updateAuthState(AuthState.Error(e))
-                onSignInFailure(e)
+                if (e !is AuthException.AuthCancelledException) onSignInFailure(e)
             } catch (e: Exception) {
                 val authException = AuthException.from(e, context)
                 updateAuthState(AuthState.Error(authException))
-                onSignInFailure(authException)
+                if (authException !is AuthException.AuthCancelledException) onSignInFailure(authException)
             }
         }
     }

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProvider+FirebaseAuthUI.kt
@@ -22,8 +22,8 @@ import kotlinx.coroutines.launch
  * Creates a remembered callback for Google Sign-In that can be invoked from UI components.
  *
  * This Composable function returns a lambda that, when invoked, initiates the Google Sign-In
- * flow using [signInWithGoogle]. The callback is stable across recompositions and automatically
- * handles coroutine scoping and error state management.
+ * flow using [signInWithGoogle]. The callback is rebuilt on every recomposition so it always
+ * captures the latest parameters, and handles coroutine scoping and error state management.
  *
  * **Usage:**
  * ```kotlin

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.tasks.await
  *
  * @param config Authentication UI configuration
  * @param provider OAuth provider configuration
+ * @param onSignInFailure Callback invoked with the resulting [AuthException] on failure
  *
  * @return Lambda that triggers OAuth sign-in when invoked
  *
@@ -54,6 +55,7 @@ internal fun FirebaseAuthUI.rememberOAuthSignInHandler(
     activity: Activity?,
     config: AuthUIConfiguration,
     provider: AuthProvider.OAuth,
+    onSignInFailure: (AuthException) -> Unit = {},
 ): () -> Unit {
     val coroutineScope = rememberCoroutineScope()
     activity ?: throw IllegalStateException(
@@ -73,9 +75,11 @@ internal fun FirebaseAuthUI.rememberOAuthSignInHandler(
                     )
                 } catch (e: AuthException) {
                     updateAuthState(AuthState.Error(e))
+                    onSignInFailure(e)
                 } catch (e: Exception) {
                     val authException = AuthException.from(e, context)
                     updateAuthState(AuthState.Error(authException))
+                    onSignInFailure(authException)
                 }
             }
         }

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
@@ -20,8 +20,9 @@ import kotlinx.coroutines.tasks.await
 /**
  * Creates a Composable handler for OAuth provider sign-in.
  *
- * This function creates a remember-scoped sign-in handler that can be invoked
- * from button clicks or other UI events. It automatically handles:
+ * This function creates a sign-in handler, rebuilt on every recomposition so it always
+ * captures the latest parameters, that can be invoked from button clicks or other UI events.
+ * It automatically handles:
  * - Activity retrieval from LocalActivity
  * - Coroutine scope management
  * - Error handling and state updates

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
@@ -73,11 +73,11 @@ internal fun FirebaseAuthUI.rememberOAuthSignInHandler(
                 )
             } catch (e: AuthException) {
                 updateAuthState(AuthState.Error(e))
-                onSignInFailure(e)
+                if (e !is AuthException.AuthCancelledException) onSignInFailure(e)
             } catch (e: Exception) {
                 val authException = AuthException.from(e, context)
                 updateAuthState(AuthState.Error(authException))
-                onSignInFailure(authException)
+                if (authException !is AuthException.AuthCancelledException) onSignInFailure(authException)
             }
         }
     }

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
@@ -3,7 +3,6 @@ package com.firebase.ui.auth.configuration.auth_provider
 import android.app.Activity
 import android.content.Context
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
@@ -63,24 +62,22 @@ internal fun FirebaseAuthUI.rememberOAuthSignInHandler(
                 "Ensure FirebaseAuthScreen is used within an Activity."
     )
 
-    return remember(this, provider.providerId, config) {
-        {
-            coroutineScope.launch {
-                try {
-                    signInWithProvider(
-                        context = context,
-                        config = config,
-                        activity = activity,
-                        provider = provider
-                    )
-                } catch (e: AuthException) {
-                    updateAuthState(AuthState.Error(e))
-                    onSignInFailure(e)
-                } catch (e: Exception) {
-                    val authException = AuthException.from(e, context)
-                    updateAuthState(AuthState.Error(authException))
-                    onSignInFailure(authException)
-                }
+    return {
+        coroutineScope.launch {
+            try {
+                signInWithProvider(
+                    context = context,
+                    config = config,
+                    activity = activity,
+                    provider = provider
+                )
+            } catch (e: AuthException) {
+                updateAuthState(AuthState.Error(e))
+                onSignInFailure(e)
+            } catch (e: Exception) {
+                val authException = AuthException.from(e, context)
+                updateAuthState(AuthState.Error(authException))
+                onSignInFailure(authException)
             }
         }
     }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
@@ -188,6 +188,7 @@ fun FirebaseAuthScreen(
                 )
             )
         },
+        onSignInFailure = onSignInFailure,
     )
     val continueWithProvider: (String) -> Unit = { providerId ->
         configuration.providers.find { it.providerId == providerId }?.let { onProviderSelected(it) }
@@ -1012,6 +1013,7 @@ private fun FirebaseAuthUI.rememberOnProviderSelected(
     config: AuthUIConfiguration,
     onNavigate: (AuthRoute) -> Unit,
     onUnknownProvider: ((AuthProvider) -> Unit)? = null,
+    onSignInFailure: (AuthException) -> Unit = {},
 ): (AuthProvider) -> Unit {
     val anonymousProvider = config.providers.filterIsInstance<AuthProvider.Anonymous>().firstOrNull()
     val googleProvider = config.providers.filterIsInstance<AuthProvider.Google>().firstOrNull()
@@ -1023,16 +1025,18 @@ private fun FirebaseAuthUI.rememberOnProviderSelected(
     val twitterProvider = config.providers.filterIsInstance<AuthProvider.Twitter>().firstOrNull()
     val genericOAuthProviders = config.providers.filterIsInstance<AuthProvider.GenericOAuth>()
 
-    val onSignInAnonymously = anonymousProvider?.let { rememberAnonymousSignInHandler(config) }
-    val onSignInWithGoogle = googleProvider?.let { rememberGoogleSignInHandler(context, config, it) }
-    val onSignInWithFacebook = facebookProvider?.let { rememberSignInWithFacebookLauncher(context, config, it) }
-    val onSignInWithApple = appleProvider?.let { rememberOAuthSignInHandler(context, activity, config, it) }
-    val onSignInWithGithub = githubProvider?.let { rememberOAuthSignInHandler(context, activity, config, it) }
-    val onSignInWithMicrosoft = microsoftProvider?.let { rememberOAuthSignInHandler(context, activity, config, it) }
-    val onSignInWithYahoo = yahooProvider?.let { rememberOAuthSignInHandler(context, activity, config, it) }
-    val onSignInWithTwitter = twitterProvider?.let { rememberOAuthSignInHandler(context, activity, config, it) }
+    val onSignInAnonymously = anonymousProvider?.let { rememberAnonymousSignInHandler(config, onSignInFailure) }
+    val onSignInWithGoogle = googleProvider?.let { rememberGoogleSignInHandler(context, config, it, onSignInFailure) }
+    val onSignInWithFacebook = facebookProvider?.let {
+        rememberSignInWithFacebookLauncher(context, config, it, onSignInFailure = onSignInFailure)
+    }
+    val onSignInWithApple = appleProvider?.let { rememberOAuthSignInHandler(context, activity, config, it, onSignInFailure) }
+    val onSignInWithGithub = githubProvider?.let { rememberOAuthSignInHandler(context, activity, config, it, onSignInFailure) }
+    val onSignInWithMicrosoft = microsoftProvider?.let { rememberOAuthSignInHandler(context, activity, config, it, onSignInFailure) }
+    val onSignInWithYahoo = yahooProvider?.let { rememberOAuthSignInHandler(context, activity, config, it, onSignInFailure) }
+    val onSignInWithTwitter = twitterProvider?.let { rememberOAuthSignInHandler(context, activity, config, it, onSignInFailure) }
     val genericOAuthHandlers = genericOAuthProviders.associateWith {
-        rememberOAuthSignInHandler(context, activity, config, it)
+        rememberOAuthSignInHandler(context, activity, config, it, onSignInFailure)
     }
 
     return { provider ->

--- a/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProviderFirebaseAuthUITest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProviderFirebaseAuthUITest.kt
@@ -15,6 +15,7 @@
 package com.firebase.ui.auth.configuration.auth_provider
 
 import android.content.Context
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.core.app.ApplicationProvider
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
@@ -38,6 +39,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
@@ -53,6 +55,9 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
 class AnonymousAuthProviderFirebaseAuthUITest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
 
     @Mock
     private lateinit var mockFirebaseAuth: FirebaseAuth
@@ -212,6 +217,35 @@ class AnonymousAuthProviderFirebaseAuthUITest {
         assertThat(currentState).isInstanceOf(AuthState.Error::class.java)
         val errorState = currentState as AuthState.Error
         assertThat(errorState.exception).isInstanceOf(AuthException.UnknownException::class.java)
+    }
+
+    // =============================================================================================
+    // rememberAnonymousSignInHandler - onSignInFailure reporting
+    // =============================================================================================
+
+    @Test
+    fun `rememberAnonymousSignInHandler reports failure via onSignInFailure immediately, at the source`() {
+        val networkException = FirebaseNetworkException("Network error")
+        val taskCompletionSource = TaskCompletionSource<AuthResult>()
+        taskCompletionSource.setException(networkException)
+        `when`(mockFirebaseAuth.signInAnonymously()).thenReturn(taskCompletionSource.task)
+
+        val instance = FirebaseAuthUI.create(firebaseApp, mockFirebaseAuth)
+        val reportedFailures = mutableListOf<AuthException>()
+        var launcher: (() -> Unit)? = null
+
+        composeTestRule.setContent {
+            launcher = instance.rememberAnonymousSignInHandler(
+                config = config,
+                onSignInFailure = { reportedFailures.add(it) },
+            )
+        }
+
+        composeTestRule.runOnIdle { launcher?.invoke() }
+        composeTestRule.waitForIdle()
+
+        assertThat(reportedFailures).hasSize(1)
+        assertThat(reportedFailures.single()).isInstanceOf(AuthException.NetworkException::class.java)
     }
 
     // =============================================================================================

--- a/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProviderFirebaseAuthUITest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProviderFirebaseAuthUITest.kt
@@ -15,6 +15,7 @@
 package com.firebase.ui.auth.configuration.auth_provider
 
 import android.content.Context
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.core.net.toUri
 import androidx.credentials.CredentialManager
 import androidx.test.core.app.ApplicationProvider
@@ -37,6 +38,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
@@ -66,6 +68,9 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
 class GoogleAuthProviderFirebaseAuthUITest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
 
     @Mock
     private lateinit var mockFirebaseAuth: FirebaseAuth
@@ -919,5 +924,60 @@ class GoogleAuthProviderFirebaseAuthUITest {
         // Verify final state is Success (with the real AuthResult)
         val finalState = instance.authStateFlow().first { it !is AuthState.Loading }
         assertThat(finalState).isEqualTo(AuthState.Success(result = mockAuthResult, user = mockUser, isNewUser = false))
+    }
+
+    // =============================================================================================
+    // rememberGoogleSignInHandler - onSignInFailure reporting
+    // =============================================================================================
+
+    @Test
+    fun `rememberGoogleSignInHandler reports failure via onSignInFailure immediately, at the source`() {
+        val instance = FirebaseAuthUI.create(firebaseApp, mockFirebaseAuth)
+        val googleProvider = AuthProvider.Google(
+            serverClientId = "test-client-id",
+            scopes = emptyList()
+        )
+        val config = authUIConfiguration {
+            context = applicationContext
+            providers {
+                provider(googleProvider)
+            }
+        }
+
+        // A picker-level failure that used to never reach onSignInFailure at all:
+        // the outer fallback throws AuthException.UnknownException when no Google accounts are found.
+        instance.testCredentialManagerProvider = object : AuthProvider.Google.CredentialManagerProvider {
+            override suspend fun getGoogleCredential(
+                context: Context,
+                credentialManager: CredentialManager,
+                serverClientId: String,
+                filterByAuthorizedAccounts: Boolean,
+                autoSelectEnabled: Boolean
+            ): AuthProvider.Google.GoogleSignInResult {
+                throw AuthException.UnknownException(
+                    "No Google accounts available.\n\nPlease add a Google account to your device and try again."
+                )
+            }
+
+            override suspend fun clearCredentialState(context: Context, credentialManager: CredentialManager) = Unit
+        }
+
+        val reportedFailures = mutableListOf<AuthException>()
+        var launcher: (() -> Unit)? = null
+
+        composeTestRule.setContent {
+            launcher = instance.rememberGoogleSignInHandler(
+                context = applicationContext,
+                config = config,
+                provider = googleProvider,
+                onSignInFailure = { reportedFailures.add(it) },
+            )
+        }
+
+        composeTestRule.runOnIdle { launcher?.invoke() }
+        composeTestRule.waitForIdle()
+
+        assertThat(reportedFailures).hasSize(1)
+        assertThat(reportedFailures.single()).isInstanceOf(AuthException.UnknownException::class.java)
     }
 }

--- a/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProviderFirebaseAuthUITest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProviderFirebaseAuthUITest.kt
@@ -980,4 +980,50 @@ class GoogleAuthProviderFirebaseAuthUITest {
         assertThat(reportedFailures).hasSize(1)
         assertThat(reportedFailures.single()).isInstanceOf(AuthException.UnknownException::class.java)
     }
+
+    @Test
+    fun `rememberGoogleSignInHandler does not report onSignInFailure for user cancellation`() {
+        val instance = FirebaseAuthUI.create(firebaseApp, mockFirebaseAuth)
+        val googleProvider = AuthProvider.Google(
+            serverClientId = "test-client-id",
+            scopes = emptyList()
+        )
+        val config = authUIConfiguration {
+            context = applicationContext
+            providers {
+                provider(googleProvider)
+            }
+        }
+
+        instance.testCredentialManagerProvider = object : AuthProvider.Google.CredentialManagerProvider {
+            override suspend fun getGoogleCredential(
+                context: Context,
+                credentialManager: CredentialManager,
+                serverClientId: String,
+                filterByAuthorizedAccounts: Boolean,
+                autoSelectEnabled: Boolean
+            ): AuthProvider.Google.GoogleSignInResult {
+                throw CancellationException("User cancelled")
+            }
+
+            override suspend fun clearCredentialState(context: Context, credentialManager: CredentialManager) = Unit
+        }
+
+        val reportedFailures = mutableListOf<AuthException>()
+        var launcher: (() -> Unit)? = null
+
+        composeTestRule.setContent {
+            launcher = instance.rememberGoogleSignInHandler(
+                context = applicationContext,
+                config = config,
+                provider = googleProvider,
+                onSignInFailure = { reportedFailures.add(it) },
+            )
+        }
+
+        composeTestRule.runOnIdle { launcher?.invoke() }
+        composeTestRule.waitForIdle()
+
+        assertThat(reportedFailures).isEmpty()
+    }
 }

--- a/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProviderFirebaseAuthUITest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProviderFirebaseAuthUITest.kt
@@ -16,6 +16,7 @@ package com.firebase.ui.auth.configuration.auth_provider
 
 import android.app.Activity
 import android.content.Context
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.core.app.ApplicationProvider
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
@@ -30,6 +31,7 @@ import com.google.firebase.auth.AuthCredential
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseAuthUserCollisionException
+import com.google.firebase.auth.FirebaseAuthWebException
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.OAuthCredential
 import com.google.firebase.auth.OAuthProvider
@@ -38,6 +40,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
@@ -59,6 +62,9 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34], manifest = Config.NONE)
 class OAuthProviderFirebaseAuthUITest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
 
     @Mock
     private lateinit var mockFirebaseAuth: FirebaseAuth
@@ -289,5 +295,44 @@ class OAuthProviderFirebaseAuthUITest {
         assertThat(finalState).isInstanceOf(AuthState.Error::class.java)
         val errorState = finalState as AuthState.Error
         assertThat(errorState.exception).isInstanceOf(AuthException.AuthCancelledException::class.java)
+    }
+
+    @Test
+    fun `rememberOAuthSignInHandler does not report onSignInFailure when the web context is cancelled`() {
+        `when`(mockFirebaseAuth.pendingAuthResult).thenReturn(null)
+        `when`(mockFirebaseAuth.currentUser).thenReturn(null)
+        val taskCompletionSource = TaskCompletionSource<AuthResult>()
+        taskCompletionSource.setException(
+            FirebaseAuthWebException("ERROR_WEB_CONTEXT_CANCELED", "The web operation was canceled")
+        )
+        `when`(mockFirebaseAuth.startActivityForSignInWithProvider(any<Activity>(), any<OAuthProvider>()))
+            .thenReturn(taskCompletionSource.task)
+
+        val instance = FirebaseAuthUI.create(firebaseApp, mockFirebaseAuth)
+        val microsoftProvider = AuthProvider.Microsoft(tenant = null, customParameters = emptyMap())
+        val config = authUIConfiguration {
+            context = applicationContext
+            providers {
+                provider(microsoftProvider)
+            }
+        }
+
+        val reportedFailures = mutableListOf<AuthException>()
+        var launcher: (() -> Unit)? = null
+
+        composeTestRule.setContent {
+            launcher = instance.rememberOAuthSignInHandler(
+                context = applicationContext,
+                activity = mockActivity,
+                config = config,
+                provider = microsoftProvider,
+                onSignInFailure = { reportedFailures.add(it) },
+            )
+        }
+
+        composeTestRule.runOnIdle { launcher?.invoke() }
+        composeTestRule.waitForIdle()
+
+        assertThat(reportedFailures).isEmpty()
     }
 }


### PR DESCRIPTION
`FirebaseAuthScreen`'s `onSignInFailure` callback was only ever invoked from `EmailAuthScreen` and `PhoneAuthScreen`'s own effects. Google, Facebook, OAuth (Apple/Github/Microsoft/Yahoo/Twitter/generic), and Anonymous sign-in failures only updated the shared `AuthState.Error` - which the top-level dialog controller shows - but never reached `onSignInFailure`, so a consuming app's own error logging/analytics wired through that callback silently never fired for those providers.

Threads an `onSignInFailure` callback into all four `remember*SignInHandler` functions, calling it alongside each existing `updateAuthState(AuthState.Error(...))` so each provider reports its own failure exactly once, at the source - symmetric with how Email/Phone already report theirs.

- `GoogleAuthProvider+FirebaseAuthUI.kt`, `FacebookAuthProvider+FirebaseAuthUI.kt`, `OAuthProvider+FirebaseAuthUI.kt`, `AnonymousAuthProvider+FirebaseAuthUI.kt`: added an `onSignInFailure` parameter to each `remember*Handler`, called in their catch blocks.
- `FirebaseAuthScreen.kt`: threads `onSignInFailure` through `rememberOnProviderSelected` and its two call sites - the main flow passes the real callback; the reauth sheet keeps its existing no-op default, matching how it already no-ops Email/Phone's `onError` there.

Added direct tests forcing a failure (`testCredentialManagerProvider` for Google, a failing `signInAnonymously()` task for Anonymous) confirming `onSignInFailure` fires immediately without navigating anywhere - verified both are load-bearing by temporarily reverting the fix and confirming they fail.