### PR TITLE
fix(e2e): fix flaky Google credential-linking test

### DIFF
--- a/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/CredentialLinkingScreenTest.kt
+++ b/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/CredentialLinkingScreenTest.kt
@@ -248,11 +248,16 @@ class CredentialLinkingScreenTest {
         shadowOf(Looper.getMainLooper()).idle()
 
         // Step 7: Wait for success
+        // Note: `currentAuthState` may already be `AuthState.Success` from the initial
+        // email/password sign-in, so checking `is AuthState.Success` alone can pass
+        // immediately before the phone link has actually completed. Wait for the
+        // linked provider to actually show up on the (mutated-in-place) user instead.
         println("TEST: Waiting for auth state change after phone verification...")
         composeTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
             shadowOf(Looper.getMainLooper()).idle()
             println("TEST: Auth state: $currentAuthState")
-            currentAuthState is AuthState.Success
+            val state = currentAuthState
+            state is AuthState.Success && state.user.providerData.any { it.providerId == "phone" }
         }
 
         // Step 8: Verify the UID is preserved (linking happened, not a new account)
@@ -369,11 +374,16 @@ class CredentialLinkingScreenTest {
         shadowOf(Looper.getMainLooper()).idle()
 
         // Step 6: Wait for linking to complete
+        // Note: `currentAuthState` may already be `AuthState.Success` from the initial
+        // email/password sign-in, so checking `is AuthState.Success` alone can pass
+        // immediately before the Google link has actually completed. Wait for the
+        // linked provider to actually show up on the (mutated-in-place) user instead.
         println("TEST: Waiting for Google linking to complete...")
         composeTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
             shadowOf(Looper.getMainLooper()).idle()
             println("TEST: Auth state: $currentAuthState")
-            currentAuthState is AuthState.Success
+            val state = currentAuthState
+            state is AuthState.Success && state.user.providerData.any { it.providerId == "google.com" }
         }
 
         // Step 7: Verify the UID is preserved and Google provider is added


### PR DESCRIPTION
`isCredentialLinkingEnabled links Google to existing email user preserving UID` flaked once on CI (run 32249308037, PR #2449) with an `AssertionErrorWithFacts`, then passed clean on retry with no code changes.

Root cause: `currentAuthState is AuthState.Success` is already true from the initial email/password sign-in, and stays true through the Google-link step because `AuthState.Success.equals` compares the wrapped `FirebaseUser` by reference — Firebase mutates the same `currentUser` instance in place during linking rather than replacing it. So `waitUntil { currentAuthState is AuthState.Success }` can pass on the stale pre-link value before `linkWithCredential()` + profile merge finish, and the assertions occasionally read `providerData` mid-link.

Fix: both linking `waitUntil` checks (Google and phone) now also require the linked provider to actually be present on `providerData`, tying the wait to the real postcondition instead of racing on `AuthState` identity.

Verified with 5+ repeated `./gradlew e2eTest --tests CredentialLinkingScreenTest` runs plus the full `e2eTest` suite.