### PR TITLE
fix(auth)!: only exit auth flow on AuthState.Aborted, not per-provider Cancelled. BREAKING: Splitting two different behaviours via AuthState into `Cancelled` and `Aborted`

### DIFF
--- a/app/src/main/java/com/firebaseui/android/demo/auth/AuthFlowControllerDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/AuthFlowControllerDemoActivity.kt
@@ -227,6 +227,7 @@ fun AuthFlowDemo(
                         is AuthState.Success -> "Success - User: ${(authState as AuthState.Success).user.email}"
                         is AuthState.Error -> "Error: ${(authState as AuthState.Error).exception.message}"
                         is AuthState.Cancelled -> "Cancelled"
+                        is AuthState.Aborted -> "Aborted"
                         is AuthState.RequiresMfa -> "MFA Required"
                         is AuthState.RequiresEmailVerification -> "Email Verification Required"
                         else -> "Unknown"

--- a/auth/README.md
+++ b/auth/README.md
@@ -343,7 +343,12 @@ lifecycleScope.launch {
             Log.e(TAG, "Auth failed", state.exception)
         }
         is AuthState.Cancelled -> {
-            // User cancelled
+            // User cancelled a single sign-in attempt (e.g. dismissed the
+            // Credential Manager sheet, backed out of MFA); the flow stays open
+        }
+        is AuthState.Aborted -> {
+            // Flow was ended via controller.cancel()
+            finish()
         }
         else -> {
             // Handle other states (RequiresMfa, RequiresEmailVerification, etc.)
@@ -375,6 +380,7 @@ sealed class AuthState {
     data class RequiresEmailVerification(val user: FirebaseUser, val email: String) : AuthState()
     data class RequiresProfileCompletion(val user: FirebaseUser, val missingFields: List<String> = emptyList()) : AuthState()
     object Cancelled : AuthState()
+    object Aborted : AuthState()
     object PasswordResetLinkSent : AuthState()
     object EmailSignInLinkSent : AuthState()
     data class SMSAutoVerified(val credential: PhoneAuthCredential) : AuthState()
@@ -684,7 +690,7 @@ fun AuthenticationScreen() {
 | `configuration` | `AuthUIConfiguration` | *Required* | Authentication configuration (providers, theme, etc.) |
 | `onSignInSuccess` | `(AuthResult) -> Unit` | *Required* | Callback when sign-in succeeds |
 | `onSignInFailure` | `(AuthException) -> Unit` | *Required* | Callback when sign-in fails |
-| `onSignInCancelled` | `() -> Unit` | *Required* | Callback when user cancels authentication |
+| `onSignInCancelled` | `() -> Unit` | *Required* | Callback when the auth flow ends via `AuthState.Aborted` (e.g. `AuthFlowController.cancel()`); not called when the user merely backs out of a single sign-in attempt (`AuthState.Cancelled`) |
 | `modifier` | `Modifier` | `Modifier` | Modifier for the composable |
 | `authUI` | `FirebaseAuthUI` | `FirebaseAuthUI.getInstance()` | Custom FirebaseAuthUI instance (for multi-app support) |
 | `emailLink` | `String?` | `null` | Email link for passwordless sign-in (see [Email Link Sign-In](#email-link-sign-in)) |
@@ -777,7 +783,11 @@ class AuthActivity : ComponentActivity() {
                 showEmailVerificationScreen(state.user)
             }
             is AuthState.Cancelled -> {
-                // User cancelled authentication
+                // User cancelled a single sign-in attempt; the flow stays open
+                // and returns to the method picker
+            }
+            is AuthState.Aborted -> {
+                // Flow was ended via controller.cancel()
                 finish()
             }
             else -> {

--- a/auth/README.md
+++ b/auth/README.md
@@ -179,7 +179,9 @@ class MainActivity : ComponentActivity() {
                         Toast.makeText(this, "Error: ${exception.message}", Toast.LENGTH_SHORT).show()
                     },
                     onSignInCancelled = {
-                        finish()
+                        // User backed out of a single provider (e.g. dismissed the Google
+                        // Credential Manager sheet); FirebaseAuthScreen already returns to
+                        // the method picker on its own — no action needed here.
                     }
                 )
             }
@@ -677,7 +679,8 @@ fun AuthenticationScreen() {
             }
         },
         onSignInCancelled = {
-            navigateBack()
+            // User backed out of a single provider; the screen already returns
+            // to the method picker on its own.
         }
     )
 }
@@ -690,7 +693,7 @@ fun AuthenticationScreen() {
 | `configuration` | `AuthUIConfiguration` | *Required* | Authentication configuration (providers, theme, etc.) |
 | `onSignInSuccess` | `(AuthResult) -> Unit` | *Required* | Callback when sign-in succeeds |
 | `onSignInFailure` | `(AuthException) -> Unit` | *Required* | Callback when sign-in fails |
-| `onSignInCancelled` | `() -> Unit` | *Required* | Callback when the auth flow ends via `AuthState.Aborted` (e.g. `AuthFlowController.cancel()`); not called when the user merely backs out of a single sign-in attempt (`AuthState.Cancelled`) |
+| `onSignInCancelled` | `() -> Unit` | *Required* | Callback when the user backs out of a single sign-in attempt (`AuthState.Cancelled`, e.g. dismissing the Google Credential Manager sheet); `FirebaseAuthScreen` already returns to the method picker itself, so this is informational only. Not called when the whole flow ends via `AuthFlowController.cancel()` (`AuthState.Aborted`) — that state is observable directly on `authUI.authStateFlow()`/`authFlowController.authStateFlow` for callers who need it |
 | `modifier` | `Modifier` | `Modifier` | Modifier for the composable |
 | `authUI` | `FirebaseAuthUI` | `FirebaseAuthUI.getInstance()` | Custom FirebaseAuthUI instance (for multi-app support) |
 | `emailLink` | `String?` | `null` | Email link for passwordless sign-in (see [Email Link Sign-In](#email-link-sign-in)) |
@@ -712,7 +715,8 @@ FirebaseAuthScreen(
         showError(exception)
     },
     onSignInCancelled = {
-        finish()
+        // User backed out of a single provider; the screen already returns
+        // to the method picker on its own.
     },
     authenticatedContent = { state, uiContext ->
         // Show a welcome screen or profile completion UI
@@ -1739,7 +1743,8 @@ override fun onCreate(savedInstanceState: Bundle?) {
                     // Handle error
                 },
                 onSignInCancelled = {
-                    finish()
+                    // User backed out of a single provider; the screen already
+                    // returns to the method picker on its own.
                 }
             )
         }

--- a/auth/src/main/java/com/firebase/ui/auth/AuthFlowController.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthFlowController.kt
@@ -18,6 +18,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import androidx.activity.result.ActivityResultLauncher
+import androidx.annotation.MainThread
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -218,6 +219,7 @@ class AuthFlowController internal constructor(
      *
      * @throws IllegalStateException if the controller has been disposed
      */
+    @MainThread
     fun cancel() {
         checkNotDisposed()
         authUI.updateAuthState(AuthState.Aborted)

--- a/auth/src/main/java/com/firebase/ui/auth/AuthFlowController.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthFlowController.kt
@@ -71,7 +71,10 @@ import java.util.concurrent.atomic.AtomicBoolean
  *                         // Handle error
  *                     }
  *                     is AuthState.Cancelled -> {
- *                         // User cancelled
+ *                         // User cancelled a single sign-in attempt; flow stays open
+ *                     }
+ *                     is AuthState.Aborted -> {
+ *                         // The whole flow was ended via authController.cancel()
  *                     }
  *                     else -> {}
  *                 }
@@ -93,7 +96,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * **Lifecycle Management:**
  * - [createIntent] - Generate Intent to start the auth flow Activity
  * - [start] - Alternative to launch the flow (for Activity context)
- * - [cancel] - Cancel the ongoing auth flow, transitions to [AuthState.Cancelled]
+ * - [cancel] - Cancel the ongoing auth flow, transitions to [AuthState.Aborted]
  * - [dispose] - Release all resources (coroutines, listeners). Call in onDestroy()
  *
  * @property authUI The [FirebaseAuthUI] instance managing authentication
@@ -120,7 +123,9 @@ class AuthFlowController internal constructor(
      * - [AuthState.Loading] - Authentication in progress
      * - [AuthState.Success] - User signed in successfully
      * - [AuthState.Error] - Authentication error occurred
-     * - [AuthState.Cancelled] - User cancelled the flow
+     * - [AuthState.Cancelled] - Operation-level cancellation; the user cancelled a single
+     *   sign-in attempt and the flow stays open
+     * - [AuthState.Aborted] - The whole flow was ended via [cancel]
      * - [AuthState.RequiresMfa] - Multi-factor authentication required
      * - [AuthState.RequiresEmailVerification] - Email verification required
      */
@@ -195,9 +200,13 @@ class AuthFlowController internal constructor(
     /**
      * Cancels the ongoing authentication flow.
      *
-     * This method transitions the auth state to [AuthState.Cancelled] and
+     * This method transitions the auth state to [AuthState.Aborted] and
      * signals the auth flow to terminate. The auth flow Activity will finish
      * and return [Activity.RESULT_CANCELED].
+     *
+     * Unlike [AuthState.Cancelled] (an operation-level cancellation that leaves the flow
+     * open, e.g. dismissing the Google Credential Manager sheet), calling this method ends
+     * the entire flow.
      *
      * **Example:**
      * ```kotlin
@@ -211,7 +220,7 @@ class AuthFlowController internal constructor(
      */
     fun cancel() {
         checkNotDisposed()
-        authUI.updateAuthState(AuthState.Cancelled)
+        authUI.updateAuthState(AuthState.Aborted)
     }
 
     /**

--- a/auth/src/main/java/com/firebase/ui/auth/AuthState.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthState.kt
@@ -132,12 +132,35 @@ abstract class AuthState private constructor() {
 
     /**
      * Authentication was cancelled by the user.
+     *
+     * This is an operation-level cancellation: the user backed out of a single sign-in
+     * attempt (e.g. dismissed the Google Credential Manager sheet, backed out of an MFA
+     * challenge). The flow stays open and the screen returns to the method picker.
+     *
+     * @see Aborted for the state that ends the whole flow instead
      */
     class Cancelled internal constructor() : AuthState() {
         override val isNotification: Boolean = true
         override fun equals(other: Any?): Boolean = other is Cancelled
         override fun hashCode(): Int = javaClass.hashCode()
         override fun toString(): String = "AuthState.Cancelled"
+    }
+
+    /**
+     * The entire authentication flow was aborted.
+     *
+     * This state is emitted only by [AuthFlowController.cancel]. Unlike [Cancelled], which is
+     * a normal in-flow outcome that leaves the flow open, [Aborted] ends the whole flow —
+     * for example, [FirebaseAuthActivity] finishes with `RESULT_CANCELED` when it observes
+     * this state.
+     *
+     * @see Cancelled for the operation-level state that leaves the flow open
+     */
+    class Aborted internal constructor() : AuthState() {
+        override val isNotification: Boolean = true
+        override fun equals(other: Any?): Boolean = other is Aborted
+        override fun hashCode(): Int = javaClass.hashCode()
+        override fun toString(): String = "AuthState.Aborted"
     }
 
     /**
@@ -358,5 +381,12 @@ abstract class AuthState private constructor() {
          */
         @JvmStatic
         val Cancelled: Cancelled = Cancelled()
+
+        /**
+         * Creates an Aborted state instance.
+         * @return A new [Aborted] state
+         */
+        @JvmStatic
+        val Aborted: Aborted = Aborted()
     }
 }

--- a/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthActivity.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthActivity.kt
@@ -122,6 +122,7 @@ class FirebaseAuthActivity : ComponentActivity() {
                     }
                     is AuthState.Aborted -> {
                         setResult(RESULT_CANCELED)
+                        authUI.updateAuthState(AuthState.Idle)
                         finish()
                     }
                     is AuthState.Error -> {

--- a/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthActivity.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthActivity.kt
@@ -36,7 +36,11 @@ import java.util.concurrent.ConcurrentHashMap
  *
  * This activity displays the [FirebaseAuthScreen] composable and manages
  * the authentication flow lifecycle. It automatically finishes when the user
- * signs in successfully or cancels the flow.
+ * signs in successfully ([AuthState.Success]) or the flow is aborted
+ * ([AuthState.Aborted], e.g. via [AuthFlowController.cancel]). Operation-level
+ * cancellations ([AuthState.Cancelled], e.g. dismissing the Google Credential Manager
+ * sheet) do not finish the activity — the flow stays open and the screen returns to
+ * the method picker.
  *
  * **Do not launch this Activity directly.**
  * Use [AuthFlowController] to start the auth flow:
@@ -116,8 +120,8 @@ class FirebaseAuthActivity : ComponentActivity() {
                         setResult(RESULT_OK, resultIntent)
                         finish()
                     }
-                    is AuthState.Cancelled -> {
-                        // User cancelled the flow
+                    is AuthState.Aborted -> {
+                        // The whole flow was aborted (e.g. AuthFlowController.cancel())
                         setResult(RESULT_CANCELED)
                         finish()
                     }
@@ -149,6 +153,9 @@ class FirebaseAuthActivity : ComponentActivity() {
                     onSignInFailure = { exception ->
                         // State flow will handle error
                     },
+                    // TODO(J2): Re-check this once FirebaseAuthScreen's internals are split for
+                    // Cancelled/Aborted — onSignInCancelled may need to emit AuthState.Aborted
+                    // instead if it now represents the whole flow ending.
                     onSignInCancelled = {
                         authUI.updateAuthState(AuthState.Cancelled)
                     }

--- a/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthActivity.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthActivity.kt
@@ -121,7 +121,17 @@ class FirebaseAuthActivity : ComponentActivity() {
                         finish()
                     }
                     is AuthState.Aborted -> {
-                        // The whole flow was aborted (e.g. AuthFlowController.cancel())
+                        // The whole flow was aborted (e.g. AuthFlowController.cancel(), which now
+                        // carries @MainThread, enforced by lint, not just convention).
+                        //
+                        // We collect authUI.authStateFlow() — a combine(...).distinctUntilChanged()
+                        // — via lifecycleScope's default Dispatchers.Main.immediate, so a main-thread
+                        // cancel() resumes this collector in-line and finish() below runs before
+                        // cancel() returns, strictly before FirebaseAuthScreen's Compose-driven Idle
+                        // reset (see that branch). That in-line resume depends on combine()
+                        // propagating the caller's dispatcher rather than dispatching its own — a
+                        // kotlinx-coroutines implementation detail worth re-checking if
+                        // authStateFlow()'s implementation changes.
                         setResult(RESULT_CANCELED)
                         finish()
                     }
@@ -153,12 +163,13 @@ class FirebaseAuthActivity : ComponentActivity() {
                     onSignInFailure = { exception ->
                         // State flow will handle error
                     },
-                    // TODO(J2): Re-check this once FirebaseAuthScreen's internals are split for
-                    // Cancelled/Aborted — onSignInCancelled may need to emit AuthState.Aborted
-                    // instead if it now represents the whole flow ending.
-                    onSignInCancelled = {
-                        authUI.updateAuthState(AuthState.Cancelled)
-                    }
+                    // onSignInCancelled() is now only invoked by FirebaseAuthScreen from its
+                    // Aborted branch (Cancelled is operation-level and keeps the flow open, so it
+                    // no longer fires this terminal callback). The authStateFlow collector above
+                    // already finishes this activity on Aborted, so there's nothing left to do
+                    // here — re-emitting Cancelled would incorrectly push a stale state onto the
+                    // shared authUI instance after the flow has already ended.
+                    onSignInCancelled = {}
                 )
             }
         }

--- a/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthActivity.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthActivity.kt
@@ -121,17 +121,6 @@ class FirebaseAuthActivity : ComponentActivity() {
                         finish()
                     }
                     is AuthState.Aborted -> {
-                        // The whole flow was aborted (e.g. AuthFlowController.cancel(), which now
-                        // carries @MainThread, enforced by lint, not just convention).
-                        //
-                        // We collect authUI.authStateFlow() — a combine(...).distinctUntilChanged()
-                        // — via lifecycleScope's default Dispatchers.Main.immediate, so a main-thread
-                        // cancel() resumes this collector in-line and finish() below runs before
-                        // cancel() returns, strictly before FirebaseAuthScreen's Compose-driven Idle
-                        // reset (see that branch). That in-line resume depends on combine()
-                        // propagating the caller's dispatcher rather than dispatching its own — a
-                        // kotlinx-coroutines implementation detail worth re-checking if
-                        // authStateFlow()'s implementation changes.
                         setResult(RESULT_CANCELED)
                         finish()
                     }
@@ -163,12 +152,6 @@ class FirebaseAuthActivity : ComponentActivity() {
                     onSignInFailure = { exception ->
                         // State flow will handle error
                     },
-                    // onSignInCancelled() is now only invoked by FirebaseAuthScreen from its
-                    // Aborted branch (Cancelled is operation-level and keeps the flow open, so it
-                    // no longer fires this terminal callback). The authStateFlow collector above
-                    // already finishes this activity on Aborted, so there's nothing left to do
-                    // here — re-emitting Cancelled would incorrectly push a stale state onto the
-                    // shared authUI instance after the flow has already ended.
                     onSignInCancelled = {}
                 )
             }

--- a/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthUI.kt
@@ -16,6 +16,7 @@ package com.firebase.ui.auth
 
 import android.content.Context
 import android.content.Intent
+import androidx.annotation.MainThread
 import androidx.annotation.RestrictTo
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
@@ -360,6 +361,7 @@ class FirebaseAuthUI private constructor(
      *
      * @param state The new [AuthState] to emit
      */
+    @MainThread
     fun updateAuthState(state: AuthState) {
         _authStateFlow.value = state
     }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
@@ -550,10 +550,6 @@ fun FirebaseAuthScreen(
                     }
 
                     is AuthState.Cancelled -> {
-                        // Operation-level cancellation only: the flow stays open and returns to
-                        // the method picker. No terminal callback here — onSignInCancelled() is
-                        // reserved for Aborted, since firing a terminal callback while this screen
-                        // keeps running would mislead a host that isn't watching AuthState itself.
                         pendingReauthOperation.value = null
                         pendingReauthConfig.value = null
                         pendingReauthState.value = null
@@ -566,17 +562,10 @@ fun FirebaseAuthScreen(
                                 launchSingleTop = true
                             }
                         }
-                        // Consumed so this doesn't leak to a freshly created screen.
                         authUI.updateAuthState(AuthState.Idle)
                     }
 
                     is AuthState.Aborted -> {
-                        // Flow-ending: when hosted by FirebaseAuthActivity, that activity's own
-                        // authStateFlow collector independently finishes on Aborted. When this
-                        // screen is embedded standalone (no FirebaseAuthActivity around to absorb
-                        // it), onSignInCancelled() is the only signal the host gets that the flow
-                        // is over, so it's invoked unconditionally here. No navigation: the screen
-                        // is being torn down or the host is otherwise handling flow-end.
                         pendingReauthOperation.value = null
                         pendingReauthConfig.value = null
                         pendingReauthState.value = null
@@ -584,19 +573,6 @@ fun FirebaseAuthScreen(
                         pendingLinkingCredential.value = null
                         lastSuccessfulUserId.value = null
                         onSignInCancelled()
-                        // Consumed so this doesn't leak to a freshly created screen.
-                        //
-                        // NOT a race with FirebaseAuthActivity's own Aborted collector: cancel()
-                        // (the sole setter of Aborted) now carries @MainThread, enforced by lint,
-                        // not just convention. Activity's collector observes authUI.authStateFlow()
-                        // — a combine(...).distinctUntilChanged() — via Dispatchers.Main.immediate,
-                        // so a main-thread cancel() resumes it in-line and finish() runs before
-                        // cancel() returns. This LaunchedEffect, by contrast, is driven by Compose's
-                        // collectAsState() recomposition, which requires an actual dispatch, so this
-                        // branch and the Idle reset below run strictly after the Activity has
-                        // already finished. See FirebaseAuthActivity's Aborted branch for why that
-                        // in-line resume is a kotlinx-coroutines implementation detail (combine()
-                        // propagating the caller's dispatcher), not an unconditional guarantee.
                         authUI.updateAuthState(AuthState.Idle)
                     }
 

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
@@ -62,6 +62,7 @@ import androidx.navigation.compose.rememberNavController
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.BuildConfig
+import com.firebase.ui.auth.FirebaseAuthActivity
 import com.firebase.ui.auth.FirebaseAuthUI
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.configuration.MfaConfiguration
@@ -567,13 +568,17 @@ fun FirebaseAuthScreen(
                     }
 
                     is AuthState.Aborted -> {
-                        pendingReauthOperation.value = null
-                        pendingReauthConfig.value = null
-                        pendingReauthState.value = null
-                        pendingResolver.value = null
-                        pendingLinkingCredential.value = null
-                        lastSuccessfulUserId.value = null
-                        authUI.updateAuthState(AuthState.Idle)
+                        // Hosted by FirebaseAuthActivity: its own authStateFlow collector
+                        // independently finishes the activity and resets state on Aborted.
+                        if (activity !is FirebaseAuthActivity) {
+                            pendingReauthOperation.value = null
+                            pendingReauthConfig.value = null
+                            pendingReauthState.value = null
+                            pendingResolver.value = null
+                            pendingLinkingCredential.value = null
+                            lastSuccessfulUserId.value = null
+                            authUI.updateAuthState(AuthState.Idle)
+                        }
                     }
 
                     is AuthState.Idle -> {

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
@@ -562,6 +562,7 @@ fun FirebaseAuthScreen(
                                 launchSingleTop = true
                             }
                         }
+                        onSignInCancelled()
                         authUI.updateAuthState(AuthState.Idle)
                     }
 
@@ -572,7 +573,6 @@ fun FirebaseAuthScreen(
                         pendingResolver.value = null
                         pendingLinkingCredential.value = null
                         lastSuccessfulUserId.value = null
-                        onSignInCancelled()
                         authUI.updateAuthState(AuthState.Idle)
                     }
 

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
@@ -550,6 +550,10 @@ fun FirebaseAuthScreen(
                     }
 
                     is AuthState.Cancelled -> {
+                        // Operation-level cancellation only: the flow stays open and returns to
+                        // the method picker. No terminal callback here — onSignInCancelled() is
+                        // reserved for Aborted, since firing a terminal callback while this screen
+                        // keeps running would mislead a host that isn't watching AuthState itself.
                         pendingReauthOperation.value = null
                         pendingReauthConfig.value = null
                         pendingReauthState.value = null
@@ -562,10 +566,37 @@ fun FirebaseAuthScreen(
                                 launchSingleTop = true
                             }
                         }
-                        // Keep external cancellation reporting centralized here so child screens
-                        // can handle local navigation without triggering duplicate callbacks.
+                        // Consumed so this doesn't leak to a freshly created screen.
+                        authUI.updateAuthState(AuthState.Idle)
+                    }
+
+                    is AuthState.Aborted -> {
+                        // Flow-ending: when hosted by FirebaseAuthActivity, that activity's own
+                        // authStateFlow collector independently finishes on Aborted. When this
+                        // screen is embedded standalone (no FirebaseAuthActivity around to absorb
+                        // it), onSignInCancelled() is the only signal the host gets that the flow
+                        // is over, so it's invoked unconditionally here. No navigation: the screen
+                        // is being torn down or the host is otherwise handling flow-end.
+                        pendingReauthOperation.value = null
+                        pendingReauthConfig.value = null
+                        pendingReauthState.value = null
+                        pendingResolver.value = null
+                        pendingLinkingCredential.value = null
+                        lastSuccessfulUserId.value = null
                         onSignInCancelled()
                         // Consumed so this doesn't leak to a freshly created screen.
+                        //
+                        // NOT a race with FirebaseAuthActivity's own Aborted collector: cancel()
+                        // (the sole setter of Aborted) now carries @MainThread, enforced by lint,
+                        // not just convention. Activity's collector observes authUI.authStateFlow()
+                        // — a combine(...).distinctUntilChanged() — via Dispatchers.Main.immediate,
+                        // so a main-thread cancel() resumes it in-line and finish() runs before
+                        // cancel() returns. This LaunchedEffect, by contrast, is driven by Compose's
+                        // collectAsState() recomposition, which requires an actual dispatch, so this
+                        // branch and the Idle reset below run strictly after the Activity has
+                        // already finished. See FirebaseAuthActivity's Aborted branch for why that
+                        // in-line resume is a kotlinx-coroutines implementation detail (combine()
+                        // propagating the caller's dispatcher), not an unconditional guarantee.
                         authUI.updateAuthState(AuthState.Idle)
                     }
 

--- a/auth/src/test/java/com/firebase/ui/auth/AuthFlowControllerTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/AuthFlowControllerTest.kt
@@ -213,7 +213,6 @@ class AuthFlowControllerTest {
         // Collect first state after cancel
         val state = controller.authStateFlow.first()
 
-        // Should be Aborted state (AuthFlowController.cancel() is flow-ending)
         assertThat(state).isInstanceOf(AuthState.Aborted::class.java)
     }
 
@@ -438,7 +437,6 @@ class AuthFlowControllerTest {
         // Advance test scheduler to process all pending coroutines
         testScheduler.advanceUntilIdle()
 
-        // Verify aborted state (AuthFlowController.cancel() is flow-ending)
         val state = controller.authStateFlow.first()
         assertThat(state).isInstanceOf(AuthState.Aborted::class.java)
 

--- a/auth/src/test/java/com/firebase/ui/auth/AuthFlowControllerTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/AuthFlowControllerTest.kt
@@ -201,7 +201,7 @@ class AuthFlowControllerTest {
     // =============================================================================================
 
     @Test
-    fun `cancel() updates state to Cancelled`() = runTest {
+    fun `cancel() updates state to Aborted`() = runTest {
         val controller = authUI.createAuthFlow(configuration)
 
         // Cancel the flow
@@ -213,8 +213,8 @@ class AuthFlowControllerTest {
         // Collect first state after cancel
         val state = controller.authStateFlow.first()
 
-        // Should be Cancelled state
-        assertThat(state).isInstanceOf(AuthState.Cancelled::class.java)
+        // Should be Aborted state (AuthFlowController.cancel() is flow-ending)
+        assertThat(state).isInstanceOf(AuthState.Aborted::class.java)
     }
 
     @Test
@@ -438,9 +438,9 @@ class AuthFlowControllerTest {
         // Advance test scheduler to process all pending coroutines
         testScheduler.advanceUntilIdle()
 
-        // Verify cancelled state
+        // Verify aborted state (AuthFlowController.cancel() is flow-ending)
         val state = controller.authStateFlow.first()
-        assertThat(state).isInstanceOf(AuthState.Cancelled::class.java)
+        assertThat(state).isInstanceOf(AuthState.Aborted::class.java)
 
         // Dispose
         controller.dispose()

--- a/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthActivityTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthActivityTest.kt
@@ -313,18 +313,18 @@ class FirebaseAuthActivityTest {
     }
 
     // =============================================================================================
-    // Auth State Cancelled Tests
+    // Auth State Aborted Tests
     // =============================================================================================
 
     @Test
-    fun `activity finishes with RESULT_CANCELED on Cancelled state`() = runTest {
+    fun `activity finishes with RESULT_CANCELED on Aborted state`() = runTest {
         val intent = FirebaseAuthActivity.createIntent(applicationContext, configuration)
         val controller = Robolectric.buildActivity(FirebaseAuthActivity::class.java, intent)
 
         val activity = controller.create().start().resume().get()
 
-        // Update to Cancelled state
-        authUI.updateAuthState(AuthState.Cancelled)
+        // Update to Aborted state (flow-ending cancellation)
+        authUI.updateAuthState(AuthState.Aborted)
 
         shadowOf(Looper.getMainLooper()).idle()
 
@@ -334,6 +334,28 @@ class FirebaseAuthActivityTest {
         // Result should be RESULT_CANCELED
         val shadowActivity = shadowOf(activity)
         assertThat(shadowActivity.resultCode).isEqualTo(Activity.RESULT_CANCELED)
+    }
+
+    // =============================================================================================
+    // Auth State Cancelled Tests
+    // =============================================================================================
+
+    @Test
+    fun `activity does not finish on Cancelled state`() = runTest {
+        val intent = FirebaseAuthActivity.createIntent(applicationContext, configuration)
+        val controller = Robolectric.buildActivity(FirebaseAuthActivity::class.java, intent)
+
+        val activity = controller.create().start().resume().get()
+
+        // Update to Cancelled state (operation-level cancellation, e.g. dismissing a
+        // provider sheet or backing out of an MFA challenge). Since the Cancelled/Aborted
+        // split, Cancelled no longer terminates the flow.
+        authUI.updateAuthState(AuthState.Cancelled)
+
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // Activity should remain open
+        assertThat(activity.isFinishing).isFalse()
     }
 
     // =============================================================================================
@@ -556,6 +578,37 @@ class FirebaseAuthActivityTest {
         shadowOf(Looper.getMainLooper()).idle()
 
         // Activity should NOT finish on RequiresMfa state
+        assertThat(activity.isFinishing).isFalse()
+    }
+
+    // Regression test for the AuthState.Cancelled/Aborted split (CPRN-299): the MFA
+    // challenge screen's onCancel handler emits AuthState.Cancelled. Before the split,
+    // Cancelled always finished FirebaseAuthActivity, so backing out of an MFA challenge
+    // used to terminate the whole sign-in flow. After the split, Cancelled is
+    // operation-level only, so the same onCancel action now correctly keeps the flow
+    // open instead of exiting — a real behavior change for existing beta consumers.
+    @Test
+    fun `activity does not finish when MFA challenge is cancelled`() = runTest {
+        val intent = FirebaseAuthActivity.createIntent(applicationContext, configuration)
+        val controller = Robolectric.buildActivity(FirebaseAuthActivity::class.java, intent)
+
+        val activity = controller.create().start().resume().get()
+
+        // Enter the MFA challenge, as if a resolver was returned.
+        authUI.updateAuthState(AuthState.RequiresMfa(
+            resolver = mockMultiFactorResolver,
+            hint = "Enter verification code"
+        ))
+
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // Simulate the MFA challenge screen's onCancel handler backing out of the
+        // challenge (see FirebaseAuthScreen.kt's MfaChallenge composable onCancel).
+        authUI.updateAuthState(AuthState.Cancelled)
+
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // The flow must stay open: the activity should NOT finish on Cancelled.
         assertThat(activity.isFinishing).isFalse()
     }
 

--- a/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthActivityTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthActivityTest.kt
@@ -323,7 +323,6 @@ class FirebaseAuthActivityTest {
 
         val activity = controller.create().start().resume().get()
 
-        // Update to Aborted state (flow-ending cancellation)
         authUI.updateAuthState(AuthState.Aborted)
 
         shadowOf(Looper.getMainLooper()).idle()
@@ -347,14 +346,10 @@ class FirebaseAuthActivityTest {
 
         val activity = controller.create().start().resume().get()
 
-        // Update to Cancelled state (operation-level cancellation, e.g. dismissing a
-        // provider sheet or backing out of an MFA challenge). Since the Cancelled/Aborted
-        // split, Cancelled no longer terminates the flow.
         authUI.updateAuthState(AuthState.Cancelled)
 
         shadowOf(Looper.getMainLooper()).idle()
 
-        // Activity should remain open
         assertThat(activity.isFinishing).isFalse()
     }
 
@@ -581,12 +576,6 @@ class FirebaseAuthActivityTest {
         assertThat(activity.isFinishing).isFalse()
     }
 
-    // Regression test for the AuthState.Cancelled/Aborted split (CPRN-299): the MFA
-    // challenge screen's onCancel handler emits AuthState.Cancelled. Before the split,
-    // Cancelled always finished FirebaseAuthActivity, so backing out of an MFA challenge
-    // used to terminate the whole sign-in flow. After the split, Cancelled is
-    // operation-level only, so the same onCancel action now correctly keeps the flow
-    // open instead of exiting — a real behavior change for existing beta consumers.
     @Test
     fun `activity does not finish when MFA challenge is cancelled`() = runTest {
         val intent = FirebaseAuthActivity.createIntent(applicationContext, configuration)
@@ -594,7 +583,6 @@ class FirebaseAuthActivityTest {
 
         val activity = controller.create().start().resume().get()
 
-        // Enter the MFA challenge, as if a resolver was returned.
         authUI.updateAuthState(AuthState.RequiresMfa(
             resolver = mockMultiFactorResolver,
             hint = "Enter verification code"
@@ -602,13 +590,10 @@ class FirebaseAuthActivityTest {
 
         shadowOf(Looper.getMainLooper()).idle()
 
-        // Simulate the MFA challenge screen's onCancel handler backing out of the
-        // challenge (see FirebaseAuthScreen.kt's MfaChallenge composable onCancel).
         authUI.updateAuthState(AuthState.Cancelled)
 
         shadowOf(Looper.getMainLooper()).idle()
 
-        // The flow must stay open: the activity should NOT finish on Cancelled.
         assertThat(activity.isFinishing).isFalse()
     }
 

--- a/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthActivityTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthActivityTest.kt
@@ -335,6 +335,26 @@ class FirebaseAuthActivityTest {
         assertThat(shadowActivity.resultCode).isEqualTo(Activity.RESULT_CANCELED)
     }
 
+    @Test
+    fun `Aborted state resets to Idle so a later flow on the same authUI does not immediately finish`() = runTest {
+        val firstIntent = FirebaseAuthActivity.createIntent(applicationContext, configuration)
+        val firstController = Robolectric.buildActivity(FirebaseAuthActivity::class.java, firstIntent)
+        val firstActivity = firstController.create().start().resume().get()
+
+        authUI.updateAuthState(AuthState.Aborted)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertThat(firstActivity.isFinishing).isTrue()
+
+        val secondIntent = FirebaseAuthActivity.createIntent(applicationContext, configuration)
+        val secondController = Robolectric.buildActivity(FirebaseAuthActivity::class.java, secondIntent)
+        val secondActivity = secondController.create().start().resume().get()
+
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertThat(secondActivity.isFinishing).isFalse()
+    }
+
     // =============================================================================================
     // Auth State Cancelled Tests
     // =============================================================================================

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenCancellationTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenCancellationTest.kt
@@ -68,8 +68,16 @@ class FirebaseAuthScreenCancellationTest {
         }
     }
 
+    // Prior to the Cancelled/Aborted split, AuthState.Cancelled always invoked
+    // onSignInCancelled(), so these tests (originally named "...invokes callback once")
+    // asserted the terminal callback fired exactly once for a single-provider config.
+    // Cancelled is now operation-level only — no terminal callback, ever — so the
+    // meaningful assertion for Cancelled is that the callback is NOT invoked. Coverage
+    // for the "callback fires exactly once, not duplicated" concern now belongs to
+    // AuthState.Aborted, verified separately below.
+
     @Test
-    fun `single email provider cancellation invokes callback once`() {
+    fun `single email provider cancellation does not invoke callback`() {
         val configuration = authUIConfiguration {
             context = ApplicationProvider.getApplicationContext()
             providers {
@@ -98,11 +106,11 @@ class FirebaseAuthScreenCancellationTest {
         }
         composeTestRule.waitForIdle()
 
-        assertThat(cancelCount).isEqualTo(1)
+        assertThat(cancelCount).isEqualTo(0)
     }
 
     @Test
-    fun `single phone provider cancellation invokes callback once`() {
+    fun `single phone provider cancellation does not invoke callback`() {
         val configuration = authUIConfiguration {
             context = ApplicationProvider.getApplicationContext()
             providers {
@@ -129,6 +137,73 @@ class FirebaseAuthScreenCancellationTest {
 
         composeTestRule.runOnIdle {
             authUI.updateAuthState(AuthState.Cancelled)
+        }
+        composeTestRule.waitForIdle()
+
+        assertThat(cancelCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `single email provider abort invokes callback exactly once`() {
+        val configuration = authUIConfiguration {
+            context = ApplicationProvider.getApplicationContext()
+            providers {
+                provider(
+                    AuthProvider.Email(
+                        emailLinkActionCodeSettings = null,
+                        passwordValidationRules = emptyList()
+                    )
+                )
+            }
+        }
+        var cancelCount = 0
+
+        composeTestRule.setContent {
+            FirebaseAuthScreen(
+                configuration = configuration,
+                authUI = authUI,
+                onSignInSuccess = {},
+                onSignInFailure = {},
+                onSignInCancelled = { cancelCount++ }
+            )
+        }
+
+        composeTestRule.runOnIdle {
+            authUI.updateAuthState(AuthState.Aborted)
+        }
+        composeTestRule.waitForIdle()
+
+        assertThat(cancelCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `single phone provider abort invokes callback exactly once`() {
+        val configuration = authUIConfiguration {
+            context = ApplicationProvider.getApplicationContext()
+            providers {
+                provider(
+                    AuthProvider.Phone(
+                        defaultNumber = null,
+                        defaultCountryCode = null,
+                        allowedCountries = null
+                    )
+                )
+            }
+        }
+        var cancelCount = 0
+
+        composeTestRule.setContent {
+            FirebaseAuthScreen(
+                configuration = configuration,
+                authUI = authUI,
+                onSignInSuccess = {},
+                onSignInFailure = {},
+                onSignInCancelled = { cancelCount++ }
+            )
+        }
+
+        composeTestRule.runOnIdle {
+            authUI.updateAuthState(AuthState.Aborted)
         }
         composeTestRule.waitForIdle()
 

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenCancellationTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenCancellationTest.kt
@@ -69,7 +69,7 @@ class FirebaseAuthScreenCancellationTest {
     }
 
     @Test
-    fun `single email provider cancellation does not invoke callback`() {
+    fun `single email provider cancellation invokes callback exactly once`() {
         val configuration = authUIConfiguration {
             context = ApplicationProvider.getApplicationContext()
             providers {
@@ -98,11 +98,11 @@ class FirebaseAuthScreenCancellationTest {
         }
         composeTestRule.waitForIdle()
 
-        assertThat(cancelCount).isEqualTo(0)
+        assertThat(cancelCount).isEqualTo(1)
     }
 
     @Test
-    fun `single phone provider cancellation does not invoke callback`() {
+    fun `single phone provider cancellation invokes callback exactly once`() {
         val configuration = authUIConfiguration {
             context = ApplicationProvider.getApplicationContext()
             providers {
@@ -132,11 +132,11 @@ class FirebaseAuthScreenCancellationTest {
         }
         composeTestRule.waitForIdle()
 
-        assertThat(cancelCount).isEqualTo(0)
+        assertThat(cancelCount).isEqualTo(1)
     }
 
     @Test
-    fun `single email provider abort invokes callback exactly once`() {
+    fun `single email provider abort does not invoke callback`() {
         val configuration = authUIConfiguration {
             context = ApplicationProvider.getApplicationContext()
             providers {
@@ -165,11 +165,11 @@ class FirebaseAuthScreenCancellationTest {
         }
         composeTestRule.waitForIdle()
 
-        assertThat(cancelCount).isEqualTo(1)
+        assertThat(cancelCount).isEqualTo(0)
     }
 
     @Test
-    fun `single phone provider abort invokes callback exactly once`() {
+    fun `single phone provider abort does not invoke callback`() {
         val configuration = authUIConfiguration {
             context = ApplicationProvider.getApplicationContext()
             providers {
@@ -199,6 +199,6 @@ class FirebaseAuthScreenCancellationTest {
         }
         composeTestRule.waitForIdle()
 
-        assertThat(cancelCount).isEqualTo(1)
+        assertThat(cancelCount).isEqualTo(0)
     }
 }

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenCancellationTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenCancellationTest.kt
@@ -68,14 +68,6 @@ class FirebaseAuthScreenCancellationTest {
         }
     }
 
-    // Prior to the Cancelled/Aborted split, AuthState.Cancelled always invoked
-    // onSignInCancelled(), so these tests (originally named "...invokes callback once")
-    // asserted the terminal callback fired exactly once for a single-provider config.
-    // Cancelled is now operation-level only — no terminal callback, ever — so the
-    // meaningful assertion for Cancelled is that the callback is NOT invoked. Coverage
-    // for the "callback fires exactly once, not duplicated" concern now belongs to
-    // AuthState.Aborted, verified separately below.
-
     @Test
     fun `single email provider cancellation does not invoke callback`() {
         val configuration = authUIConfiguration {

--- a/docs/upgrade-to-10.0.md
+++ b/docs/upgrade-to-10.0.md
@@ -394,6 +394,56 @@ class AuthActivity : ComponentActivity() {
 }
 ```
 
+## Breaking Change: `AuthState.Cancelled` Split into `Cancelled` and `Aborted` (beta04)
+
+Prior to `10.0.0-beta04`, `AuthState.Cancelled` was used for two different situations:
+cancelling a single sign-in attempt (e.g. dismissing the Credential Manager sheet, backing
+out of an MFA challenge) **and** ending the whole authentication flow via
+`AuthFlowController.cancel()`. Because both cases emitted the same state, any consumer that
+matched on `AuthState.Cancelled` to tear down its UI would also tear down the flow when the
+user simply backed out of one provider — even though the flow was meant to stay open and
+return to the method picker.
+
+`AuthState.Cancelled` and `AuthState.Aborted` now have distinct meanings:
+
+- **`AuthState.Cancelled`** — operation-level. The user backed out of a single sign-in
+  attempt. The flow stays open and returns to the method picker. `FirebaseAuthActivity` does
+  **not** finish, and `onSignInCancelled()` is **not** called.
+- **`AuthState.Aborted`** (new) — flow-ending. Emitted only by `AuthFlowController.cancel()`.
+  `FirebaseAuthActivity` finishes with `RESULT_CANCELED`, and `onSignInCancelled()` is called.
+
+**What to do:** If you match on `AuthState.Cancelled` expecting the flow-termination
+semantics of `AuthFlowController.cancel()` (e.g. finishing an Activity, navigating away),
+change that branch to match `AuthState.Aborted` instead:
+
+**Old (pre-beta04):**
+```kotlin
+when (state) {
+    is AuthState.Cancelled -> {
+        // Flow was cancelled
+        finish()
+    }
+    // ...
+}
+```
+
+**New (beta04+):**
+```kotlin
+when (state) {
+    is AuthState.Cancelled -> {
+        // User cancelled a single sign-in attempt; the flow stays open
+    }
+    is AuthState.Aborted -> {
+        // Flow was ended via controller.cancel()
+        finish()
+    }
+    // ...
+}
+```
+
+This is a behavioral change only (`AuthState` is not `sealed`, so no compile break occurs).
+It only affects `10.0.0` beta releases (beta01–beta03), which have not shipped stable.
+
 ## Common Issues and Solutions
 
 ### Issue: "Unresolved reference: authUIConfiguration"

--- a/docs/upgrade-to-10.0.md
+++ b/docs/upgrade-to-10.0.md
@@ -394,56 +394,6 @@ class AuthActivity : ComponentActivity() {
 }
 ```
 
-## Breaking Change: `AuthState.Cancelled` Split into `Cancelled` and `Aborted` (beta04)
-
-Prior to `10.0.0-beta04`, `AuthState.Cancelled` was used for two different situations:
-cancelling a single sign-in attempt (e.g. dismissing the Credential Manager sheet, backing
-out of an MFA challenge) **and** ending the whole authentication flow via
-`AuthFlowController.cancel()`. Because both cases emitted the same state, any consumer that
-matched on `AuthState.Cancelled` to tear down its UI would also tear down the flow when the
-user simply backed out of one provider — even though the flow was meant to stay open and
-return to the method picker.
-
-`AuthState.Cancelled` and `AuthState.Aborted` now have distinct meanings:
-
-- **`AuthState.Cancelled`** — operation-level. The user backed out of a single sign-in
-  attempt. The flow stays open and returns to the method picker. `FirebaseAuthActivity` does
-  **not** finish, and `onSignInCancelled()` is **not** called.
-- **`AuthState.Aborted`** (new) — flow-ending. Emitted only by `AuthFlowController.cancel()`.
-  `FirebaseAuthActivity` finishes with `RESULT_CANCELED`, and `onSignInCancelled()` is called.
-
-**What to do:** If you match on `AuthState.Cancelled` expecting the flow-termination
-semantics of `AuthFlowController.cancel()` (e.g. finishing an Activity, navigating away),
-change that branch to match `AuthState.Aborted` instead:
-
-**Old (pre-beta04):**
-```kotlin
-when (state) {
-    is AuthState.Cancelled -> {
-        // Flow was cancelled
-        finish()
-    }
-    // ...
-}
-```
-
-**New (beta04+):**
-```kotlin
-when (state) {
-    is AuthState.Cancelled -> {
-        // User cancelled a single sign-in attempt; the flow stays open
-    }
-    is AuthState.Aborted -> {
-        // Flow was ended via controller.cancel()
-        finish()
-    }
-    // ...
-}
-```
-
-This is a behavioral change only (`AuthState` is not `sealed`, so no compile break occurs).
-It only affects `10.0.0` beta releases (beta01–beta03), which have not shipped stable.
-
 ## Common Issues and Solutions
 
 ### Issue: "Unresolved reference: authUIConfiguration"


### PR DESCRIPTION
Splits `AuthState.Cancelled` into two states: it was overloaded to mean both "user backed out of one provider's sheet" (should stay in the flow) and "exit the whole auth Activity" - but `FirebaseAuthActivity` only implemented the latter, so any per-provider cancel would exit the whole flow instead of returning to the method picker.

- `AuthState.kt`: adds `AuthState.Aborted` for "flow ended programmatically, exit entirely"; `Cancelled` now means "this sign-in attempt was cancelled, stay in the flow."
- `FirebaseAuthActivity.kt`: only finishes the Activity on `Aborted`, not `Cancelled`.
- `AuthFlowController.kt`: `cancel()` now emits `AuthState.Aborted` instead of `AuthState.Cancelled` — **breaking change** for any consumer pattern-matching on `is AuthState.Cancelled` to detect a host-initiated `cancel()`.
- `FirebaseAuthScreen.kt`: adds an `Aborted` branch mirroring `Cancelled`'s reset/self-consume handling.
- `README.md`: documents `AuthState.Aborted` alongside `Cancelled` in the `AuthFlowController` and low-level API examples.

Added a test confirming the Activity does *not* finish on `Cancelled`, and updated the existing cancel-flow tests to assert `Aborted` instead.