### PR TITLE
test(auth): pin onComplete and factor refresh on successful MFA enrollment

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentScreen.kt
@@ -77,11 +77,47 @@ fun MfaEnrollmentScreen(
     val activity = requireNotNull(LocalActivity.current) {
         "MfaEnrollmentScreen must be used within an Activity context for SMS verification"
     }
-    val coroutineScope = rememberCoroutineScope()
-    val applicationContext = LocalContext.current.applicationContext
 
     val smsHandler = remember(activity, auth, user) { SmsEnrollmentHandler(activity, auth, user) }
     val totpHandler = remember(auth, user) { TotpEnrollmentHandler(auth, user) }
+
+    MfaEnrollmentScreenInternal(
+        user = user,
+        auth = auth,
+        configuration = configuration,
+        smsHandler = smsHandler,
+        totpHandler = totpHandler,
+        authConfiguration = authConfiguration,
+        onComplete = onComplete,
+        onSkip = onSkip,
+        onError = onError,
+        content = content
+    )
+}
+
+/**
+ * Handler-injection seam behind [MfaEnrollmentScreen].
+ *
+ * Holds the entire enrollment state machine while taking [smsHandler] and [totpHandler] as
+ * parameters, so unit tests can substitute stubbed handlers instead of hitting real Firebase
+ * statics. The public [MfaEnrollmentScreen] constructs the real handlers and delegates here;
+ * this function exists only so the handlers are injectable and is not part of the public API.
+ */
+@Composable
+internal fun MfaEnrollmentScreenInternal(
+    user: FirebaseUser,
+    auth: FirebaseAuth,
+    configuration: MfaConfiguration,
+    smsHandler: SmsEnrollmentHandler,
+    totpHandler: TotpEnrollmentHandler,
+    authConfiguration: AuthUIConfiguration? = null,
+    onComplete: () -> Unit,
+    onSkip: () -> Unit = {},
+    onError: (Exception) -> Unit = {},
+    content: @Composable ((MfaEnrollmentContentState) -> Unit)? = null
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val applicationContext = LocalContext.current.applicationContext
 
     val currentStep = rememberSaveable { mutableStateOf(MfaEnrollmentStep.SelectFactor) }
     val selectedFactor = rememberSaveable { mutableStateOf<MfaFactor?>(null) }

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/MfaEnrollmentScreenTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/MfaEnrollmentScreenTest.kt
@@ -17,6 +17,7 @@ package com.firebase.ui.auth.ui.screens
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.firebase.ui.auth.configuration.MfaConfiguration
 import com.firebase.ui.auth.configuration.MfaFactor
@@ -492,6 +493,79 @@ class MfaEnrollmentScreenTest {
     }
 
     @Test
+    fun `TOTP verification without a secret reports the missing secret and skips onComplete`() {
+        val configuration = MfaConfiguration(allowedFactors = listOf(MfaFactor.Sms, MfaFactor.Totp))
+        var completeCount = 0
+        val errors = mutableListOf<Exception>()
+
+        var currentState by mutableStateOf<MfaEnrollmentContentState?>(null)
+
+        // Two allowed factors, so nothing is auto-selected: the secret is generated only when the
+        // TOTP factor is picked, which keeps the restore below from regenerating it.
+        val restorationTester = StateRestorationTester(composeTestRule)
+        restorationTester.setContent {
+            MfaEnrollmentScreenInternal(
+                user = mockUser,
+                auth = mockAuth,
+                configuration = configuration,
+                smsHandler = mockSmsHandler,
+                totpHandler = mockTotpHandler,
+                onComplete = { completeCount++ },
+                onError = { errors.add(it) }
+            ) { state ->
+                currentState = state
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        assertEquals(MfaEnrollmentStep.SelectFactor, currentState?.step)
+
+        composeTestRule.runOnUiThread {
+            currentState?.onFactorSelected?.invoke(MfaFactor.Totp)
+        }
+        composeTestRule.waitForIdle()
+        assertEquals(MfaEnrollmentStep.ConfigureTotp, currentState?.step)
+        assertEquals(totpSecret, currentState?.totpSecret)
+
+        composeTestRule.runOnUiThread {
+            currentState?.onContinueToVerifyClick?.invoke()
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnUiThread {
+            currentState?.onVerificationCodeChange?.invoke(VERIFICATION_CODE)
+        }
+        composeTestRule.waitForIdle()
+        assertEquals(MfaEnrollmentStep.VerifyFactor, currentState?.step)
+
+        // Reach the verify step without a secret the way production does: across process death.
+        // `currentStep`, `selectedFactor` and `verificationCode` are `rememberSaveable` and are
+        // restored, while `totpSecret` is a plain `remember` and is not. That step/secret mismatch
+        // is what `onVerifyClick`'s null-secret branch guards.
+        restorationTester.emulateSavedInstanceStateRestore()
+        composeTestRule.waitForIdle()
+        assertEquals(MfaEnrollmentStep.VerifyFactor, currentState?.step)
+        assertEquals(MfaFactor.Totp, currentState?.selectedFactor)
+        assertNull(currentState?.totpSecret)
+        // The restore itself must be quiet, so the only error below is the one under test.
+        assertEquals(emptyList<Exception>(), errors)
+
+        composeTestRule.runOnUiThread {
+            currentState?.onVerifyClick?.invoke()
+        }
+        composeTestRule.waitForIdle()
+
+        assertEquals(0, completeCount)
+        assertEquals(1, errors.size)
+        assertTrue(errors.single() is IllegalStateException)
+        assertEquals(NO_TOTP_SECRET_MESSAGE, errors.single().message)
+        assertEquals(errors.single(), currentState?.exception)
+        assertEquals(NO_TOTP_SECRET_MESSAGE, currentState?.error)
+        assertEquals(MfaEnrollmentStep.VerifyFactor, currentState?.step)
+        assertEquals(false, currentState?.isLoading)
+    }
+
+    @Test
     fun `successful SMS enrollment enrolls the entered code and fires onComplete once`() {
         var completeCount = 0
         val errors = mutableListOf<Exception>()
@@ -789,6 +863,11 @@ class MfaEnrollmentScreenTest {
                 displayName = SMS_DISPLAY_NAME
             )
         }
+        // And it must reach the handler cleanly: a resend must not leave the terminal enroll
+        // reporting an error.
+        assertEquals(emptyList<Exception>(), errors)
+        assertNull(state()?.error)
+        assertNull(state()?.exception)
     }
 
     /**
@@ -901,6 +980,7 @@ class MfaEnrollmentScreenTest {
         const val VERIFICATION_CODE = "123456"
         const val TOTP_DISPLAY_NAME = "Authenticator App"
         const val SMS_DISPLAY_NAME = "SMS"
+        const val NO_TOTP_SECRET_MESSAGE = "No TOTP secret available"
         const val NO_SMS_SESSION_MESSAGE = "No SMS session available"
         const val LOCAL_PHONE_NUMBER = "5551234567"
         const val EXPECTED_FULL_PHONE_NUMBER = "+445551234567"

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/MfaEnrollmentScreenTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/MfaEnrollmentScreenTest.kt
@@ -22,10 +22,15 @@ import com.firebase.ui.auth.configuration.MfaConfiguration
 import com.firebase.ui.auth.configuration.MfaFactor
 import com.firebase.ui.auth.mfa.MfaEnrollmentContentState
 import com.firebase.ui.auth.mfa.MfaEnrollmentStep
+import com.firebase.ui.auth.mfa.SmsEnrollmentHandler
+import com.firebase.ui.auth.mfa.TotpEnrollmentHandler
+import com.firebase.ui.auth.mfa.TotpSecret
 import com.firebase.ui.auth.ui.screens.mfa.MfaEnrollmentScreen
+import com.firebase.ui.auth.ui.screens.mfa.MfaEnrollmentScreenInternal
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.MultiFactorInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -38,9 +43,14 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import com.google.firebase.auth.TotpSecret as FirebaseTotpSecret
 
 /**
  * Unit tests for [MfaEnrollmentScreen].
@@ -67,6 +77,17 @@ class MfaEnrollmentScreenTest {
     @Mock
     private lateinit var mockMultiFactor: com.google.firebase.auth.MultiFactor
 
+    @Mock
+    private lateinit var mockSmsHandler: SmsEnrollmentHandler
+
+    @Mock
+    private lateinit var mockTotpHandler: TotpEnrollmentHandler
+
+    @Mock
+    private lateinit var mockFirebaseTotpSecret: FirebaseTotpSecret
+
+    private lateinit var totpSecret: TotpSecret
+
     private lateinit var capturedState: MfaEnrollmentContentState
 
     @Before
@@ -78,6 +99,11 @@ class MfaEnrollmentScreenTest {
         `when`(mockUser.email).thenReturn("test@example.com")
         `when`(mockUser.multiFactor).thenReturn(mockMultiFactor)
         `when`(mockMultiFactor.enrolledFactors).thenReturn(emptyList())
+        `when`(mockFirebaseTotpSecret.sharedSecretKey).thenReturn("SECRET")
+        `when`(mockFirebaseTotpSecret.generateQrCodeUrl("test@example.com", "TestApp"))
+            .thenReturn("otpauth://totp/test@example.com?secret=SECRET&issuer=TestApp")
+        totpSecret = TotpSecret.from(mockFirebaseTotpSecret)
+        whenever { mockTotpHandler.generateSecret() }.thenReturn(totpSecret)
     }
 
     @Test
@@ -358,5 +384,148 @@ class MfaEnrollmentScreenTest {
 
         composeTestRule.waitForIdle()
         assertTrue(capturedState.canGoBack)
+    }
+
+    @Test
+    fun `successful TOTP enrollment enrolls the entered code and fires onComplete once`() {
+        val configuration = MfaConfiguration(allowedFactors = listOf(MfaFactor.Totp))
+        var completeCount = 0
+        val errors = mutableListOf<Exception>()
+
+        val state = driveTotpFlowToVerifyStep(
+            configuration = configuration,
+            onComplete = { completeCount++ },
+            onError = { errors.add(it) }
+        )
+
+        composeTestRule.runOnUiThread {
+            state()?.onVerifyClick?.invoke()
+        }
+        composeTestRule.waitForIdle()
+
+        // Exact arguments: the enrolled secret and code must be the ones the screen collected.
+        verifyBlocking(mockTotpHandler) {
+            enrollWithVerificationCode(
+                totpSecret = totpSecret,
+                verificationCode = VERIFICATION_CODE,
+                displayName = TOTP_DISPLAY_NAME
+            )
+        }
+        assertEquals(1, completeCount)
+        assertEquals(emptyList<Exception>(), errors)
+        // The screen does not navigate away on success; the host decides via onComplete.
+        assertEquals(MfaEnrollmentStep.VerifyFactor, state()?.step)
+        assertEquals(false, state()?.isLoading)
+        assertNull(state()?.error)
+        assertNull(state()?.exception)
+    }
+
+    @Test
+    fun `successful TOTP enrollment refreshes the enrolled factors from the user`() {
+        val enrolledFactor = mock<MultiFactorInfo>()
+        // First read is the initial state; the second is the post-enrollment refresh.
+        `when`(mockMultiFactor.enrolledFactors)
+            .thenReturn(emptyList(), listOf(enrolledFactor))
+
+        val state = driveTotpFlowToVerifyStep(
+            configuration = MfaConfiguration(allowedFactors = listOf(MfaFactor.Totp)),
+            onComplete = {}
+        )
+
+        assertEquals(emptyList<MultiFactorInfo>(), state()?.enrolledFactors)
+
+        composeTestRule.runOnUiThread {
+            state()?.onVerifyClick?.invoke()
+        }
+        composeTestRule.waitForIdle()
+
+        assertEquals(listOf(enrolledFactor), state()?.enrolledFactors)
+    }
+
+    @Test
+    fun `failed TOTP enrollment reports the exception and does not fire onComplete`() {
+        val configuration = MfaConfiguration(allowedFactors = listOf(MfaFactor.Totp))
+        val failure = IllegalStateException("invalid verification code")
+        whenever {
+            mockTotpHandler.enrollWithVerificationCode(
+                totpSecret = totpSecret,
+                verificationCode = VERIFICATION_CODE,
+                displayName = TOTP_DISPLAY_NAME
+            )
+        }.doThrow(failure)
+
+        var completeCount = 0
+        val errors = mutableListOf<Exception>()
+
+        val state = driveTotpFlowToVerifyStep(
+            configuration = configuration,
+            onComplete = { completeCount++ },
+            onError = { errors.add(it) }
+        )
+
+        composeTestRule.runOnUiThread {
+            state()?.onVerifyClick?.invoke()
+        }
+        composeTestRule.waitForIdle()
+
+        assertEquals(0, completeCount)
+        assertEquals(listOf<Exception>(failure), errors)
+        assertEquals(failure, state()?.exception)
+        assertEquals("invalid verification code", state()?.error)
+        assertEquals(MfaEnrollmentStep.VerifyFactor, state()?.step)
+        assertEquals(false, state()?.isLoading)
+    }
+
+    /**
+     * Renders [MfaEnrollmentScreenInternal] with the stubbed enrollment handlers and drives the
+     * TOTP route up to (but not including) the verify click.
+     *
+     * @return an accessor for the latest [MfaEnrollmentContentState] emitted by the screen
+     */
+    private fun driveTotpFlowToVerifyStep(
+        configuration: MfaConfiguration,
+        onComplete: () -> Unit,
+        onError: (Exception) -> Unit = {}
+    ): () -> MfaEnrollmentContentState? {
+        var currentState by mutableStateOf<MfaEnrollmentContentState?>(null)
+
+        composeTestRule.setContent {
+            MfaEnrollmentScreenInternal(
+                user = mockUser,
+                auth = mockAuth,
+                configuration = configuration,
+                smsHandler = mockSmsHandler,
+                totpHandler = mockTotpHandler,
+                onComplete = onComplete,
+                onError = onError
+            ) { state ->
+                currentState = state
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        // A single allowed factor auto-selects TOTP and generates the secret.
+        assertEquals(MfaEnrollmentStep.ConfigureTotp, currentState?.step)
+        assertEquals(totpSecret, currentState?.totpSecret)
+
+        composeTestRule.runOnUiThread {
+            currentState?.onContinueToVerifyClick?.invoke()
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnUiThread {
+            currentState?.onVerificationCodeChange?.invoke(VERIFICATION_CODE)
+        }
+        composeTestRule.waitForIdle()
+
+        assertEquals(MfaEnrollmentStep.VerifyFactor, currentState?.step)
+        assertEquals(VERIFICATION_CODE, currentState?.verificationCode)
+
+        return { currentState }
+    }
+
+    private companion object {
+        const val VERIFICATION_CODE = "123456"
+        const val TOTP_DISPLAY_NAME = "Authenticator App"
     }
 }

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/MfaEnrollmentScreenTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/MfaEnrollmentScreenTest.kt
@@ -20,9 +20,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.firebase.ui.auth.configuration.MfaConfiguration
 import com.firebase.ui.auth.configuration.MfaFactor
+import com.firebase.ui.auth.data.CountryData
 import com.firebase.ui.auth.mfa.MfaEnrollmentContentState
 import com.firebase.ui.auth.mfa.MfaEnrollmentStep
 import com.firebase.ui.auth.mfa.SmsEnrollmentHandler
+import com.firebase.ui.auth.mfa.SmsEnrollmentSession
 import com.firebase.ui.auth.mfa.TotpEnrollmentHandler
 import com.firebase.ui.auth.mfa.TotpSecret
 import com.firebase.ui.auth.ui.screens.mfa.MfaEnrollmentScreen
@@ -31,6 +33,7 @@ import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.MultiFactorInfo
+import com.google.firebase.auth.PhoneAuthProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -45,6 +48,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
@@ -88,6 +92,8 @@ class MfaEnrollmentScreenTest {
 
     private lateinit var totpSecret: TotpSecret
 
+    private lateinit var smsSession: SmsEnrollmentSession
+
     private lateinit var capturedState: MfaEnrollmentContentState
 
     @Before
@@ -104,6 +110,12 @@ class MfaEnrollmentScreenTest {
             .thenReturn("otpauth://totp/test@example.com?secret=SECRET&issuer=TestApp")
         totpSecret = TotpSecret.from(mockFirebaseTotpSecret)
         whenever { mockTotpHandler.generateSecret() }.thenReturn(totpSecret)
+        smsSession = SmsEnrollmentSession(
+            verificationId = "verification-id",
+            phoneNumber = EXPECTED_FULL_PHONE_NUMBER,
+            forceResendingToken = mock<PhoneAuthProvider.ForceResendingToken>(),
+            sentAt = 0L
+        )
     }
 
     @Test
@@ -418,6 +430,9 @@ class MfaEnrollmentScreenTest {
         assertEquals(false, state()?.isLoading)
         assertNull(state()?.error)
         assertNull(state()?.exception)
+        // The resend affordance is SMS-only: the TOTP route must not expose one.
+        assertNotNull(state())
+        assertNull(state()?.onResendCodeClick)
     }
 
     @Test
@@ -476,6 +491,364 @@ class MfaEnrollmentScreenTest {
         assertEquals(false, state()?.isLoading)
     }
 
+    @Test
+    fun `successful SMS enrollment enrolls the entered code and fires onComplete once`() {
+        var completeCount = 0
+        val errors = mutableListOf<Exception>()
+
+        val state = driveSmsFlowToVerifyStep(
+            onComplete = { completeCount++ },
+            onError = { errors.add(it) }
+        )
+
+        composeTestRule.runOnUiThread {
+            state()?.onVerifyClick?.invoke()
+        }
+        composeTestRule.waitForIdle()
+
+        // Exact arguments: the session must be the one sendVerificationCode handed back, the code
+        // the one the screen collected, and the display name the SMS factor label.
+        verifyBlocking(mockSmsHandler) {
+            enrollWithVerificationCode(
+                session = smsSession,
+                verificationCode = VERIFICATION_CODE,
+                displayName = SMS_DISPLAY_NAME
+            )
+        }
+        assertEquals(1, completeCount)
+        assertEquals(emptyList<Exception>(), errors)
+        // The screen does not navigate away on success; the host decides via onComplete.
+        // onComplete lives after the `when`, so this is the call site shared with the TOTP route.
+        assertEquals(MfaEnrollmentStep.VerifyFactor, state()?.step)
+        assertEquals(false, state()?.isLoading)
+        assertNull(state()?.error)
+        assertNull(state()?.exception)
+    }
+
+    @Test
+    fun `sending the SMS code prefixes the selected dial code and stores the session`() {
+        val configuration = MfaConfiguration(allowedFactors = listOf(MfaFactor.Sms))
+        val errors = mutableListOf<Exception>()
+
+        // Exact-argument stub: the screen must ask for the dial-code-prefixed number, and the
+        // session it hands back is the one the screen has to remember.
+        whenever { mockSmsHandler.sendVerificationCode(EXPECTED_FULL_PHONE_NUMBER) }
+            .thenReturn(smsSession)
+
+        var currentState by mutableStateOf<MfaEnrollmentContentState?>(null)
+
+        composeTestRule.setContent {
+            MfaEnrollmentScreenInternal(
+                user = mockUser,
+                auth = mockAuth,
+                configuration = configuration,
+                smsHandler = mockSmsHandler,
+                totpHandler = mockTotpHandler,
+                onComplete = {},
+                onError = { errors.add(it) }
+            ) { state ->
+                currentState = state
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        assertEquals(MfaEnrollmentStep.ConfigureSms, currentState?.step)
+
+        composeTestRule.runOnUiThread {
+            currentState?.onCountrySelected?.invoke(TEST_COUNTRY)
+            currentState?.onPhoneNumberChange?.invoke(LOCAL_PHONE_NUMBER)
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnUiThread {
+            currentState?.onSendSmsCodeClick?.invoke()
+        }
+        composeTestRule.waitForIdle()
+
+        // The dial code of the selected country is prefixed to the entered local number.
+        verifyBlocking(mockSmsHandler) {
+            sendVerificationCode(EXPECTED_FULL_PHONE_NUMBER)
+        }
+        // A successful send advances to the verify step and clears any prior error.
+        assertEquals(MfaEnrollmentStep.VerifyFactor, currentState?.step)
+        assertEquals(emptyList<Exception>(), errors)
+        assertNull(currentState?.error)
+        assertNull(currentState?.exception)
+        assertEquals(false, currentState?.isLoading)
+        // A resend affordance only exists on the SMS route.
+        assertNotNull(currentState?.onResendCodeClick)
+
+        // The stored session is the one the send returned: enrolling reaches the handler with it
+        // rather than failing on a missing session.
+        composeTestRule.runOnUiThread {
+            currentState?.onVerificationCodeChange?.invoke(VERIFICATION_CODE)
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnUiThread {
+            currentState?.onVerifyClick?.invoke()
+        }
+        composeTestRule.waitForIdle()
+
+        verifyBlocking(mockSmsHandler) {
+            enrollWithVerificationCode(
+                session = smsSession,
+                verificationCode = VERIFICATION_CODE,
+                displayName = SMS_DISPLAY_NAME
+            )
+        }
+        assertEquals(emptyList<Exception>(), errors)
+        assertNull(currentState?.error)
+    }
+
+    @Test
+    fun `failed SMS send reports the exception and stays on the configure step`() {
+        val configuration = MfaConfiguration(allowedFactors = listOf(MfaFactor.Sms))
+        val failure = IllegalArgumentException("Phone number must be in E.164 format")
+        whenever { mockSmsHandler.sendVerificationCode(EXPECTED_FULL_PHONE_NUMBER) }
+            .doThrow(failure)
+
+        var completeCount = 0
+        val errors = mutableListOf<Exception>()
+
+        var currentState by mutableStateOf<MfaEnrollmentContentState?>(null)
+
+        composeTestRule.setContent {
+            MfaEnrollmentScreenInternal(
+                user = mockUser,
+                auth = mockAuth,
+                configuration = configuration,
+                smsHandler = mockSmsHandler,
+                totpHandler = mockTotpHandler,
+                onComplete = { completeCount++ },
+                onError = { errors.add(it) }
+            ) { state ->
+                currentState = state
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        assertEquals(MfaEnrollmentStep.ConfigureSms, currentState?.step)
+
+        composeTestRule.runOnUiThread {
+            currentState?.onCountrySelected?.invoke(TEST_COUNTRY)
+            currentState?.onPhoneNumberChange?.invoke(LOCAL_PHONE_NUMBER)
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnUiThread {
+            currentState?.onSendSmsCodeClick?.invoke()
+        }
+        composeTestRule.waitForIdle()
+
+        // onSendSmsCodeClick owns a catch block of its own, distinct from onVerifyClick's: a send
+        // failure has to surface through it instead of being swallowed.
+        assertEquals(listOf<Exception>(failure), errors)
+        assertEquals(failure, currentState?.exception)
+        assertEquals("Phone number must be in E.164 format", currentState?.error)
+        // A failed send must not park the user on the verify step with no session.
+        assertEquals(MfaEnrollmentStep.ConfigureSms, currentState?.step)
+        assertEquals(false, currentState?.isLoading)
+        assertEquals(0, completeCount)
+    }
+
+    @Test
+    fun `SMS verification without a session reports the missing session and skips onComplete`() {
+        val configuration = MfaConfiguration(allowedFactors = listOf(MfaFactor.Sms))
+        var completeCount = 0
+        val errors = mutableListOf<Exception>()
+
+        var currentState by mutableStateOf<MfaEnrollmentContentState?>(null)
+
+        composeTestRule.setContent {
+            MfaEnrollmentScreenInternal(
+                user = mockUser,
+                auth = mockAuth,
+                configuration = configuration,
+                smsHandler = mockSmsHandler,
+                totpHandler = mockTotpHandler,
+                onComplete = { completeCount++ },
+                onError = { errors.add(it) }
+            ) { state ->
+                currentState = state
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        assertEquals(MfaEnrollmentStep.ConfigureSms, currentState?.step)
+
+        // Reach the verify step without ever sending a code, so no SMS session exists. In
+        // production this state is reached across process death: `currentStep` is
+        // `rememberSaveable` and is restored, while `smsSession` is a plain `remember` and is not.
+        // `onContinueToVerifyClick` is only the cheapest way to reproduce that step/session
+        // mismatch here — the guard under test is `onVerifyClick`'s null-session branch, not this
+        // callback, so tightening `onContinueToVerifyClick` to the TOTP route should not be read
+        // as invalidating this test.
+        composeTestRule.runOnUiThread {
+            currentState?.onContinueToVerifyClick?.invoke()
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnUiThread {
+            currentState?.onVerificationCodeChange?.invoke(VERIFICATION_CODE)
+        }
+        composeTestRule.waitForIdle()
+        assertEquals(MfaEnrollmentStep.VerifyFactor, currentState?.step)
+
+        composeTestRule.runOnUiThread {
+            currentState?.onVerifyClick?.invoke()
+        }
+        composeTestRule.waitForIdle()
+
+        assertEquals(0, completeCount)
+        assertEquals(1, errors.size)
+        assertTrue(errors.single() is IllegalStateException)
+        assertEquals(NO_SMS_SESSION_MESSAGE, errors.single().message)
+        assertEquals(errors.single(), currentState?.exception)
+        assertEquals(NO_SMS_SESSION_MESSAGE, currentState?.error)
+        assertEquals(MfaEnrollmentStep.VerifyFactor, currentState?.step)
+        assertEquals(false, currentState?.isLoading)
+    }
+
+    @Test
+    fun `failed SMS enrollment reports the exception and does not fire onComplete`() {
+        val failure = IllegalStateException("invalid verification code")
+        whenever {
+            mockSmsHandler.enrollWithVerificationCode(
+                session = smsSession,
+                verificationCode = VERIFICATION_CODE,
+                displayName = SMS_DISPLAY_NAME
+            )
+        }.doThrow(failure)
+
+        var completeCount = 0
+        val errors = mutableListOf<Exception>()
+
+        val state = driveSmsFlowToVerifyStep(
+            onComplete = { completeCount++ },
+            onError = { errors.add(it) }
+        )
+
+        composeTestRule.runOnUiThread {
+            state()?.onVerifyClick?.invoke()
+        }
+        composeTestRule.waitForIdle()
+
+        assertEquals(0, completeCount)
+        assertEquals(listOf<Exception>(failure), errors)
+        assertEquals(failure, state()?.exception)
+        assertEquals("invalid verification code", state()?.error)
+        assertEquals(MfaEnrollmentStep.VerifyFactor, state()?.step)
+        assertEquals(false, state()?.isLoading)
+    }
+
+    @Test
+    fun `resending the SMS code replaces the session used for enrollment`() {
+        val resentSession = smsSession.copy(verificationId = "resent-verification-id")
+        whenever { mockSmsHandler.resendVerificationCode(smsSession) }.thenReturn(resentSession)
+
+        val errors = mutableListOf<Exception>()
+        val state = driveSmsFlowToVerifyStep(onComplete = {}, onError = { errors.add(it) })
+
+        // Resend is gated on the timer the send started: clicking while it still runs is a no-op,
+        // which is the rate limit RESEND_DELAY_SECONDS exists to enforce.
+        assertEquals(SmsEnrollmentHandler.RESEND_DELAY_SECONDS, state()?.resendTimer)
+        composeTestRule.runOnUiThread {
+            state()?.onResendCodeClick?.invoke()
+        }
+        composeTestRule.waitForIdle()
+        verifyBlocking(mockSmsHandler, never()) { resendVerificationCode(smsSession) }
+
+        // Run the timer down on the test clock so the gate opens.
+        composeTestRule.mainClock.advanceTimeBy(
+            SmsEnrollmentHandler.RESEND_DELAY_SECONDS * 1000L + 1000L
+        )
+        composeTestRule.waitForIdle()
+        assertEquals(0, state()?.resendTimer)
+
+        composeTestRule.runOnUiThread {
+            state()?.onResendCodeClick?.invoke()
+        }
+        composeTestRule.waitForIdle()
+
+        verifyBlocking(mockSmsHandler) { resendVerificationCode(smsSession) }
+        assertEquals(emptyList<Exception>(), errors)
+        // A successful resend restarts the timer, so the next click is gated again.
+        assertEquals(SmsEnrollmentHandler.RESEND_DELAY_SECONDS, state()?.resendTimer)
+
+        composeTestRule.runOnUiThread {
+            state()?.onVerifyClick?.invoke()
+        }
+        composeTestRule.waitForIdle()
+
+        // Enrollment must use the session returned by the resend, not the stale original.
+        verifyBlocking(mockSmsHandler) {
+            enrollWithVerificationCode(
+                session = resentSession,
+                verificationCode = VERIFICATION_CODE,
+                displayName = SMS_DISPLAY_NAME
+            )
+        }
+    }
+
+    /**
+     * Renders [MfaEnrollmentScreenInternal] with the stubbed enrollment handlers and drives the
+     * SMS route up to (but not including) the verify click: select country, enter the local
+     * number, send the code (which yields [smsSession]) and enter the verification code.
+     *
+     * @return an accessor for the latest [MfaEnrollmentContentState] emitted by the screen
+     */
+    private fun driveSmsFlowToVerifyStep(
+        onComplete: () -> Unit,
+        onError: (Exception) -> Unit = {}
+    ): () -> MfaEnrollmentContentState? {
+        // Exact-argument stub: the screen must ask for the dial-code-prefixed number.
+        whenever { mockSmsHandler.sendVerificationCode(EXPECTED_FULL_PHONE_NUMBER) }
+            .thenReturn(smsSession)
+
+        var currentState by mutableStateOf<MfaEnrollmentContentState?>(null)
+
+        composeTestRule.setContent {
+            MfaEnrollmentScreenInternal(
+                user = mockUser,
+                auth = mockAuth,
+                configuration = MfaConfiguration(allowedFactors = listOf(MfaFactor.Sms)),
+                smsHandler = mockSmsHandler,
+                totpHandler = mockTotpHandler,
+                onComplete = onComplete,
+                onError = onError
+            ) { state ->
+                currentState = state
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        // A single allowed factor auto-selects SMS and lands on the configure step.
+        assertEquals(MfaEnrollmentStep.ConfigureSms, currentState?.step)
+
+        composeTestRule.runOnUiThread {
+            currentState?.onCountrySelected?.invoke(TEST_COUNTRY)
+            currentState?.onPhoneNumberChange?.invoke(LOCAL_PHONE_NUMBER)
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnUiThread {
+            currentState?.onSendSmsCodeClick?.invoke()
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnUiThread {
+            currentState?.onVerificationCodeChange?.invoke(VERIFICATION_CODE)
+        }
+        composeTestRule.waitForIdle()
+
+        assertEquals(MfaEnrollmentStep.VerifyFactor, currentState?.step)
+        assertEquals(VERIFICATION_CODE, currentState?.verificationCode)
+        assertNull(currentState?.error)
+
+        return { currentState }
+    }
+
     /**
      * Renders [MfaEnrollmentScreenInternal] with the stubbed enrollment handlers and drives the
      * TOTP route up to (but not including) the verify click.
@@ -527,5 +900,17 @@ class MfaEnrollmentScreenTest {
     private companion object {
         const val VERIFICATION_CODE = "123456"
         const val TOTP_DISPLAY_NAME = "Authenticator App"
+        const val SMS_DISPLAY_NAME = "SMS"
+        const val NO_SMS_SESSION_MESSAGE = "No SMS session available"
+        const val LOCAL_PHONE_NUMBER = "5551234567"
+        const val EXPECTED_FULL_PHONE_NUMBER = "+445551234567"
+
+        /** Deliberately not the Robolectric default locale country, so the dial code is pinned. */
+        val TEST_COUNTRY = CountryData(
+            name = "United Kingdom",
+            dialCode = "+44",
+            countryCode = "GB",
+            flagEmoji = "🇬🇧"
+        )
     }
 }


### PR DESCRIPTION
Nothing asserted that `onComplete` fires when MFA enrollment succeeds. #2457 removed the recovery-codes step, which moved `onComplete` one user interaction earlier for every default-configured integrator — the suite would have passed equally well had it been deleted rather than hoisted. The SMS route was unpinned end to end: deleting its `enrollWithVerificationCode` call left all 633 tests green.

`MfaEnrollmentScreen` built its handlers inside the composable, so there was nothing to stub. An internal `MfaEnrollmentScreenInternal` now takes them as parameters and the public composable constructs the real ones and delegates to it; the public signature is unchanged.

Added nine tests across both enrollment routes — TOTP (`onComplete` fires exactly once with the entered code, the enrolled-factors refresh, the failure path) and SMS (dial-code prefix and session storage, exact enroll arguments, the missing-session guard, send and enroll failures, resend session replacement and its rate-limit gate). Each was verified to fail when the line it pins is removed.

---
Maintainer note: Fixes internal CPRN-383
