### PR TITLE
build(deps)!: upgrade AGP to 9.3.0 and bump compileSdk to 37

### DIFF
--- a/auth/build.gradle.kts
+++ b/auth/build.gradle.kts
@@ -106,7 +106,7 @@ dependencies {
     implementation(libs.zxing.core)
     annotationProcessor(libs.androidx.lifecycle.compiler)
 
-    implementation(platform(libs.firebase.bom))
+    api(platform(libs.firebase.bom))
     api(libs.firebase.auth)
 
     // Phone number validation

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -3,7 +3,7 @@ object Config {
     val submodules = listOf("auth", "common", "firestore", "database", "storage")
 
     object SdkVersions {
-        const val compile = 36
+        const val compile = 37
         const val target = 36
         const val min = 23
     }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -42,7 +42,6 @@ android {
     buildTypes {
         named("release").configure {
             isMinifyEnabled = false
-            consumerProguardFiles("proguard-rules.pro")
         }
     }
 }

--- a/database/build.gradle.kts
+++ b/database/build.gradle.kts
@@ -55,7 +55,7 @@ android {
 }
 
 dependencies {
-    implementation(platform(libs.firebase.bom))
+    api(platform(libs.firebase.bom))
     api(project(":common"))
     api(libs.firebase.database)
 

--- a/firestore/build.gradle.kts
+++ b/firestore/build.gradle.kts
@@ -54,7 +54,7 @@ android {
 }
 
 dependencies {
-    implementation(platform(libs.firebase.bom))
+    api(platform(libs.firebase.bom))
     api(project(":common"))
     api(libs.firebase.firestore)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,8 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=false
+android.builtInKotlin=false
+android.newDsl=false
 GROUP=com.firebaseui
 VERSION_NAME=10.0.0-beta04
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "2.4.10"
-android-gradle-plugin = "8.10.0"
+android-gradle-plugin = "9.3.0"
 google-services = "4.5.0"
 maven-publish-plugin = "0.34.0"
 

--- a/proguard-tests/build.gradle.kts
+++ b/proguard-tests/build.gradle.kts
@@ -35,11 +35,8 @@ android {
             // using the debug key
             signingConfig = signingConfigs["debug"]
 
-            postprocessing {
-                isRemoveUnusedCode = true
-                isRemoveUnusedResources = true
-                isObfuscate = true
-            }
+            isMinifyEnabled = true
+            isShrinkResources = true
         }
     }
 

--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -42,7 +42,6 @@ android {
     buildTypes {
         named("release").configure {
             isMinifyEnabled = false
-            consumerProguardFiles("proguard-rules.pro")
         }
     }
 }
@@ -50,7 +49,7 @@ android {
 dependencies {
     api(libs.glide)
 
-    implementation(platform(libs.firebase.bom))
+    api(platform(libs.firebase.bom))
     api(libs.firebase.storage)
     // Override Play Services
     implementation(libs.androidx.legacy.support.v4)


### PR DESCRIPTION
- Closes #2429
- Related to #2364
- Related to #2430
- Related to #2371
- Related to #2451

Dependabot's `com.vanniktech.maven.publish` bump (0.34.0 → 0.37.0, #2364) fails CI because 0.36.0+ requires AGP ≥ 8.13.0, and no AGP 8.x release is compatible with this repo's Gradle 9.7.0 wrapper (AGP 8.11–8.13.x depend on an internal Gradle API removed in 9.6.0). This upgrades AGP to 9.3.0 to unblock it — that part alone has no consumer impact, verified by publishing to `mavenLocal()` and confirming the AAR metadata is unchanged from the pre-upgrade baseline.

It also bumps `compileSdk` 36 → 37, to unblock a separate cluster of stuck dependabot PRs (#2430 glide, #2371 core-ktx, #2451 compose-bom) whose newer versions were themselves built against compileSdk 37 and can't be consumed while we're at 36. **This part does have real consumer impact**: the published AAR now stamps `minCompileSdk=37`, so consumers still on AGP 8.10.0 (max recommended compileSdk 36) will need to upgrade AGP to pick up the next FirebaseUI-Android release. That's a deliberate, accepted tradeoff for unblocking those PRs, not an oversight.

`#2429` is dependabot's own attempt at this same AGP bump (8.10.0 → 9.3.1) - it hit the identical `org.jetbrains.kotlin.android`/AGP-9-defaults wall this PR already resolves, so merging this supersedes it.

- `gradle.properties`: added `android.builtInKotlin=false` and `android.newDsl=false` to keep `org.jetbrains.kotlin.android` working under AGP 9's defaults - both flags are deprecated and removed in AGP 10, so the real Kotlin/new-DSL migration is deferred to a follow-up.
- `proguard-tests/build.gradle.kts`: migrated the removed `postprocessing {}` block to `isMinifyEnabled`/`isShrinkResources`.
- `common/build.gradle.kts`, `storage/build.gradle.kts`: removed a dangling `consumerProguardFiles("proguard-rules.pro")` pointing at a file that's never existed — silently ignored under AGP 8, hard-fails release builds under AGP 9. Neither module has dependencies needing consumer keep rules.
- `auth`, `database`, `firestore`, `storage`: `implementation(platform(libs.firebase.bom))` → `api(platform(libs.firebase.bom))`, fixing an AGP 9 dependency-resolution regression where the BOM's version constraint wasn't propagating to modules already exposing these artifacts via `api`.
- `buildSrc/src/main/kotlin/Config.kt`: `compileSdk` 36 → 37 (`targetSdk` intentionally left at 36 - all modules set it explicitly, so AGP 9's "target defaults to compile" default never fires; `target ≤ compile` is a valid combination).

---
Maintainer note: Fixes internal CPRN-146