### PR TITLE
feat(auth)!: make each email sign-in mode a real navigation destination

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
@@ -14,6 +14,7 @@
 
 package com.firebase.ui.auth.ui.screens
 
+import android.net.Uri
 import android.util.Log
 import androidx.activity.compose.LocalActivity
 import androidx.compose.animation.core.tween
@@ -58,7 +59,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -90,7 +91,11 @@ import com.firebase.ui.auth.ui.exposeTestTagsAsResourceIds
 import com.firebase.ui.auth.ui.method_picker.AuthMethodPicker
 import com.firebase.ui.auth.ui.method_picker.MethodPickerTermsConfiguration
 import com.firebase.ui.auth.ui.screens.email.EmailAuthContentState
-import com.firebase.ui.auth.ui.screens.email.EmailAuthScreen
+import com.firebase.ui.auth.ui.screens.email.EmailAuthMode
+import com.firebase.ui.auth.ui.screens.email.emailAuthDestinations
+import com.firebase.ui.auth.ui.screens.email.isEmailLinkSignInOffered
+import com.firebase.ui.auth.ui.screens.email.isEmailSignUpOffered
+import com.firebase.ui.auth.ui.screens.email.navigateToEmailStep
 import com.firebase.ui.auth.ui.screens.mfa.MfaChallengeScreen
 import com.firebase.ui.auth.ui.screens.mfa.MfaEnrollmentScreen
 import com.firebase.ui.auth.ui.screens.phone.PhoneAuthContentState
@@ -157,7 +162,6 @@ fun FirebaseAuthScreen(
     reauthContent: (@Composable (ReauthContentState) -> Unit)? = null,
     authenticatedContent: (@Composable (state: AuthState, uiContext: AuthSuccessUiContext) -> Unit)? = null,
 ) {
-    // Set FirebaseUI version
     LaunchedEffect(authUI.auth) {
         authUI.auth.setFirebaseUIVersion(BuildConfig.VERSION_NAME)
     }
@@ -175,8 +179,7 @@ fun FirebaseAuthScreen(
     val lastSuccessfulUserId = remember { mutableStateOf<String?>(null) }
     val pendingLinkingCredential = remember { mutableStateOf<AuthCredential?>(null) }
     val pendingResolver = remember { mutableStateOf<MultiFactorResolver?>(null) }
-    // This screen is the only thing that can drive a reauthentication request to completion, so
-    // FirebaseAuthUI only folds ordinary states into an armed request while one is registered.
+    // FirebaseAuthUI only folds ordinary states into an armed request while a drainer is present.
     DisposableEffect(authUI) {
         authUI.addReauthenticationDrainer()
         onDispose { authUI.removeReauthenticationDrainer() }
@@ -196,8 +199,6 @@ fun FirebaseAuthScreen(
             ?.let { linkedProviders ->
                 configuration.copy(
                     providers = linkedProviders,
-                    // Belt and braces with the canLinkCredential/canUpgradeAnonymous guards: a
-                    // linked credential is not a proof of identity, so neither is ever enabled.
                     isAnonymousUpgradeEnabled = false,
                     isCredentialLinkingEnabled = false,
                     isNewEmailAccountsAllowed = false,
@@ -214,26 +215,23 @@ fun FirebaseAuthScreen(
             }
         }
     val reauthErrorMessage = reauthException?.let { getRecoveryMessage(it, stringProvider) }
-    // Firebase requires the second factor to complete the reauthentication too, so the challenge
-    // is presented as a reauth sub-flow instead of on the outer NavHost under the modal.
+    // The challenge is a reauth sub-flow, not an outer-NavHost destination under the modal.
     val reauthMfa = reauthState as? AuthState.Reauthentication.RequiresMfa
     val emailLinkFromDifferentDevice = remember { mutableStateOf<String?>(null) }
-    val prefillEmail = remember { mutableStateOf<String?>(null) }
+    // The address in play. Read only from callbacks, never during composition.
+    val typedEmail = rememberSaveable { mutableStateOf<String?>(null) }
     val reauthPrefillEmail = remember(authUI, configuration.isReauthenticationMode) {
         if (configuration.isReauthenticationMode) authUI.auth.currentUser?.email else null
     }
     val lastSignInPreference =
         remember { mutableStateOf<SignInPreferenceManager.SignInPreference?>(null) }
     // Lets the Idle branch below tell a genuine reset apart from consuming a notification.
-    // collectAsState uses null until the first real flow emission, so process restoration can
-    // distinguish that placeholder from FirebaseAuthUI's actual Idle/Success state.
     val previousAuthState = remember { mutableStateOf<AuthState?>(null) }
     val startRoute = remember(configuration.providers, configuration.isProviderChoiceAlwaysShown) {
         getStartRoute(configuration)
     }
     val skipsMethodPicker = startRoute != AuthRoute.MethodPicker
 
-    // Load last sign-in preference on launch
     LaunchedEffect(authState) {
         lastSignInPreference.value = SignInPreferenceManager.getLastSignIn(context)
     }
@@ -244,7 +242,13 @@ fun FirebaseAuthScreen(
         context = context,
         activity = activity,
         config = configuration,
-        onNavigate = { route -> navController.navigate(route.route) },
+        onNavigate = { route ->
+            if (route == AuthRoute.Email) {
+                navController.navigateToEmailStep(AuthRoute.Email.SignIn, typedEmail.value)
+            } else {
+                navController.navigate(route.route)
+            }
+        },
         onUnknownProvider = { provider ->
             onSignInFailure(
                 AuthException.UnknownException(
@@ -257,8 +261,7 @@ fun FirebaseAuthScreen(
         },
         onSignInFailure = onSignInFailure,
     )
-    // Remembered so the method picker is not recomposed on every parent recomposition;
-    // rememberOnProviderSelected returns a fresh lambda each time, so read it through a holder.
+    // rememberOnProviderSelected returns a fresh lambda each time; hold it so the picker is stable.
     val currentOuterProviderSelected = rememberUpdatedState(onOuterProviderSelected)
     val currentReauthState = rememberUpdatedState(reauthState)
     val onProviderSelected: (AuthProvider) -> Unit = remember {
@@ -284,7 +287,7 @@ fun FirebaseAuthScreen(
         ) {
             NavHost(
                 navController = navController,
-                startDestination = startRoute.route,
+                startDestination = startRoute.routePattern,
                 enterTransition = configuration.transitions?.enterTransition ?: {
                     fadeIn(animationSpec = tween(700))
                 },
@@ -298,14 +301,12 @@ fun FirebaseAuthScreen(
                     fadeOut(animationSpec = tween(700))
                 }
             ) {
-                composable(AuthRoute.MethodPicker.route) {
+                composable(AuthRoute.MethodPicker.routePattern) {
                     if (customMethodPickerLayout != null) {
                         Box(modifier = Modifier.fillMaxSize()) {
                             customMethodPickerLayout(configuration.providers, onProviderSelected)
                         }
                     } else {
-                        // Redundant under the flagged Surface above, but kept uniform per
-                        // exposeTestTagsAsResourceIds.
                         Scaffold(modifier = Modifier.exposeTestTagsAsResourceIds()) { innerPadding ->
                             AuthMethodPicker(
                                 modifier = Modifier
@@ -317,11 +318,12 @@ fun FirebaseAuthScreen(
                                 lastSignInPreference = lastSignInPreference.value,
                                 termsConfiguration = customMethodPickerTermsConfiguration,
                                 onProviderSelected = { provider ->
-                                    prefillEmail.value = null
+                                    typedEmail.value = null
                                     onProviderSelected(provider)
                                 },
                                 onContinueAsSelected = { provider, identifier ->
-                                    prefillEmail.value = if (provider is AuthProvider.Email) identifier else null
+                                    typedEmail.value =
+                                        if (provider is AuthProvider.Email) identifier else null
                                     onProviderSelected(provider)
                                 },
                             )
@@ -329,58 +331,57 @@ fun FirebaseAuthScreen(
                     }
                 }
 
-                composable(AuthRoute.Email.route) {
-                    EmailAuthScreen(
-                        context = context,
-                        configuration = configuration,
-                        authUI = authUI,
-                        // The reauth user's own address wins: a stale "Continue as" identifier
-                        // would lock the field to an account that cannot be re-proved here.
-                        prefillEmail = reauthPrefillEmail ?: prefillEmail.value,
-                        credentialForLinking = pendingLinkingCredential.value,
-                        emailLinkFromDifferentDevice = emailLinkFromDifferentDevice.value,
-                        onContinueWithProvider = continueWithProvider,
-                        content = emailContent,
-                        onSuccess = {
-                            pendingLinkingCredential.value = null
-                        },
-                        onError = { exception ->
-                            onSignInFailure(exception)
-                        },
-                        onCancel = {
-                            pendingLinkingCredential.value = null
-                            if (!skipsMethodPicker && !navController.popBackStack()) {
-                                navController.navigate(AuthRoute.MethodPicker.route) {
-                                    popUpTo(AuthRoute.MethodPicker.route) { inclusive = true }
-                                    launchSingleTop = true
-                                }
+                emailAuthDestinations(
+                    navController = navController,
+                    context = context,
+                    configuration = configuration,
+                    authUI = authUI,
+                    content = emailContent,
+                    // Only the address the library itself fixed; the user's own travels on the route.
+                    prefillEmail = { reauthPrefillEmail },
+                    credentialForLinking = { pendingLinkingCredential.value },
+                    emailLinkFromDifferentDevice = { emailLinkFromDifferentDevice.value },
+                    onEmailTyped = { typedEmail.value = it },
+                    onSuccess = { pendingLinkingCredential.value = null },
+                    onError = { exception -> onSignInFailure(exception) },
+                    onCancel = {
+                        pendingLinkingCredential.value = null
+                        if (!skipsMethodPicker && !navController.popBackStack()) {
+                            navController.navigate(AuthRoute.MethodPicker.route) {
+                                popUpTo(AuthRoute.MethodPicker.routePattern) { inclusive = true }
+                                launchSingleTop = true
                             }
                         }
-                    )
-                }
+                    },
+                )
 
-                composable(AuthRoute.Phone.route) {
-                    PhoneAuthScreen(
-                        context = context,
-                        configuration = configuration,
-                        authUI = authUI,
-                        content = phoneContent,
-                        onSuccess = {},
-                        onError = { exception ->
-                            onSignInFailure(exception)
-                        },
-                        onCancel = {
-                            if (!skipsMethodPicker && !navController.popBackStack()) {
-                                navController.navigate(AuthRoute.MethodPicker.route) {
-                                    popUpTo(AuthRoute.MethodPicker.route) { inclusive = true }
-                                    launchSingleTop = true
+                // One destination per step so every public AuthRoute is navigable, all one screen.
+                AuthRoute.Phone.steps.forEach { step ->
+                    composable(step.routePattern) {
+                        PhoneAuthScreen(
+                            context = context,
+                            configuration = configuration,
+                            authUI = authUI,
+                            content = phoneContent,
+                            onSuccess = {},
+                            onError = { exception ->
+                                onSignInFailure(exception)
+                            },
+                            onCancel = {
+                                if (!skipsMethodPicker && !navController.popBackStack()) {
+                                    navController.navigate(AuthRoute.MethodPicker.route) {
+                                        popUpTo(AuthRoute.MethodPicker.routePattern) {
+                                            inclusive = true
+                                        }
+                                        launchSingleTop = true
+                                    }
                                 }
                             }
-                        }
-                    )
+                        )
+                    }
                 }
 
-                composable(AuthRoute.Success.route) {
+                composable(AuthRoute.Success.routePattern) {
                     val uiContext = remember(authState, stringProvider) {
                         AuthSuccessUiContext(
                             authUI = authUI,
@@ -416,7 +417,6 @@ fun FirebaseAuthScreen(
                             onReloadUser = {
                                 coroutineScope.launch {
                                     try {
-                                        // Reload user to get fresh data from server
                                         authUI.getCurrentUser()?.let {
                                             it.reload().await()
                                             it.getIdToken(true).await()
@@ -463,29 +463,31 @@ fun FirebaseAuthScreen(
                     }
                 }
 
-                composable(AuthRoute.MfaEnrollment.route) {
-                    val user = authUI.getCurrentUser()
-                    if (user != null) {
-                        MfaEnrollmentScreen(
-                            user = user,
-                            auth = authUI.auth,
-                            configuration = mfaConfiguration,
-                            authConfiguration = configuration,
-                            content = mfaEnrollmentContent,
-                            onComplete = { navController.popBackStack() },
-                            onSkip = { navController.popBackStack() },
-                            onError = { exception ->
-                                onSignInFailure(AuthException.from(exception, stringProvider))
-                            }
-                        )
-                    } else {
-                        navController.popBackStack()
+                // As with the phone steps: every declared step registered, all one screen.
+                AuthRoute.MfaEnrollment.steps.forEach { step ->
+                    composable(step.routePattern) {
+                        val user = authUI.getCurrentUser()
+                        if (user != null) {
+                            MfaEnrollmentScreen(
+                                user = user,
+                                auth = authUI.auth,
+                                configuration = mfaConfiguration,
+                                authConfiguration = configuration,
+                                content = mfaEnrollmentContent,
+                                onComplete = { navController.popBackStack() },
+                                onSkip = { navController.popBackStack() },
+                                onError = { exception ->
+                                    onSignInFailure(AuthException.from(exception, stringProvider))
+                                }
+                            )
+                        } else {
+                            navController.popBackStack()
+                        }
                     }
                 }
 
-                composable(AuthRoute.MfaChallenge.route) {
-                    // Retained for this back-stack entry: onSuccess clears pendingResolver, and
-                    // reading it directly would blank the screen through the exit transition.
+                composable(AuthRoute.MfaChallenge.routePattern) {
+                    // Retained for this entry: onSuccess clears pendingResolver, blanking the exit.
                     val resolver = remember { pendingResolver.value }
                     if (resolver != null) {
                         MfaChallengeScreen(
@@ -494,8 +496,7 @@ fun FirebaseAuthScreen(
                             content = mfaChallengeContent,
                             onSuccess = { result ->
                                 pendingResolver.value = null
-                                // Route through the same path every other provider uses so
-                                // onSignInSuccess receives the resolved AuthResult.
+                                // Same path as every other provider, so onSignInSuccess sees the result.
                                 authUI.updateAuthStateWithResult(result)
                             },
                             onCancel = {
@@ -513,18 +514,14 @@ fun FirebaseAuthScreen(
                 }
             }
 
-            // Handle email link sign-in (deep links)
             LaunchedEffect(emailLink) {
-                // A link arriving while armed would sign in on the non-reauth configuration, and
-                // could sign in a different user the armed operation can then never match.
+                // A link arriving while armed would sign in on the non-reauth configuration.
                 if (emailLink != null && emailProvider != null && reauthState == null) {
                     try {
-                        // Try to retrieve saved email from DataStore (same-device flow)
                         val savedEmail =
                             EmailLinkPersistenceManager.default.retrieveSessionRecord(context)?.email
 
                         if (savedEmail != null) {
-                            // Same device - we have the email, sign in automatically
                             authUI.signInWithEmailLink(
                                 context = context,
                                 config = configuration,
@@ -533,9 +530,6 @@ fun FirebaseAuthScreen(
                                 emailLink = emailLink
                             )
                         } else {
-                            // Different device - no saved email
-                            // Call signInWithEmailLink with empty email to trigger validation
-                            // This will throw EmailLinkPromptForEmailException or EmailLinkWrongDeviceException
                             authUI.signInWithEmailLink(
                                 context = context,
                                 config = configuration,
@@ -550,7 +544,6 @@ fun FirebaseAuthScreen(
                 }
             }
 
-            // Synchronise auth state changes with navigation stack.
             LaunchedEffect(observedAuthState) {
                 val state = observedAuthState ?: return@LaunchedEffect
                 val previous = previousAuthState.value
@@ -558,9 +551,7 @@ fun FirebaseAuthScreen(
                 val currentRoute = navController.currentBackStackEntry?.destination?.route
                 val savedPresentation = reauthPresentation.value
 
-                // A saveable marker without its matching process-local AuthState means process
-                // death discarded the retry callback. Report that loss for every real first
-                // emission, not only Loading; FirebaseAuth commonly restores as Success.
+                // A saved marker with no matching AuthState means process death lost the callback.
                 if (savedPresentation != null &&
                     state !is AuthState.Reauthentication &&
                     state !is AuthState.Aborted
@@ -585,7 +576,6 @@ fun FirebaseAuthScreen(
                                 onSignInSuccess(result)
                                 lastSuccessfulUserId.value = state.user.uid
 
-                                // Reload sign-in preference (may have been updated by provider)
                                 coroutineScope.launch {
                                     lastSignInPreference.value =
                                         SignInPreferenceManager.getLastSignIn(context)
@@ -593,11 +583,8 @@ fun FirebaseAuthScreen(
                             }
                         }
 
-                        if (currentRoute != AuthRoute.Success.route) {
-                            navController.navigate(AuthRoute.Success.route) {
-                                popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
-                                launchSingleTop = true
-                            }
+                        if (currentRoute != AuthRoute.Success.routePattern) {
+                            navController.resetBackStackTo(AuthRoute.Success)
                         }
                     }
 
@@ -654,8 +641,7 @@ fun FirebaseAuthScreen(
                             )
                             return@LaunchedEffect
                         }
-                        // Claimed before the first suspension point, so a recreation that resumes
-                        // this phase reports the interruption instead of running the operation again.
+                        // Claimed before the first suspension point, so a recreation cannot rerun it.
                         val retry = request.claimRetryOperation()
                         if (retry == null) {
                             clearReauthPresentation()
@@ -718,17 +704,14 @@ fun FirebaseAuthScreen(
                         -> {
                         pendingResolver.value = null
                         pendingLinkingCredential.value = null
-                        if (currentRoute != AuthRoute.Success.route) {
-                            navController.navigate(AuthRoute.Success.route) {
-                                popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
-                                launchSingleTop = true
-                            }
+                        if (currentRoute != AuthRoute.Success.routePattern) {
+                            navController.resetBackStackTo(AuthRoute.Success)
                         }
                     }
 
                     is AuthState.RequiresMfa -> {
                         pendingResolver.value = state.resolver
-                        if (currentRoute != AuthRoute.MfaChallenge.route) {
+                        if (currentRoute != AuthRoute.MfaChallenge.routePattern) {
                             navController.navigate(AuthRoute.MfaChallenge.route) {
                                 launchSingleTop = true
                             }
@@ -740,41 +723,37 @@ fun FirebaseAuthScreen(
                         pendingResolver.value = null
                         pendingLinkingCredential.value = null
                         lastSuccessfulUserId.value = null
-                        if (currentRoute != startRoute.route) {
-                            navController.navigate(startRoute.route) {
-                                popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
-                                launchSingleTop = true
-                            }
+                        // Left behind, it would be carried by the next session's recovery.
+                        typedEmail.value = null
+                        if (currentRoute != startRoute.routePattern) {
+                            navController.resetBackStackTo(startRoute)
                         }
                         onSignInCancelled()
                         authUI.updateAuthState(AuthState.Idle)
                     }
 
                     is AuthState.Aborted -> {
-                        // Hosted by FirebaseAuthActivity: its own authStateFlow collector
-                        // independently finishes the activity and resets state on Aborted.
+                        // FirebaseAuthActivity's own collector already finishes and resets on Aborted.
                         if (activity !is FirebaseAuthActivity) {
                             clearReauthPresentation()
                             pendingResolver.value = null
                             pendingLinkingCredential.value = null
                             lastSuccessfulUserId.value = null
+                            typedEmail.value = null
                             authUI.updateAuthState(AuthState.Idle)
                         }
                     }
 
                     is AuthState.Idle -> {
-                        // A notification resets to Idle purely to avoid leaking to a freshly
-                        // created screen — that's not a request to leave the current one.
+                        // A notification's reset to Idle is not a request to leave the current screen.
                         if (previous != null && !previous.isNotification) {
                             clearReauthPresentation()
                             pendingResolver.value = null
                             pendingLinkingCredential.value = null
                             lastSuccessfulUserId.value = null
-                            if (currentRoute != startRoute.route) {
-                                navController.navigate(startRoute.route) {
-                                    popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
-                                    launchSingleTop = true
-                                }
+                            typedEmail.value = null
+                            if (currentRoute != startRoute.routePattern) {
+                                navController.resetBackStackTo(startRoute)
                             }
                         }
                     }
@@ -796,8 +775,7 @@ fun FirebaseAuthScreen(
 
                 else -> false
             }
-            // Derived from the state rather than the saveable marker, because the resolver lives
-            // only in the state: this sub-route can never outlive the challenge it presents.
+            // Derived from the state, not the marker: the resolver lives only in the state.
             val reauthSubRoute = if (reauthMfa != null) {
                 AuthRoute.MfaChallenge
             } else {
@@ -814,8 +792,7 @@ fun FirebaseAuthScreen(
                     val exception = reauthException ?: return@LaunchedEffect
                     dialogController.showErrorDialog(
                         exception = exception,
-                        // The latched failure is never the live Error, so without an explicit key
-                        // reopening a sub-flow re-adds this effect and re-shows a stale dialog.
+                        // The latched failure is never the live Error; without this a stale dialog re-shows.
                         errorState = AuthState.Error(reauthAttemptFailure.exception),
                         onRetry = null,
                         onRecover = null,
@@ -823,7 +800,32 @@ fun FirebaseAuthScreen(
                 }
             }
 
-            // Handle errors using top-level dialog controller
+            /**
+             * Moves the flow to [target] unless it is already the current destination. This screen
+             * is the only place a recoverable error moves the flow; the email steps observe the
+             * same shared error event and leave it alone.
+             *
+             * Whether the recovery replaces the form that failed or pushes on top of it follows
+             * from the one rule in [NavHostController.navigateToEmailStep].
+             *
+             * @param address the address the failure itself names, when it names one. It beats
+             * [typedEmail], because a recovery can start from a provider attempt that never went
+             * through an email step at all.
+             */
+            fun navigateToEmailStep(target: AuthRoute.Email.Step, address: String? = null) {
+                val currentRoute = navController.currentBackStackEntry?.destination?.route
+                if (currentRoute == target.routePattern) return
+                val carriedEmail = address?.takeIf { it.isNotEmpty() } ?: typedEmail.value
+                navController.navigateToEmailStep(target, carriedEmail)
+            }
+
+            // The same predicate the step guards with, so a recovery cannot aim at a bounce.
+            val emailLinkRecoveryStep = if (configuration.isEmailLinkSignInOffered()) {
+                AuthRoute.Email.EmailLinkSignIn
+            } else {
+                AuthRoute.Email.SignIn
+            }
+
             val errorState = authState as? AuthState.Error
             if (errorState != null) {
                 LaunchedEffect(errorState) {
@@ -835,41 +837,42 @@ fun FirebaseAuthScreen(
                     dialogController.showErrorDialog(
                         exception = exception,
                         errorState = errorState,
-                        // Child screens own their retry logic, so there is nothing to retry here.
                         onRetry = null,
-                        onRecover = when (exception) {
-                            is AuthException.EmailAlreadyInUseException -> {
-                                {
-                                    navController.navigate(AuthRoute.Email.route) {
-                                        launchSingleTop = true
-                                    }
+                        // Reauthenticating, no recovery may be offered: the dialog is dismiss-only.
+                        onRecover = if (configuration.isReauthenticationMode) {
+                            null
+                        } else when (exception) {
+                            // Names no address, so the recovery falls back to the typed one.
+                            is AuthException.UserNotFoundException -> {
+                                if (configuration.isEmailSignUpOffered()) {
+                                    { navigateToEmailStep(AuthRoute.Email.SignUp) }
+                                } else {
+                                    null
                                 }
+                            }
+
+                            is AuthException.EmailAlreadyInUseException -> {
+                                { navigateToEmailStep(AuthRoute.Email.SignIn, exception.email) }
                             }
 
                             is AuthException.AccountLinkingRequiredException -> {
                                 {
                                     pendingLinkingCredential.value = exception.credential
-                                    navController.navigate(AuthRoute.Email.route) {
-                                        launchSingleTop = true
-                                    }
+                                    navigateToEmailStep(AuthRoute.Email.SignIn, exception.email)
                                 }
                             }
 
                             is AuthException.EmailLinkPromptForEmailException -> {
                                 {
                                     emailLinkFromDifferentDevice.value = exception.emailLink
-                                    navController.navigate(AuthRoute.Email.route) {
-                                        launchSingleTop = true
-                                    }
+                                    navigateToEmailStep(emailLinkRecoveryStep)
                                 }
                             }
 
                             is AuthException.EmailLinkCrossDeviceLinkingException -> {
                                 {
                                     emailLinkFromDifferentDevice.value = exception.emailLink
-                                    navController.navigate(AuthRoute.Email.route) {
-                                        launchSingleTop = true
-                                    }
+                                    navigateToEmailStep(emailLinkRecoveryStep)
                                 }
                             }
 
@@ -877,9 +880,10 @@ fun FirebaseAuthScreen(
                                 {
                                     val providerId = exception.suggestedSignInMethod
                                     if (providerId == EmailAuthProvider.EMAIL_LINK_SIGN_IN_METHOD) {
-                                        navController.navigate(AuthRoute.Email.route) {
-                                            launchSingleTop = true
-                                        }
+                                        navigateToEmailStep(
+                                            emailLinkRecoveryStep,
+                                            exception.email,
+                                        )
                                     } else {
                                         continueWithProvider(providerId)
                                     }
@@ -889,7 +893,6 @@ fun FirebaseAuthScreen(
                             else -> null
                         },
                         onDismiss = {
-                            // Dialog dismissed
                         }
                     )
                     // Consumed immediately so this doesn't leak to a freshly created screen.
@@ -897,7 +900,6 @@ fun FirebaseAuthScreen(
                 }
             }
 
-            // Render the top-level dialog (only one instance)
             dialogController.CurrentDialog()
 
             val loadingMessage = when (val state = authState) {
@@ -913,15 +915,13 @@ fun FirebaseAuthScreen(
                 LoadingDialog(loadingMessage ?: stringProvider.progressDialogLoading)
             }
 
-            // Keyed on authUI only: onSignInCancelled is a caller lambda that is typically not
-            // remembered, so keying on it would defeat the remember entirely.
+            // Keyed on authUI only: onSignInCancelled is usually unremembered and would defeat it.
             val currentOnSignInCancelled = rememberUpdatedState(onSignInCancelled)
             val onReauthDismiss: () -> Unit = remember(authUI, clearReauthPresentation) {
                 {
                     clearReauthPresentation()
                     authUI.finishReauthentication(AuthState.Idle)
-                    // Abandoning reauthentication drops the pending operation for good, so the
-                    // host has to learn it will never run. A cancelled provider attempt does not.
+                    // Abandoning reauthentication drops the pending operation for good.
                     currentOnSignInCancelled.value()
                 }
             }
@@ -940,8 +940,7 @@ fun FirebaseAuthScreen(
                 }
             val onReauthMfaError: (Exception) -> Unit = remember(authUI) {
                 { exception ->
-                    // Clear the sub-flow that triggered the challenge so the failure lands on the
-                    // slot, where the caller renders `error`, rather than back inside that sub-flow.
+                    // Cleared so the failure lands on the slot, not back inside the sub-flow.
                     reauthPresentation.value = reauthPresentation.value?.copy(subRoute = null)
                     authUI.updateAuthState(AuthState.Error(exception))
                 }
@@ -997,13 +996,151 @@ fun FirebaseAuthScreen(
     }
 }
 
-sealed class AuthRoute(val route: String) {
-    object MethodPicker : AuthRoute("auth_method_picker")
-    object Email : AuthRoute("auth_email")
-    object Phone : AuthRoute("auth_phone")
-    object Success : AuthRoute("auth_success")
-    object MfaEnrollment : AuthRoute("auth_mfa_enrollment")
-    object MfaChallenge : AuthRoute("auth_mfa_challenge")
+/**
+ * Name of the optional argument every [AuthRoute.Email] step carries: the address the user has
+ * typed so far, which travels with the navigation — see [AuthRoute.Email.Step.withEmail].
+ */
+internal const val EMAIL_ARG = "email"
+
+/**
+ * A destination the library's navigation graph can be told to go to.
+ *
+ * Values come in two kinds:
+ *
+ * * **Flow entry points** — [Email], [Phone] and [MfaEnrollment]. Naming one means "enter this
+ *   flow" and resolves to that flow's start step, so callers — [getStartRoute], the method
+ *   picker, [AuthSuccessUiContext.onNavigate] — never have to name a step.
+ * * **Steps** — the objects nested inside each flow, one per screen the flow walks through, each
+ *   with its flow's own `Step` supertype. Every one is registered on the graph, so navigating to
+ *   any of them resolves and gets its own back-stack entry. Switching between [Email] steps is
+ *   navigation, so it animates with the configured transitions and is undone by system back.
+ *   [Phone] and [MfaEnrollment] register their steps, but their screens drive their own step
+ *   internally, so every step of those flows renders the same screen as the flow's start step.
+ *
+ * @property route What to *navigate* with. **Not an identity:** a flow entry point shares its
+ * start step's string, so two different values can report the same [route] and code must never
+ * map a route string back to an `AuthRoute` by scanning for a match.
+ * @property routePattern What the destination is *registered* with, and what a live
+ * `NavDestination.route` (and therefore `popUpTo`) is compared against. It differs from [route]
+ * only for a destination that takes arguments, which means the [Email] steps and their optional
+ * `?email={email}`. Unlike [route] it does identify a destination, since the flow entry points are
+ * not registered as destinations of their own.
+ *
+ * @since 10.0.0
+ */
+sealed class AuthRoute {
+    abstract val route: String
+
+    open val routePattern: String get() = route
+
+    object MethodPicker : AuthRoute() {
+        override val route: String get() = "auth_method_picker"
+    }
+
+    object Success : AuthRoute() {
+        override val route: String get() = "auth_success"
+    }
+
+    object MfaChallenge : AuthRoute() {
+        override val route: String get() = "auth_mfa_challenge"
+    }
+
+    /** Email and password, password recovery, and email-link sign-in. Starts at [SignIn]. */
+    object Email : AuthRoute() {
+        override val route: String get() = SignIn.route
+        override val routePattern: String get() = SignIn.routePattern
+
+        /**
+         * One step per [EmailAuthMode]. Every step carries the typed address as an optional
+         * [EMAIL_ARG], which is what preserves it across a switch.
+         */
+        sealed class Step(
+            private val id: String,
+            internal val mode: EmailAuthMode,
+        ) : AuthRoute() {
+            override val route: String get() = id
+            override val routePattern: String get() = "$id?$EMAIL_ARG={$EMAIL_ARG}"
+
+            /** [route] pre-filled with [email], for `NavController.navigate`. */
+            fun withEmail(email: String?): String =
+                if (email.isNullOrEmpty()) route else "$route?$EMAIL_ARG=${Uri.encode(email)}"
+        }
+
+        object SignIn : Step("auth_email_signin", EmailAuthMode.SignIn)
+        object SignUp : Step("auth_email_signup", EmailAuthMode.SignUp)
+        object ResetPassword : Step("auth_email_reset_password", EmailAuthMode.ResetPassword)
+        object EmailLinkSignIn : Step("auth_email_link_signin", EmailAuthMode.EmailLinkSignIn)
+
+        // Computed: a stored list is built while Email is still initialising and captures nulls.
+        internal val steps: List<Step>
+            get() = listOf(SignIn, SignUp, ResetPassword, EmailLinkSignIn)
+
+        internal fun stepFor(mode: EmailAuthMode): Step = steps.first { it.mode == mode }
+
+        /** Whether [route] — a live `NavDestination.route` — belongs to this flow. */
+        internal fun isStep(route: String?): Boolean = steps.any { it.routePattern == route }
+    }
+
+    /** Phone number verification. Starts at [EnterPhoneNumber]. */
+    object Phone : AuthRoute() {
+        override val route: String get() = EnterPhoneNumber.route
+
+        /** One step per screen the phone flow walks through. */
+        sealed class Step(private val id: String) : AuthRoute() {
+            override val route: String get() = id
+        }
+
+        object EnterPhoneNumber : Step("auth_phone_number")
+
+        object EnterVerificationCode : Step("auth_phone_verification_code")
+
+        // Computed for the same reason [Email.steps] is.
+        internal val steps: List<Step>
+            get() = listOf(EnterPhoneNumber, EnterVerificationCode)
+    }
+
+    /** Second-factor enrolment. Starts at [SelectFactor]. */
+    object MfaEnrollment : AuthRoute() {
+        override val route: String get() = SelectFactor.route
+
+        /** One step per screen the enrolment flow walks through. */
+        sealed class Step(private val id: String) : AuthRoute() {
+            override val route: String get() = id
+        }
+
+        object SelectFactor : Step("auth_mfa_enrollment_select_factor")
+
+        object ConfigureSms : Step("auth_mfa_enrollment_configure_sms")
+
+        object ConfigureTotp : Step("auth_mfa_enrollment_configure_totp")
+
+        object VerifyFactor : Step("auth_mfa_enrollment_verify_factor")
+
+        internal val steps: List<Step>
+            get() = listOf(SelectFactor, ConfigureSms, ConfigureTotp, VerifyFactor)
+    }
+
+    internal companion object {
+        /** Every value a caller can hand the graph, flow entry points included. */
+        val all: List<AuthRoute>
+            get() = listOf(MethodPicker, Success, MfaChallenge) +
+                    listOf(Email) + Email.steps +
+                    listOf(Phone) + Phone.steps +
+                    listOf(MfaEnrollment) + MfaEnrollment.steps
+    }
+}
+
+/**
+ * Sends the flow back to [route] as the only thing on the back stack.
+ *
+ * Clears the graph rather than popping up to `graph.findStartDestination()`: androidx.navigation
+ * silently ignores a `popUpTo` whose target is not on the current back stack, which would leave
+ * the form that had just failed underneath the new destination for system back to return to.
+ */
+internal fun NavHostController.resetBackStackTo(route: AuthRoute) {
+    navigate(route.route) {
+        popUpTo(graph.id) { inclusive = true }
+    }
 }
 
 internal fun getStartRoute(configuration: AuthUIConfiguration): AuthRoute {
@@ -1103,8 +1240,7 @@ private fun AuthSuccessContent(
                     TooltipAnchorPosition.Above
                 ),
                 tooltip = {
-                    // The tooltip is its own semantics owner (a popup), so it's flagged even
-                    // though nothing inside it is tagged yet.
+                    // A popup is its own semantics owner, so it needs its own flag.
                     PlainTooltip(modifier = Modifier.exposeTestTagsAsResourceIds()) {
                         Text(stringProvider.mfaDisabledTooltip)
                     }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthDestinations.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthDestinations.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens.email
+
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.firebase.ui.auth.AuthException
+import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.configuration.AuthUIConfiguration
+import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.ui.screens.AuthRoute
+import com.firebase.ui.auth.ui.screens.EMAIL_ARG
+import com.google.firebase.auth.AuthCredential
+import com.google.firebase.auth.AuthResult
+
+/**
+ * Registers the email flow's steps on [this] graph.
+ *
+ * Each step hosts an [EmailAuthScreen] pinned to its own [EmailAuthMode], turning mode switches
+ * into navigation through [navigateToEmailStep]; the address travels as [EMAIL_ARG] so it survives
+ * a switch. Errors are not acted on here: moving the flow on an
+ * [com.firebase.ui.auth.AuthState.Error] is the host's job alone.
+ *
+ * @param onCancel Invoked when the flow is *left*, not when stepping between email steps.
+ * @param prefillEmail The address already fixed for this flow, used to seed a step entered without
+ * [EMAIL_ARG]. Read during a step's composition, so it must not be state that changes while that
+ * step is on screen.
+ * @param onEmailTyped Reports the address as the user edits it, so a host-driven recovery that
+ * does not itself know the address can carry the live value.
+ */
+internal fun NavGraphBuilder.emailAuthDestinations(
+    navController: NavHostController,
+    context: Context,
+    configuration: AuthUIConfiguration,
+    authUI: FirebaseAuthUI,
+    content: (@Composable (EmailAuthContentState) -> Unit)?,
+    onCancel: () -> Unit,
+    prefillEmail: () -> String? = { null },
+    credentialForLinking: () -> AuthCredential? = { null },
+    emailLinkFromDifferentDevice: () -> String? = { null },
+    onEmailTyped: (String) -> Unit = {},
+    onSuccess: (AuthResult) -> Unit = {},
+    onError: (AuthException) -> Unit = {},
+) {
+    AuthRoute.Email.steps.forEach { step ->
+        composable(
+            route = step.routePattern,
+            arguments = listOf(
+                navArgument(EMAIL_ARG) {
+                    type = NavType.StringType
+                    defaultValue = ""
+                }
+            ),
+        ) { entry ->
+            val routeEmail = entry.arguments?.getString(EMAIL_ARG).orEmpty()
+
+            if (!configuration.isEmailStepOffered(step)) {
+                // Keyed on Unit: the redirect must run at most once per back-stack entry.
+                LaunchedEffect(Unit) {
+                    // Pop first; navigating alone leaves the unreachable step for back to return to.
+                    navController.popBackStack(step.routePattern, inclusive = true)
+                    navController.navigateToEmailStep(AuthRoute.Email.SignIn, routeEmail)
+                }
+                RedirectingStep()
+                return@composable
+            }
+
+            EmailAuthScreen(
+                context = context,
+                configuration = configuration,
+                authUI = authUI,
+                prefillEmail = routeEmail.ifEmpty { prefillEmail() },
+                credentialForLinking = credentialForLinking(),
+                emailLinkFromDifferentDevice = emailLinkFromDifferentDevice(),
+                content = content,
+                mode = step.mode,
+                onNavigateToMode = { targetMode, email ->
+                    navController.navigateToEmailStep(AuthRoute.Email.stepFor(targetMode), email)
+                },
+                onEmailTyped = onEmailTyped,
+                onSuccess = onSuccess,
+                onError = onError,
+                onCancel = {
+                    val previous = navController.previousBackStackEntry
+                    if (previous != null && AuthRoute.Email.isStep(previous.destination.route)) {
+                        navController.popBackStack()
+                    } else {
+                        onCancel()
+                    }
+                },
+            )
+        }
+    }
+}
+
+/**
+ * Moves the flow to [step], carrying [email] so the typed address survives the step being left.
+ *
+ * Pops any existing entry for [step], then pushes a fresh one:
+ *
+ * * **Already on the stack — replaces.** Toggling sign-in ↔ sign-up cannot grow the stack, and a
+ *   recovery removes the form that just failed rather than leaving it for back to return to.
+ * * **Not on the stack — pushes.** The origin stays reachable.
+ *
+ * Pushing rather than only popping means the address just typed wins over the stale one the old
+ * entry held, and saved state is not restored, so a mode switch's password clear survives. System
+ * back is the one case that does restore it.
+ *
+ * The push always leaves an entry for [step], so the graph's start destination can never be popped
+ * out from under it.
+ */
+internal fun NavHostController.navigateToEmailStep(step: AuthRoute.Email.Step, email: String?) {
+    navigate(step.withEmail(email)) {
+        popUpTo(step.routePattern) { inclusive = true }
+    }
+}
+
+/** Shown for as long as a redirect out of an unreachable step takes. */
+@Composable
+internal fun RedirectingStep() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+/** Whether [step] is reachable at all in this configuration. */
+internal fun AuthUIConfiguration.isEmailStepOffered(step: AuthRoute.Email.Step): Boolean =
+    when (step) {
+        AuthRoute.Email.SignUp -> isEmailSignUpOffered()
+        AuthRoute.Email.EmailLinkSignIn -> isEmailLinkSignInOffered()
+        AuthRoute.Email.SignIn, AuthRoute.Email.ResetPassword -> true
+    }
+
+/**
+ * Whether the email flow may offer account creation. False while reauthenticating, and whenever
+ * the configuration or the email provider itself disables new accounts.
+ */
+internal fun AuthUIConfiguration.isEmailSignUpOffered(): Boolean {
+    if (isReauthenticationMode || !isNewEmailAccountsAllowed) return false
+    return providers.filterIsInstance<AuthProvider.Email>()
+        .firstOrNull()
+        ?.isNewAccountsAllowed == true
+}
+
+/**
+ * Whether the email flow may offer email-link sign-in. False while reauthenticating: a link
+ * reopens the app with nothing armed, so completing one there reports an interruption.
+ */
+internal fun AuthUIConfiguration.isEmailLinkSignInOffered(): Boolean {
+    if (isReauthenticationMode) return false
+    return providers.filterIsInstance<AuthProvider.Email>()
+        .firstOrNull()
+        ?.isEmailLinkSignInEnabled == true
+}

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
@@ -43,7 +43,6 @@ import com.firebase.ui.auth.credentialmanager.PasswordCredentialNotFoundExceptio
 import com.firebase.ui.auth.ui.components.LocalTopLevelDialogController
 import com.google.firebase.auth.AuthCredential
 import com.google.firebase.auth.AuthResult
-import com.google.firebase.auth.EmailAuthProvider
 import kotlinx.coroutines.launch
 
 enum class EmailAuthMode {
@@ -57,8 +56,12 @@ enum class EmailAuthMode {
  * A class passed to the content slot, containing all the necessary information to render custom
  * UIs for sign-in, sign-up, and password reset flows.
  *
+ * Switching modes keeps whatever address the user has typed; only the password, its confirmation
+ * and the display name are cleared.
+ *
  * @param mode An enum representing the current UI mode. Use a when expression on this to render
- * the correct screen.
+ * the correct screen. Inside [com.firebase.ui.auth.ui.screens.FirebaseAuthScreen] every mode is its
+ * own navigation destination and this mirrors the active one.
  * @param isLoading true when an asynchronous operation (like signing in or sending an email)
  * is in progress.
  * @param error An optional error message to display to the user.
@@ -85,9 +88,13 @@ enum class EmailAuthMode {
  * has been successfully sent.
  * @param emailSignInLinkSent (Mode: [EmailAuthMode.SignIn]) true after the email sign in link has
  * been successfully sent.
- * @param onGoToSignUp A callback to switch the UI to the SignUp mode.
+ * @param onGoToSignUp A callback to switch the UI to the SignUp mode. Inert when account creation
+ * is not on offer: reauthentication, or new accounts disabled in the configuration or on the
+ * provider.
  * @param onGoToSignIn A callback to switch the UI to the SignIn mode.
  * @param onGoToResetPassword A callback to switch the UI to the ResetPassword mode.
+ * @param onGoToEmailLinkSignIn A callback to switch the UI to the EmailLinkSignIn mode. Inert when
+ * email-link sign-in is not on offer: reauthentication, or a provider that does not enable it.
  * @param isEmailLocked true when the library fixed [email] and it must not be edited. Render the
  * email field read-only while it is true.
  */
@@ -122,11 +129,22 @@ class EmailAuthContentState(
  * including sign-in, sign-up, and password reset. It exposes the state for the current mode to
  * a custom UI via a trailing lambda (slot), allowing for complete visual customization.
  *
- * @param configuration
- * @param onSuccess
- * @param onError
- * @param onCancel
- * @param content
+ * The mode can be driven from the outside — [com.firebase.ui.auth.ui.screens.FirebaseAuthScreen]
+ * gives every mode its own navigation destination and passes [mode] and [onNavigateToMode] — or
+ * left to this composable, which then keeps the mode in local state.
+ *
+ * This composable never changes mode on its own in response to an error. Signing in with an
+ * address that has no account leaves the user on the sign-in form rather than moving them to
+ * sign-up; acting on an error is the host's job alone.
+ *
+ * @param mode The mode to render. When null this composable owns the mode itself, starting at
+ * [EmailAuthMode.EmailLinkSignIn] for a cross-device email link and [EmailAuthMode.SignIn]
+ * otherwise. Goes together with [onNavigateToMode]: passing either without the other is rejected.
+ * @param onNavigateToMode Invoked instead of changing local state when the user switches mode,
+ * with the address currently typed so the host can carry it over. Goes together with [mode].
+ * @param onEmailTyped Invoked with the address as the user edits it, so a host driving [mode] has
+ * the live value once this step is disposed. Fires per keystroke, so a host must keep what it
+ * hears out of anything read during composition.
  */
 @Composable
 fun EmailAuthScreen(
@@ -135,25 +153,33 @@ fun EmailAuthScreen(
     authUI: FirebaseAuthUI,
     credentialForLinking: AuthCredential? = null,
     emailLinkFromDifferentDevice: String? = null,
-    onContinueWithProvider: (String) -> Unit = {},
     onSuccess: (AuthResult) -> Unit,
     onError: (AuthException) -> Unit,
     onCancel: () -> Unit,
     prefillEmail: String? = null,
+    mode: EmailAuthMode? = null,
+    onNavigateToMode: ((mode: EmailAuthMode, email: String) -> Unit)? = null,
+    onEmailTyped: (String) -> Unit = {},
     content: @Composable ((EmailAuthContentState) -> Unit)? = null,
 ) {
+    require((mode == null) == (onNavigateToMode == null)) {
+        "EmailAuthScreen's mode and onNavigateToMode go together: pass both to drive the mode " +
+                "from outside, or neither to let the screen own it. Got mode=$mode and " +
+                "onNavigateToMode=${if (onNavigateToMode == null) "null" else "a callback"}."
+    }
     val provider = configuration.providers.filterIsInstance<AuthProvider.Email>().first()
     val stringProvider = LocalAuthUIStringProvider.current
     val dialogController = LocalTopLevelDialogController.current
     val coroutineScope = rememberCoroutineScope()
 
-    // Start in EmailLinkSignIn mode if coming from cross-device flow
     val initialMode = if (emailLinkFromDifferentDevice != null && provider.isEmailLinkSignInEnabled) {
         EmailAuthMode.EmailLinkSignIn
     } else {
         EmailAuthMode.SignIn
     }
-    val mode = rememberSaveable { mutableStateOf(initialMode) }
+    // Allocated unconditionally: a rememberSaveable must not sit behind a branch on a parameter.
+    val localMode = rememberSaveable { mutableStateOf(initialMode) }
+    val currentMode = mode ?: localMode.value
     val displayNameValue = rememberSaveable { mutableStateOf("") }
     val emailTextValue = rememberSaveable { mutableStateOf(prefillEmail ?: "") }
     val passwordTextValue = rememberSaveable { mutableStateOf("") }
@@ -163,27 +189,16 @@ fun EmailAuthScreen(
         configuration.isReauthenticationMode && !prefillEmail.isNullOrEmpty()
     }
 
-    val isSignUpOffered = provider.isNewAccountsAllowed &&
-            configuration.isNewEmailAccountsAllowed &&
-            !configuration.isReauthenticationMode
+    val isSignUpOffered = configuration.isEmailSignUpOffered()
+    val isEmailLinkSignInOffered = configuration.isEmailLinkSignInOffered()
 
-    // Used for clearing text fields when switching EmailAuthMode changes
-    val textValues = remember {
+    // Cleared on a mode change; the address the user typed is deliberately not among them.
+    val secretTextValues = remember {
         listOf(
             displayNameValue,
-            emailTextValue,
             passwordTextValue,
             confirmPasswordTextValue
         )
-    }
-
-    val resetTextValues: () -> Unit = remember(textValues, isEmailLocked, prefillEmail) {
-        {
-            textValues.forEach { it.value = "" }
-            if (isEmailLocked) {
-                emailTextValue.value = prefillEmail.orEmpty()
-            }
-        }
     }
 
     val authState by remember(authUI) { authUI.authStateFlow() }.collectAsState(AuthState.Idle)
@@ -196,13 +211,35 @@ fun EmailAuthScreen(
         else -> null
     }
 
-    // Latched locally since these get consumed (reset to Idle) below — deriving directly from
-    // authState would close ResetPasswordUI/SignInEmailLinkUI's dialogs as soon as it resets.
+    // Latched: these states are consumed to Idle below, so deriving from authState closes dialogs.
     var resetLinkSentLocal by rememberSaveable { mutableStateOf(false) }
     var emailSignInLinkSentLocal by rememberSaveable { mutableStateOf(false) }
 
-    // Track if credentials were retrieved from Credential Manager
     val retrievedCredential = remember { mutableStateOf<Pair<String, String>?>(null) }
+
+    /**
+     * The single way this screen changes mode, so every guard lives in one place. Hosted, it asks
+     * the host to navigate and hands over the typed address; unhosted, it swaps local state and
+     * clears the mode-specific fields itself.
+     *
+     * Only ever called for a switch the user asked for; error recovery is the host's.
+     */
+    fun goToMode(target: EmailAuthMode) {
+        if (target == EmailAuthMode.SignUp && !isSignUpOffered) return
+        if (target == EmailAuthMode.EmailLinkSignIn && !isEmailLinkSignInOffered) return
+        if (onNavigateToMode != null) {
+            onNavigateToMode(target, emailTextValue.value)
+            return
+        }
+        // Unhosted, the same composition renders the target, so stale "link sent" latches must go.
+        when (target) {
+            EmailAuthMode.ResetPassword -> resetLinkSentLocal = false
+            EmailAuthMode.SignIn, EmailAuthMode.EmailLinkSignIn -> emailSignInLinkSentLocal = false
+            EmailAuthMode.SignUp -> Unit
+        }
+        secretTextValues.forEach { it.value = "" }
+        localMode.value = target
+    }
 
     LaunchedEffect(authState) {
         Log.d("EmailAuthScreen", "Current state: $authState")
@@ -216,61 +253,21 @@ fun EmailAuthScreen(
             is AuthState.Error -> {
                 val exception = AuthException.from(state.exception, stringProvider)
                 onError(exception)
-                dialogController?.showErrorDialog(
-                    exception = exception,
-                    errorState = state,
-                    // Every branch below is inert while reauthenticating, so an action button
-                    // would only dismiss the dialog — leave it without one.
-                    onRetry = if (configuration.isReauthenticationMode) {
-                        null
-                    } else {
-                        { ex: AuthException ->
-                            when (ex) {
-                                is AuthException.UserNotFoundException -> {
-                                    if (isSignUpOffered) {
-                                        // User not found, but new accounts are allowed, switch to sign-up
-                                        mode.value = EmailAuthMode.SignUp
-                                    }
-                                }
-
-                                is AuthException.InvalidCredentialsException -> {
-                                    // User can retry sign in with corrected credentials
-                                }
-
-                                is AuthException.EmailAlreadyInUseException -> {
-                                    // Switch to sign-in mode
-                                    mode.value = EmailAuthMode.SignIn
-                                }
-
-                                else -> Unit
-                            }
-                        }
-                    },
-                    onRecover = if (exception is AuthException.DifferentSignInMethodRequiredException) {
-                        { ex ->
-                            val differentProviderException =
-                                ex as AuthException.DifferentSignInMethodRequiredException
-                            if (differentProviderException.suggestedSignInMethod ==
-                                EmailAuthProvider.EMAIL_LINK_SIGN_IN_METHOD) {
-                                mode.value = EmailAuthMode.EmailLinkSignIn
-                            } else {
-                                onContinueWithProvider(differentProviderException.suggestedSignInMethod)
-                            }
-                        }
-                    } else {
-                        null
-                    },
-                    onDismiss = {
-                        // Dialog dismissed
-                    }
-                )
-                // Consumed immediately so this doesn't leak to a freshly created screen.
+                // Hosted, the host already shows this error with its own recovery actions.
+                if (onNavigateToMode == null) {
+                    dialogController?.showErrorDialog(
+                        exception = exception,
+                        errorState = state,
+                        onRetry = null,
+                        onRecover = null,
+                    )
+                }
+                // Consumed so the error doesn't leak into a freshly created screen.
                 authUI.updateAuthState(AuthState.Idle)
             }
 
             is AuthState.Cancelled -> {
                 onCancel()
-                // Consumed so this doesn't leak to a freshly created screen.
                 authUI.updateAuthState(AuthState.Idle)
             }
 
@@ -299,7 +296,7 @@ fun EmailAuthScreen(
     }
 
     val state = EmailAuthContentState(
-        mode = mode.value,
+        mode = currentMode,
         displayName = displayNameValue.value,
         email = emailTextValue.value,
         isEmailLocked = isEmailLocked,
@@ -312,6 +309,7 @@ fun EmailAuthScreen(
         onEmailChange = { email ->
             if (!isEmailLocked) {
                 emailTextValue.value = email
+                onEmailTyped(email)
             }
         },
         onPasswordChange = { password ->
@@ -329,7 +327,6 @@ fun EmailAuthScreen(
         onSignInClick = {
             coroutineScope.launch {
                 try {
-                    // Check if user is signing in with retrieved credentials
                     val isUsingRetrievedCredential = retrievedCredential.value?.let { (email, password) ->
                         email == emailTextValue.value && password == passwordTextValue.value
                     } ?: false
@@ -403,31 +400,11 @@ fun EmailAuthScreen(
                 }
             }
         },
-        onGoToSignUp = {
-            if (isSignUpOffered) {
-                resetTextValues()
-                mode.value = EmailAuthMode.SignUp
-            }
-        },
-        onGoToSignIn = {
-            resetTextValues()
-            mode.value = EmailAuthMode.SignIn
-            emailSignInLinkSentLocal = false
-        },
-        onGoToResetPassword = {
-            // Offered during reauthentication too: a reset email leaves the sheet up and the
-            // request armed, and blocking it strands a user who has forgotten their password.
-            resetTextValues()
-            mode.value = EmailAuthMode.ResetPassword
-            resetLinkSentLocal = false
-        },
-        onGoToEmailLinkSignIn = {
-            if (!configuration.isReauthenticationMode) {
-                resetTextValues()
-                mode.value = EmailAuthMode.EmailLinkSignIn
-                emailSignInLinkSentLocal = false
-            }
-        },
+        onGoToSignUp = { goToMode(EmailAuthMode.SignUp) },
+        onGoToSignIn = { goToMode(EmailAuthMode.SignIn) },
+        // Offered during reauthentication too; blocking it strands a user who forgot their password.
+        onGoToResetPassword = { goToMode(EmailAuthMode.ResetPassword) },
+        onGoToEmailLinkSignIn = { goToMode(EmailAuthMode.EmailLinkSignIn) },
     )
 
     if (content != null) {

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/reauth/ReauthPresentationState.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/reauth/ReauthPresentationState.kt
@@ -23,21 +23,41 @@ internal data class ReauthPresentationState(
     val subRoute: AuthRoute? = null,
 )
 
-// The process-local request and retry callback live in AuthState.Reauthentication. Only the marker
-// and presentation route needed for Activity/process restoration are saveable here.
+/**
+ * Explicit ids for the sub-routes this marker round-trips. Independent of [AuthRoute.route], so
+ * renaming a destination cannot change what an already-saved marker restores to.
+ */
+private const val SUB_ROUTE_EMAIL = "email"
+private const val SUB_ROUTE_PHONE = "phone"
+
+/**
+ * The id to save for a sub-route, or null for one that must not be restored.
+ *
+ * [AuthRoute.MfaChallenge] is absent: its resolver lives only in the process-local
+ * [com.firebase.ui.auth.AuthState], so that sub-route is derived on restore rather than saved.
+ */
+internal fun AuthRoute?.reauthSubRouteId(): String? = when (this) {
+    AuthRoute.Email -> SUB_ROUTE_EMAIL
+    AuthRoute.Phone -> SUB_ROUTE_PHONE
+    else -> null
+}
+
+internal fun reauthSubRouteForId(id: String?): AuthRoute? = when (id) {
+    SUB_ROUTE_EMAIL -> AuthRoute.Email
+    SUB_ROUTE_PHONE -> AuthRoute.Phone
+    else -> null
+}
+
+// Only the marker and presentation route are saveable; the rest of the request is process-local.
 internal val ReauthPresentationStateSaver: Saver<ReauthPresentationState?, List<String?>> = Saver(
     save = { state ->
-        state?.let { listOf(it.requestId, it.userUid, it.subRoute?.route) }
+        state?.let { listOf(it.requestId, it.userUid, it.subRoute.reauthSubRouteId()) }
     },
     restore = { saved ->
         ReauthPresentationState(
             requestId = requireNotNull(saved[0]),
             userUid = requireNotNull(saved[1]),
-            subRoute = when (saved.getOrNull(2)) {
-                AuthRoute.Email.route -> AuthRoute.Email
-                AuthRoute.Phone.route -> AuthRoute.Phone
-                else -> null
-            },
+            subRoute = reauthSubRouteForId(saved.getOrNull(2)),
         )
     },
 )

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/reauth/ReauthSheetContent.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/reauth/ReauthSheetContent.kt
@@ -38,6 +38,7 @@ import com.firebase.ui.auth.ui.exposeTestTagsAsResourceIds
 import com.firebase.ui.auth.ui.method_picker.AuthMethodPicker
 import com.firebase.ui.auth.ui.screens.AuthRoute
 import com.firebase.ui.auth.ui.screens.email.EmailAuthContentState
+import com.firebase.ui.auth.ui.screens.email.emailAuthDestinations
 import com.firebase.ui.auth.ui.screens.getStartRoute
 import com.firebase.ui.auth.ui.screens.mfa.MfaChallengeScreen
 import com.firebase.ui.auth.ui.screens.phone.PhoneAuthContentState
@@ -69,16 +70,14 @@ internal fun ReauthSheetContent(
         config = reauthConfig,
         onNavigate = { route -> sheetNavController.navigate(route.route) },
     )
-    // Provider selection for this sheet, which is where a consumed challenge returns to. With a
-    // single provider that is its own screen, so the credential attempt can simply be repeated.
     val returnToProviderSelection: () -> Unit = {
         sheetNavController.navigate(startRoute.route) {
-            popUpTo(startRoute.route) { inclusive = true }
+            // popUpTo matches a registered destination, so it takes the pattern, not the route.
+            popUpTo(startRoute.routePattern) { inclusive = true }
             launchSingleTop = true
         }
     }
-    // Inside the sheet's own NavHost: on the outer one the challenge would render underneath
-    // this modal, where the user cannot reach it.
+    // Must be the sheet's own NavHost: on the outer one the challenge renders under this modal.
     LaunchedEffect(mfaResolver) {
         if (mfaResolver != null) {
             sheetNavController.navigate(AuthRoute.MfaChallenge.route) { launchSingleTop = true }
@@ -87,20 +86,18 @@ internal fun ReauthSheetContent(
 
     NavHost(
         navController = sheetNavController,
-        startDestination = startRoute.route,
+        startDestination = startRoute.routePattern,
         enterTransition = { fadeIn(animationSpec = tween(700)) },
         exitTransition = { fadeOut(animationSpec = tween(700)) },
         popEnterTransition = { fadeIn(animationSpec = tween(700)) },
         popExitTransition = { fadeOut(animationSpec = tween(700)) },
     ) {
-        composable(AuthRoute.MethodPicker.route) {
+        composable(AuthRoute.MethodPicker.routePattern) {
             if (customMethodPickerLayout != null) {
                 Box(modifier = Modifier.fillMaxSize()) {
                     customMethodPickerLayout(reauthConfig.providers, onProviderSelected)
                 }
             } else {
-                // Same reasoning as FirebaseAuthScreen's Scaffold: flagged even though the
-                // enclosing ModalBottomSheet already covers this subtree.
                 Scaffold(modifier = Modifier.exposeTestTagsAsResourceIds()) { innerPadding ->
                     AuthMethodPicker(
                         modifier = Modifier.padding(innerPadding),
@@ -111,51 +108,49 @@ internal fun ReauthSheetContent(
             }
         }
 
-        composable(AuthRoute.Email.route) {
-            com.firebase.ui.auth.ui.screens.email.EmailAuthScreen(
-                context = context,
-                configuration = reauthConfig,
-                authUI = authUI,
-                prefillEmail = prefillEmail,
-                content = emailContent,
-                onSuccess = {},
-                onError = {},
-                onCancel = {
-                    if (skipsMethodPicker || !sheetNavController.popBackStack()) {
-                        onDismiss()
-                    } else {
-                        authUI.updateReauthentication(requestId) { it.attemptCancelled() }
-                    }
+        emailAuthDestinations(
+            navController = sheetNavController,
+            context = context,
+            configuration = reauthConfig,
+            authUI = authUI,
+            content = emailContent,
+            prefillEmail = { prefillEmail },
+            onCancel = {
+                if (skipsMethodPicker || !sheetNavController.popBackStack()) {
+                    onDismiss()
+                } else {
+                    authUI.updateReauthentication(requestId) { it.attemptCancelled() }
                 }
-            )
+            },
+        )
+
+        // Every phone step, as on the main graph; registering only the start step strands the rest.
+        AuthRoute.Phone.steps.forEach { step ->
+            composable(step.routePattern) {
+                com.firebase.ui.auth.ui.screens.phone.PhoneAuthScreen(
+                    context = context,
+                    configuration = reauthConfig,
+                    authUI = authUI,
+                    content = phoneContent,
+                    onSuccess = {},
+                    onError = {},
+                    onCancel = {
+                        if (skipsMethodPicker || !sheetNavController.popBackStack()) {
+                            onDismiss()
+                        } else {
+                            authUI.updateReauthentication(requestId) { it.attemptCancelled() }
+                        }
+                    }
+                )
+            }
         }
 
-        composable(AuthRoute.Phone.route) {
-            com.firebase.ui.auth.ui.screens.phone.PhoneAuthScreen(
-                context = context,
-                configuration = reauthConfig,
-                authUI = authUI,
-                content = phoneContent,
-                onSuccess = {},
-                onError = {},
-                onCancel = {
-                    if (skipsMethodPicker || !sheetNavController.popBackStack()) {
-                        onDismiss()
-                    } else {
-                        authUI.updateReauthentication(requestId) { it.attemptCancelled() }
-                    }
-                }
-            )
-        }
-
-        composable(AuthRoute.MfaChallenge.route) {
+        composable(AuthRoute.MfaChallenge.routePattern) {
             if (mfaResolver != null) {
                 MfaChallengeScreen(
                     resolver = mfaResolver,
                     auth = authUI.auth,
                     content = mfaChallengeContent,
-                    // Resolving the challenge is what completed the reauthentication, so this is
-                    // where the stamped Success for it is published.
                     onSuccess = { authUI.publishReauthenticationSuccess() },
                     onCancel = {
                         returnToProviderSelection()

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenEmailRecoveryTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenEmailRecoveryTest.kt
@@ -1,0 +1,634 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens
+
+import android.content.Context
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.StateRestorationTester
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.navigation.NavBackStackEntry
+import androidx.test.core.app.ApplicationProvider
+import com.firebase.ui.auth.AuthException
+import com.firebase.ui.auth.AuthState
+import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.configuration.AuthUIConfiguration
+import com.firebase.ui.auth.configuration.AuthUITransitions
+import com.firebase.ui.auth.configuration.authUIConfiguration
+import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.configuration.string_provider.DefaultAuthUIStringProvider
+import com.firebase.ui.auth.ui.FirebaseAuthTestTags
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.auth.ActionCodeSettings
+import com.google.firebase.auth.EmailAuthProvider
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.UserInfo
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * [FirebaseAuthScreen] is the single owner of the navigation an error recovery performs; the email
+ * steps observe the same [AuthState.Error] and leave it alone.
+ *
+ * Every test here runs on the email-only configuration, where the flow's sign-in step is the
+ * graph's start destination. That is the shape the back-stack hazards live in: a recovery that
+ * destroyed the start entry makes every later reset silently do nothing, because
+ * androidx.navigation ignores a `popUpTo` whose target is not on the stack.
+ *
+ * @suppress Internal test class
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class FirebaseAuthScreenEmailRecoveryTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var applicationContext: Context
+    private lateinit var stringProvider: DefaultAuthUIStringProvider
+    private lateinit var authUI: FirebaseAuthUI
+    private lateinit var mockUser: FirebaseUser
+
+    private var pressBack: (() -> Unit)? = null
+    private var lastUiContext: AuthSuccessUiContext? = null
+
+    @Before
+    fun setUp() {
+        applicationContext = ApplicationProvider.getApplicationContext()
+        stringProvider = DefaultAuthUIStringProvider(applicationContext)
+        FirebaseAuthUI.clearInstanceCache()
+        FirebaseApp.getApps(applicationContext).forEach { it.delete() }
+        val app = FirebaseApp.initializeApp(
+            applicationContext,
+            FirebaseOptions.Builder()
+                .setApiKey("fake-api-key")
+                .setApplicationId("fake-app-id")
+                .setProjectId("fake-project-id")
+                .build()
+        )
+        val auth = mock(FirebaseAuth::class.java)
+        `when`(auth.app).thenReturn(app)
+        authUI = FirebaseAuthUI.create(app, auth)
+        mockUser = mock(FirebaseUser::class.java)
+        `when`(mockUser.uid).thenReturn("recovery-user-uid")
+    }
+
+    @After
+    fun tearDown() {
+        pressBack = null
+        lastUiContext = null
+        FirebaseAuthUI.clearInstanceCache()
+        FirebaseApp.getApps(applicationContext).forEach {
+            try {
+                it.delete()
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    // Recovery moves the flow, and only from here
+
+    @Test
+    fun `no account for the address recovers to sign-up and keeps what was typed`() {
+        start()
+        typeSignInEmail()
+
+        recoverFrom(AuthException.UserNotFoundException(message = "no such user"))
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.EMAIL_FIELD).assertIsDisplayed()
+        composeTestRule.onNodeWithText(TYPED_EMAIL).assertIsDisplayed()
+    }
+
+    /**
+     * A recovery pushes when the step it starts from stays useful: "no account for this address"
+     * leaves the sign-in form underneath, address intact, as where a mistyped one gets fixed.
+     */
+    @Test
+    fun `back from the recovery target returns to the sign-in step`() {
+        start()
+        typeSignInEmail()
+        recoverFrom(AuthException.UserNotFoundException(message = "no such user"))
+
+        back()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.EMAIL_FIELD).assertDoesNotExist()
+    }
+
+    /**
+     * A recovery must not pop the graph's start destination: the later reset's
+     * `popUpTo(startDestination)` would then match nothing and leave the form under the success
+     * screen for back to return to.
+     */
+    @Test
+    fun `back after a success cannot return to the form recovery moved to`() {
+        start()
+        typeSignInEmail()
+        recoverFrom(AuthException.UserNotFoundException(message = "no such user"))
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.EMAIL_FIELD).assertIsDisplayed()
+
+        signIn()
+        composeTestRule.onNodeWithTag(AUTHENTICATED_TAG).assertIsDisplayed()
+
+        back()
+
+        composeTestRule.onNodeWithTag(AUTHENTICATED_TAG).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.EMAIL_FIELD).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertDoesNotExist()
+    }
+
+    /**
+     * The same reset, reached the other way round: a cancellation returns the flow to its start
+     * step, and repeating it must not stack anything up for back to walk into.
+     */
+    @Test
+    fun `repeated cancellations leave a single step for back to find`() {
+        start()
+        goToSignUp()
+
+        repeat(3) {
+            composeTestRule.runOnIdle { authUI.updateAuthState(AuthState.Cancelled) }
+            composeTestRule.waitForIdle()
+        }
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+
+        back()
+
+        // Nothing inside the flow was left underneath, so back could not move at all.
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.EMAIL_FIELD).assertDoesNotExist()
+    }
+
+    /**
+     * A recovery replaces when the step it starts from is a dead end: an address that already has
+     * an account makes the sign-up form useless, so the move pops back rather than burying it.
+     */
+    @Test
+    fun `an address already in use recovers to the sign-in step`() {
+        start()
+        typeSignInEmail()
+        goToSignUp()
+
+        recoverFrom(
+            AuthException.EmailAlreadyInUseException(
+                message = "already in use",
+                email = TYPED_EMAIL,
+            )
+        )
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+        // The dead-end form is gone rather than buried.
+        back()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.EMAIL_FIELD).assertDoesNotExist()
+    }
+
+    @Test
+    fun `no recovery is offered for a missing account when sign-up is not offered`() {
+        start(configuration = emailConfiguration(isNewAccountsAllowed = false))
+        typeSignInEmail()
+
+        composeTestRule.runOnIdle {
+            authUI.updateAuthState(
+                AuthState.Error(AuthException.UserNotFoundException(message = "no such user"))
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText(stringProvider.errorDialogTitle).assertExists()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.ErrorRecovery.RETRY_BUTTON)
+            .assertDoesNotExist()
+    }
+
+    // The email-link recovery step, both branches
+
+    @Test
+    fun `a suggested email-link method recovers to the email-link step when it is enabled`() {
+        start(configuration = emailConfiguration(isEmailLinkSignInEnabled = true))
+        typeSignInEmail()
+
+        recoverFrom(differentSignInMethodRequired())
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.EmailLink.EMAIL_FIELD)
+            .assertIsDisplayed()
+    }
+
+    /**
+     * Without email-link sign-in configured there is no such step to offer, so the recovery falls
+     * back to password sign-in rather than rendering a form the provider cannot complete.
+     */
+    @Test
+    fun `a suggested email-link method recovers to the sign-in step when it is disabled`() {
+        start(configuration = emailConfiguration(isEmailLinkSignInEnabled = false))
+        typeSignInEmail()
+        goToSignUp()
+
+        recoverFrom(differentSignInMethodRequired())
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.EmailLink.EMAIL_FIELD)
+            .assertDoesNotExist()
+    }
+
+    // The address the recovery carries
+
+    /**
+     * A recovery can start from a provider attempt, which never went through an email step: the
+     * failure names the address, and the recovery must use it rather than open an empty form.
+     */
+    @Test
+    fun `a recovery with nothing typed uses the address the failure names`() {
+        start(configuration = emailAndPhoneConfiguration())
+
+        // Still on the method picker, so the host has no typed address to fall back on.
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertDoesNotExist()
+
+        recoverFrom(
+            AuthException.EmailAlreadyInUseException(
+                message = "already in use",
+                email = TYPED_EMAIL,
+            )
+        )
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+        composeTestRule.onNodeWithText(TYPED_EMAIL).assertIsDisplayed()
+    }
+
+    /**
+     * When both are available the failure still wins: the typed address can be the one that
+     * provoked the failure rather than the one it is about.
+     */
+    @Test
+    fun `the address the failure names beats the one the host recorded`() {
+        start(configuration = emailConfiguration(isEmailLinkSignInEnabled = true))
+        typeSignInEmail()
+
+        recoverFrom(
+            AuthException.DifferentSignInMethodRequiredException(
+                message = "use the email link",
+                email = OTHER_EMAIL,
+                signInMethods = listOf(EmailAuthProvider.EMAIL_LINK_SIGN_IN_METHOD),
+                suggestedSignInMethod = EmailAuthProvider.EMAIL_LINK_SIGN_IN_METHOD,
+            )
+        )
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.EmailLink.EMAIL_FIELD)
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText(OTHER_EMAIL).assertIsDisplayed()
+        composeTestRule.onNodeWithText(TYPED_EMAIL).assertDoesNotExist()
+    }
+
+    // Activity recreation
+
+    /**
+     * The address the host tracks has to be saveable: a recovery decided after a recreation has
+     * only the route argument to fall back on, and the start destination carries the empty default.
+     */
+    @Test
+    fun `a recovery after an Activity recreation still carries the typed address`() {
+        val restorationTester = StateRestorationTester(composeTestRule)
+        restorationTester.setContent {
+            CaptureBackDispatcher()
+            FirebaseAuthScreen(
+                configuration = emailConfiguration(),
+                authUI = authUI,
+                onSignInSuccess = {},
+                onSignInFailure = {},
+                onSignInCancelled = {},
+            )
+        }
+        composeTestRule.waitForIdle()
+        typeSignInEmail()
+
+        restorationTester.emulateSavedInstanceStateRestore()
+        composeTestRule.waitForIdle()
+
+        // The field itself survives on its own.
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+        composeTestRule.onNodeWithText(TYPED_EMAIL).assertIsDisplayed()
+
+        // Nothing is typed after the recreation, so the recovery has only the host's own record.
+        recoverFrom(AuthException.UserNotFoundException(message = "no such user"))
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.EMAIL_FIELD).assertIsDisplayed()
+        composeTestRule.onNodeWithText(TYPED_EMAIL).assertIsDisplayed()
+    }
+
+    /**
+     * Surviving a recreation must not mean surviving a sign-out: the next session's user must not
+     * be handed the previous one's address, on the form or through a recovery.
+     */
+    @Test
+    fun `signing out drops the address for both the form and the next recovery`() {
+        start()
+        typeSignInEmail()
+        signIn()
+        composeTestRule.onNodeWithTag(AUTHENTICATED_TAG).assertIsDisplayed()
+
+        // What signOut publishes: Loading (not a notification, so the Idle is a real reset), Idle.
+        composeTestRule.runOnIdle { authUI.updateAuthState(AuthState.Loading()) }
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnIdle { authUI.updateAuthState(AuthState.Idle) }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+        composeTestRule.onNodeWithText(TYPED_EMAIL).assertDoesNotExist()
+
+        // And the host's own record went with it, so a recovery cannot carry it either.
+        recoverFrom(AuthException.UserNotFoundException(message = "no such user"))
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.EMAIL_FIELD).assertIsDisplayed()
+        composeTestRule.onNodeWithText(TYPED_EMAIL).assertDoesNotExist()
+    }
+
+    // Reauthentication
+
+    /**
+     * The invariant the recovery veto rests on: while a request is armed,
+     * `FirebaseAuthUI.contextualizeReauthenticationState` folds every `AuthState.Error` into
+     * `AuthState.Reauthentication.AttemptFailed`, so the branch offering recovery is unreachable
+     * while a reauthentication surface is up. Were that to stop, a recovery could navigate the
+     * outer graph out from under the sheet with the request still armed.
+     */
+    @Test
+    fun `an error raised while a reauth request is armed never surfaces as an error state`() {
+        val passwordInfo = mock(UserInfo::class.java)
+        `when`(passwordInfo.providerId).thenReturn(EmailAuthProvider.PROVIDER_ID)
+        val user = mock(FirebaseUser::class.java)
+        `when`(user.providerData).thenReturn(listOf(passwordInfo))
+        `when`(user.email).thenReturn(TYPED_EMAIL)
+        `when`(user.uid).thenReturn("reauth-user-uid")
+
+        // A second collector, so the folded state can be read directly.
+        val seen = mutableListOf<AuthState>()
+        composeTestRule.setContent {
+            LaunchedEffect(authUI) { authUI.authStateFlow().collect { seen += it } }
+            FirebaseAuthScreen(
+                configuration = emailConfiguration(),
+                authUI = authUI,
+                onSignInSuccess = {},
+                onSignInFailure = {},
+                onSignInCancelled = {},
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            authUI.updateAuthState(
+                AuthState.Reauthentication.Required(user, retryOperation = {})
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            authUI.updateAuthState(
+                AuthState.Error(AuthException.UserNotFoundException(message = "no such user"))
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        assertThat(composeTestRule.runOnIdle { seen.lastOrNull() })
+            .isInstanceOf(AuthState.Reauthentication.AttemptFailed::class.java)
+        // No action button on the dialog, and the outer graph did not move behind the sheet.
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.ErrorRecovery.RETRY_BUTTON)
+            .assertDoesNotExist()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.EMAIL_FIELD).assertDoesNotExist()
+    }
+
+    /**
+     * Every recovery either moves the flow to an email step or starts a fresh provider sign-in,
+     * neither of which may happen while reauthenticating, so the dialog offers nothing.
+     */
+    @Test
+    fun `reauthentication offers no recovery action`() {
+        start(configuration = emailConfiguration().copy(isReauthenticationMode = true))
+
+        composeTestRule.runOnIdle {
+            authUI.updateAuthState(
+                AuthState.Error(AuthException.UserNotFoundException(message = "no such user"))
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText(stringProvider.errorDialogTitle).assertExists()
+        composeTestRule.onNodeWithText(stringProvider.dismissAction).assertExists()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.ErrorRecovery.RETRY_BUTTON)
+            .assertDoesNotExist()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.EMAIL_FIELD).assertDoesNotExist()
+    }
+
+    // Every route the public API exposes is a registered destination
+
+    /**
+     * `AuthSuccessUiContext.onNavigate` takes any [AuthRoute] and hands it straight to the
+     * controller, which throws for a destination nothing registered, so every value must resolve.
+     */
+    @Test
+    fun `every AuthRoute resolves to a registered destination`() {
+        // Both provider flows configured: a phone step composes the phone screen.
+        start(configuration = emailAndPhoneConfiguration())
+        signIn()
+
+        val uiContext = requireNotNull(composeTestRule.runOnIdle { lastUiContext })
+        val unresolved = mutableListOf<String>()
+        AuthRoute.all.forEach { route ->
+            composeTestRule.runOnIdle {
+                try {
+                    uiContext.onNavigate(route)
+                } catch (e: IllegalArgumentException) {
+                    unresolved += "${route.route}: ${e.message}"
+                }
+            }
+            composeTestRule.waitForIdle()
+        }
+
+        assertThat(unresolved).isEmpty()
+    }
+
+    // Configured transitions
+
+    /**
+     * A step-to-step move is real navigation, animated by whatever the caller configured: the
+     * graph asks the transition lambdas, naming the two step routes it moves between.
+     */
+    @Test
+    fun `the configured transitions drive a step-to-step move`() {
+        val observed = mutableListOf<String>()
+        start(configuration = emailConfiguration(transitions = recordingTransitions(observed)))
+
+        goToSignUp()
+
+        val signIn = AuthRoute.Email.SignIn.routePattern
+        val signUp = AuthRoute.Email.SignUp.routePattern
+        assertThat(observed).contains("enter:$signIn->$signUp")
+        assertThat(observed).contains("exit:$signIn->$signUp")
+    }
+
+    // Harness
+
+    private fun emailConfiguration(
+        isEmailLinkSignInEnabled: Boolean = false,
+        isNewAccountsAllowed: Boolean = true,
+        transitions: AuthUITransitions? = null,
+    ): AuthUIConfiguration = authUIConfiguration {
+        context = applicationContext
+        providers {
+            provider(
+                AuthProvider.Email(
+                    isDisplayNameRequired = false,
+                    isEmailLinkSignInEnabled = isEmailLinkSignInEnabled,
+                    isNewAccountsAllowed = isNewAccountsAllowed,
+                    emailLinkActionCodeSettings = if (isEmailLinkSignInEnabled) {
+                        ActionCodeSettings.newBuilder()
+                            .setUrl("https://example.com")
+                            .setHandleCodeInApp(true)
+                            .setAndroidPackageName("com.test", true, null)
+                            .build()
+                    } else {
+                        null
+                    },
+                    passwordValidationRules = emptyList()
+                )
+            )
+        }
+        isCredentialManagerEnabled = false
+        this.transitions = transitions
+    }
+
+    private fun emailAndPhoneConfiguration(): AuthUIConfiguration = authUIConfiguration {
+        context = applicationContext
+        providers {
+            provider(
+                AuthProvider.Email(
+                    isDisplayNameRequired = false,
+                    emailLinkActionCodeSettings = null,
+                    passwordValidationRules = emptyList()
+                )
+            )
+            provider(
+                AuthProvider.Phone(
+                    defaultNumber = null,
+                    defaultCountryCode = null,
+                    allowedCountries = null
+                )
+            )
+        }
+        isCredentialManagerEnabled = false
+    }
+
+    private fun recordingTransitions(into: MutableList<String>) = AuthUITransitions(
+        enterTransition = { into += "enter:${label()}"; EnterTransition.None },
+        exitTransition = { into += "exit:${label()}"; ExitTransition.None },
+        popEnterTransition = { into += "popEnter:${label()}"; EnterTransition.None },
+        popExitTransition = { into += "popExit:${label()}"; ExitTransition.None },
+    )
+
+    private fun AnimatedContentTransitionScope<NavBackStackEntry>.label(): String =
+        "${initialState.destination.route}->${targetState.destination.route}"
+
+    private fun differentSignInMethodRequired() =
+        AuthException.DifferentSignInMethodRequiredException(
+            message = "use the email link",
+            email = TYPED_EMAIL,
+            signInMethods = listOf(EmailAuthProvider.EMAIL_LINK_SIGN_IN_METHOD),
+            suggestedSignInMethod = EmailAuthProvider.EMAIL_LINK_SIGN_IN_METHOD,
+        )
+
+    private fun start(configuration: AuthUIConfiguration = emailConfiguration()) {
+        composeTestRule.setContent {
+            CaptureBackDispatcher()
+            FirebaseAuthScreen(
+                configuration = configuration,
+                authUI = authUI,
+                onSignInSuccess = {},
+                onSignInFailure = {},
+                onSignInCancelled = {},
+                authenticatedContent = { _, uiContext ->
+                    SideEffect { lastUiContext = uiContext }
+                    Text("authenticated", modifier = Modifier.testTag(AUTHENTICATED_TAG))
+                },
+            )
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    @Composable
+    private fun CaptureBackDispatcher() {
+        val dispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+        SideEffect { pressBack = dispatcher?.let { { it.onBackPressed() } } }
+    }
+
+    private fun typeSignInEmail() {
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD)
+            .performTextInput(TYPED_EMAIL)
+        composeTestRule.waitForIdle()
+    }
+
+    private fun goToSignUp() {
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.SIGN_UP_BUTTON).performClick()
+        composeTestRule.waitForIdle()
+    }
+
+    /** Raises [exception] and takes the recovery action its error dialog offers. */
+    private fun recoverFrom(exception: AuthException) {
+        composeTestRule.runOnIdle { authUI.updateAuthState(AuthState.Error(exception)) }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.ErrorRecovery.RETRY_BUTTON)
+            .performClick()
+        composeTestRule.waitForIdle()
+    }
+
+    private fun signIn() {
+        composeTestRule.runOnIdle {
+            authUI.updateAuthState(AuthState.Success(result = null, user = mockUser))
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun back() {
+        composeTestRule.runOnUiThread { requireNotNull(pressBack).invoke() }
+        composeTestRule.waitForIdle()
+    }
+
+    private companion object {
+        const val TYPED_EMAIL = "user+tag@example.com"
+        const val OTHER_EMAIL = "someone.else@example.com"
+        const val AUTHENTICATED_TAG = "recovery_test_authenticated"
+    }
+}

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenRouteTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenRouteTest.kt
@@ -1,15 +1,18 @@
 package com.firebase.ui.auth.ui.screens
 
 import android.content.Context
+import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
 import com.firebase.ui.auth.configuration.authUIConfiguration
 import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.ui.screens.email.EmailAuthMode
 import com.google.common.truth.Truth.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import kotlin.reflect.KClass
 
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
@@ -114,5 +117,174 @@ class FirebaseAuthScreenRouteTest {
         }
 
         assertThat(getStartRoute(configuration)).isEqualTo(AuthRoute.MethodPicker)
+    }
+
+    // AuthRoute shape — public API.
+
+    /**
+     * Naming a flow means "enter this flow", so its route has to be its start step's — both
+     * `route`, which callers navigate with, and `routePattern`, which the graph registers.
+     */
+    @Test
+    fun `every flow entry point resolves to its start step`() {
+        assertThat(AuthRoute.Email.route).isEqualTo(AuthRoute.Email.SignIn.route)
+        assertThat(AuthRoute.Email.routePattern).isEqualTo(AuthRoute.Email.SignIn.routePattern)
+
+        assertThat(AuthRoute.Phone.route).isEqualTo(AuthRoute.Phone.EnterPhoneNumber.route)
+        assertThat(AuthRoute.Phone.routePattern)
+            .isEqualTo(AuthRoute.Phone.EnterPhoneNumber.routePattern)
+
+        assertThat(AuthRoute.MfaEnrollment.route)
+            .isEqualTo(AuthRoute.MfaEnrollment.SelectFactor.route)
+        assertThat(AuthRoute.MfaEnrollment.routePattern)
+            .isEqualTo(AuthRoute.MfaEnrollment.SelectFactor.routePattern)
+    }
+
+    /** Only the email steps take an argument, so only they may differ from their pattern. */
+    @Test
+    fun `routePattern equals route for every destination that takes no argument`() {
+        val argumentless = listOf(
+            AuthRoute.MethodPicker,
+            AuthRoute.Success,
+            AuthRoute.MfaChallenge,
+            AuthRoute.Phone,
+            AuthRoute.Phone.EnterPhoneNumber,
+            AuthRoute.Phone.EnterVerificationCode,
+            AuthRoute.MfaEnrollment.SelectFactor,
+            AuthRoute.MfaEnrollment.ConfigureSms,
+            AuthRoute.MfaEnrollment.ConfigureTotp,
+            AuthRoute.MfaEnrollment.VerifyFactor,
+        )
+
+        argumentless.forEach { route ->
+            assertThat(route.routePattern).isEqualTo(route.route)
+        }
+    }
+
+    @Test
+    fun `every email step registers the optional email argument`() {
+        AuthRoute.Email.steps.forEach { step ->
+            assertThat(step.routePattern).isEqualTo("${step.route}?$EMAIL_ARG={$EMAIL_ARG}")
+        }
+    }
+
+    /**
+     * The step lists must be computed getters: stored, they would be built before the nested
+     * objects were assigned and capture them as null. Reading a route off each entry catches that.
+     */
+    @Test
+    fun `the email step list is fully populated and distinct`() {
+        val routes = AuthRoute.Email.steps.map { it.route }
+
+        assertThat(routes).hasSize(EmailAuthMode.entries.size)
+        assertThat(routes).containsNoDuplicates()
+        routes.forEach { route -> assertThat(route).isNotEmpty() }
+    }
+
+    @Test
+    fun `every email mode maps to exactly one step`() {
+        EmailAuthMode.entries.forEach { mode ->
+            assertThat(AuthRoute.Email.stepFor(mode).mode).isEqualTo(mode)
+        }
+    }
+
+    @Test
+    fun `withEmail appends an encoded address and omits an empty one`() {
+        val step = AuthRoute.Email.SignUp
+
+        assertThat(step.withEmail(null)).isEqualTo(step.route)
+        assertThat(step.withEmail("")).isEqualTo(step.route)
+        assertThat(step.withEmail("user+tag@example.com"))
+            .isEqualTo("${step.route}?$EMAIL_ARG=user%2Btag%40example.com")
+    }
+
+    /**
+     * The address goes into a URI query string, so anything a local part or domain may legally
+     * hold has to come back out unchanged — a raw `#` truncates the URI, a raw space invalidates it.
+     */
+    @Test
+    fun `withEmail encodes every address so the argument round-trips`() {
+        val step = AuthRoute.Email.SignUp
+
+        listOf(
+            "user+tag@example.com",
+            "user name@example.com",
+            "user#hash@example.com",
+            "user?query=1@example.com",
+            "user&more@example.com",
+            "ada@königsberg.example",
+            "用户@例え.jp",
+        ).forEach { address ->
+            val encoded = step.withEmail(address)
+
+            assertThat(encoded).startsWith("${step.route}?$EMAIL_ARG=")
+            // The encoded form is what travels; nothing that would break the URI survives in it.
+            assertThat(encoded.substringAfter('=')).doesNotContain("#")
+            assertThat(encoded).doesNotContain(" ")
+            assertThat(Uri.parse(encoded).getQueryParameters(EMAIL_ARG))
+                .containsExactly(address)
+        }
+    }
+
+    @Test
+    fun `isStep recognises the email steps and nothing else`() {
+        AuthRoute.Email.steps.forEach { step ->
+            assertThat(AuthRoute.Email.isStep(step.routePattern)).isTrue()
+        }
+
+        assertThat(AuthRoute.Email.isStep(AuthRoute.MethodPicker.routePattern)).isFalse()
+        assertThat(AuthRoute.Email.isStep(AuthRoute.Phone.routePattern)).isFalse()
+        // A live destination.route is always the pattern, never the bare navigation route.
+        assertThat(AuthRoute.Email.isStep(AuthRoute.Email.SignIn.route)).isFalse()
+        assertThat(AuthRoute.Email.isStep(null)).isFalse()
+    }
+
+    /**
+     * `AuthRoute.all` has to name every step the sealed hierarchy declares: one left out of its
+     * flow's `steps` list is registered nowhere and throws at whoever navigates to it. Enumerated
+     * from `sealedSubclasses`, since a hand-written list would agree with itself either way.
+     */
+    @Test
+    fun `the full route list names every step the hierarchy declares`() {
+        val all = AuthRoute.all
+        val standalone = listOf(
+            AuthRoute.MethodPicker,
+            AuthRoute.Success,
+            AuthRoute.MfaChallenge,
+        )
+        val flows = listOf(AuthRoute.Email, AuthRoute.Phone, AuthRoute.MfaEnrollment)
+        val declared = declaredSteps(AuthRoute.Email.Step::class) +
+                declaredSteps(AuthRoute.Phone.Step::class) +
+                declaredSteps(AuthRoute.MfaEnrollment.Step::class)
+
+        // Exactly, not at least: the list must not grow a value no host registers either.
+        assertThat(all).containsExactlyElementsIn(standalone + flows + declared)
+        // Each flow entry point shares its start step's route, which is the only duplication the
+        // list is allowed to hold — one collision per flow.
+        assertThat(all.map { it.route }.distinct()).hasSize(all.size - flows.size)
+    }
+
+    /** The same check from the other side: hosts register a flow from its own `steps` list. */
+    @Test
+    fun `each flow's step list holds exactly the steps it declares`() {
+        assertThat(AuthRoute.Email.steps)
+            .containsExactlyElementsIn(declaredSteps(AuthRoute.Email.Step::class))
+        assertThat(AuthRoute.Phone.steps)
+            .containsExactlyElementsIn(declaredSteps(AuthRoute.Phone.Step::class))
+        assertThat(AuthRoute.MfaEnrollment.steps)
+            .containsExactlyElementsIn(declaredSteps(AuthRoute.MfaEnrollment.Step::class))
+    }
+
+    /** Every step object the sealed [stepType] declares, by reflection rather than a literal list. */
+    private fun declaredSteps(stepType: KClass<out AuthRoute>): List<AuthRoute> {
+        val subclasses = stepType.sealedSubclasses
+        assertThat(subclasses).isNotEmpty()
+        return subclasses.map { subclass ->
+            requireNotNull(subclass.objectInstance) {
+                "${subclass.simpleName} is a step but not an object. Steps are named by identity " +
+                        "(the graph registers them, callers pass them), so each has to be a " +
+                        "singleton."
+            }
+        }
     }
 }

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthHostDestinationsTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthHostDestinationsTest.kt
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens.email
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.StateRestorationTester
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import com.firebase.ui.auth.AuthState
+import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.configuration.AuthUIConfiguration
+import com.firebase.ui.auth.configuration.authUIConfiguration
+import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.configuration.string_provider.DefaultAuthUIStringProvider
+import com.firebase.ui.auth.configuration.string_provider.LocalAuthUIStringProvider
+import com.firebase.ui.auth.ui.FirebaseAuthTestTags
+import com.firebase.ui.auth.ui.screens.FirebaseAuthScreen
+import com.firebase.ui.auth.ui.screens.reauth.ReauthSheetContent
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.auth.FirebaseAuth
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Both hosts of the email flow install the same destinations through the same
+ * [emailAuthDestinations] extension: [FirebaseAuthScreen]'s graph and the reauthentication
+ * sheet's own one.
+ *
+ * These drive the default email UI, so they also pin the back arrow stepping back through the
+ * flow rather than leaving it.
+ *
+ * @suppress Internal test class
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class EmailAuthHostDestinationsTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var applicationContext: Context
+    private lateinit var stringProvider: DefaultAuthUIStringProvider
+    private lateinit var authUI: FirebaseAuthUI
+
+    @Before
+    fun setUp() {
+        applicationContext = ApplicationProvider.getApplicationContext()
+        stringProvider = DefaultAuthUIStringProvider(applicationContext)
+        FirebaseAuthUI.clearInstanceCache()
+        FirebaseApp.getApps(applicationContext).forEach { it.delete() }
+        val app = FirebaseApp.initializeApp(
+            applicationContext,
+            FirebaseOptions.Builder()
+                .setApiKey("fake-api-key")
+                .setApplicationId("fake-app-id")
+                .setProjectId("fake-project-id")
+                .build()
+        )
+        val auth = mock(FirebaseAuth::class.java)
+        `when`(auth.app).thenReturn(app)
+        authUI = FirebaseAuthUI.create(app, auth)
+    }
+
+    @After
+    fun tearDown() {
+        FirebaseAuthUI.clearInstanceCache()
+        FirebaseApp.getApps(applicationContext).forEach {
+            try {
+                it.delete()
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    @Test
+    fun `the main screen walks sign-in to sign-up and back, keeping the address`() {
+        composeTestRule.setContent {
+            FirebaseAuthScreen(
+                configuration = emailConfiguration(),
+                authUI = authUI,
+                onSignInSuccess = {},
+                onSignInFailure = {},
+                onSignInCancelled = {},
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD)
+            .performTextInput(TYPED_EMAIL)
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.SIGN_UP_BUTTON).performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.EMAIL_FIELD).assertIsDisplayed()
+        composeTestRule.onNodeWithText(TYPED_EMAIL).assertIsDisplayed()
+
+        // Email is this flow's start destination, so sign-in is what lies under sign-up.
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.BACK_BUTTON).performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+    }
+
+    /**
+     * A genuine reset to [com.firebase.ui.auth.AuthState.Idle] sends the flow back to its start
+     * route, which is the sign-in step, so a reset from a sub-step does not keep the sub-step.
+     */
+    @Test
+    fun `a genuine idle reset returns to the flow's start step`() {
+        composeTestRule.setContent {
+            FirebaseAuthScreen(
+                configuration = emailConfiguration(),
+                authUI = authUI,
+                onSignInSuccess = {},
+                onSignInFailure = {},
+                onSignInCancelled = {},
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.SIGN_UP_BUTTON).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.EMAIL_FIELD).assertIsDisplayed()
+
+        // Loading is not a notification, so the Idle that follows it is a real reset.
+        composeTestRule.runOnIdle { authUI.updateAuthState(AuthState.Loading()) }
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnIdle { authUI.updateAuthState(AuthState.Idle) }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.EMAIL_FIELD).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the reauthentication sheet registers the same email destinations`() {
+        var dismissed = 0
+        composeTestRule.setContent {
+            ReauthSheetUnderTest(onDismiss = { dismissed++ })
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD)
+            .performTextInput(TYPED_EMAIL)
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.FORGOT_PASSWORD_BUTTON)
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        // Reaching it proves the sheet registered it; the address proves the argument carried.
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.ResetPassword.EMAIL_FIELD)
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText(TYPED_EMAIL).assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.ResetPassword.BACK_BUTTON).performClick()
+        composeTestRule.waitForIdle()
+
+        // Back inside the flow: the sheet stays up and the reauthentication is not abandoned.
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+        assertThat(dismissed).isEqualTo(0)
+    }
+
+    /**
+     * "Which flow is open" and "which step the user is on" are different facts. Exactly one thing
+     * records the step: the sheet's own `rememberNavController`, whose back stack Compose saves
+     * and restores, arguments included. `ReauthPresentationState` records the flow, and the
+     * built-in sheet never reads it.
+     *
+     * Pins that the step, and the address it was entered with, survive a recreation.
+     */
+    @Test
+    fun `the reauthentication sheet keeps its email step across a recreation`() {
+        val restorationTester = StateRestorationTester(composeTestRule)
+        restorationTester.setContent { ReauthSheetUnderTest(onDismiss = {}) }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD)
+            .performTextInput(TYPED_EMAIL)
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.FORGOT_PASSWORD_BUTTON)
+            .performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.ResetPassword.EMAIL_FIELD)
+            .assertIsDisplayed()
+
+        restorationTester.emulateSavedInstanceStateRestore()
+        composeTestRule.waitForIdle()
+
+        // Still the step the user was on, not the flow's start step.
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.ResetPassword.EMAIL_FIELD)
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertDoesNotExist()
+        // And the address it was entered with, which travels as the route argument.
+        composeTestRule.onNodeWithText(TYPED_EMAIL).assertIsDisplayed()
+
+        // Back still walks the flow, so what was restored is the real stack.
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.ResetPassword.BACK_BUTTON).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+    }
+
+    @Composable
+    private fun ReauthSheetUnderTest(onDismiss: () -> Unit) {
+        CompositionLocalProvider(LocalAuthUIStringProvider provides stringProvider) {
+            ReauthSheetContent(
+                authUI = authUI,
+                reauthConfig = reauthConfiguration(),
+                requestId = "request-id",
+                activity = null,
+                context = applicationContext,
+                // Nothing prefilled, so the field stays editable and this test can type into it.
+                prefillEmail = null,
+                emailContent = null,
+                phoneContent = null,
+                mfaChallengeContent = null,
+                mfaResolver = null,
+                customMethodPickerLayout = null,
+                onDismiss = onDismiss,
+            )
+        }
+    }
+
+    private fun emailConfiguration(): AuthUIConfiguration = authUIConfiguration {
+        context = applicationContext
+        providers {
+            provider(
+                AuthProvider.Email(
+                    emailLinkActionCodeSettings = null,
+                    passwordValidationRules = emptyList()
+                )
+            )
+        }
+        isCredentialManagerEnabled = false
+    }
+
+    private fun reauthConfiguration(): AuthUIConfiguration = emailConfiguration().copy(
+        isAnonymousUpgradeEnabled = false,
+        isCredentialLinkingEnabled = false,
+        isNewEmailAccountsAllowed = false,
+        isReauthenticationMode = true,
+    )
+
+    private companion object {
+        const val TYPED_EMAIL = "user+tag@example.com"
+    }
+}

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthRouteNavigationTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthRouteNavigationTest.kt
@@ -1,0 +1,560 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens.email
+
+import android.content.Context
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.hasProgressBarRangeInfo
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.get
+import androidx.test.core.app.ApplicationProvider
+import com.firebase.ui.auth.AuthException
+import com.firebase.ui.auth.AuthState
+import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.configuration.AuthUIConfiguration
+import com.firebase.ui.auth.configuration.authUIConfiguration
+import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.configuration.string_provider.DefaultAuthUIStringProvider
+import com.firebase.ui.auth.configuration.string_provider.LocalAuthUIStringProvider
+import com.firebase.ui.auth.ui.components.LocalTopLevelDialogController
+import com.firebase.ui.auth.ui.components.rememberTopLevelDialogController
+import com.firebase.ui.auth.ui.screens.AuthRoute
+import com.firebase.ui.auth.ui.screens.EMAIL_ARG
+import com.firebase.ui.auth.ui.screens.resetBackStackTo
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.auth.ActionCodeSettings
+import com.google.firebase.auth.FirebaseAuth
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Covers the one-destination-per-[EmailAuthMode] email graph.
+ *
+ * The unit under test is [emailAuthDestinations] — the same graph extension both
+ * [com.firebase.ui.auth.ui.screens.FirebaseAuthScreen] and the reauthentication sheet install —
+ * hosted here in a bare [NavHost] so the back stack, its depth and the arguments it carries can
+ * be read directly. The sign-in step is this graph's start destination, the shape a
+ * single-provider email configuration produces and the one every back-stack hazard turns on.
+ *
+ * @suppress Internal test class
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class EmailAuthRouteNavigationTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var applicationContext: Context
+    private lateinit var authUI: FirebaseAuthUI
+    private lateinit var stringProvider: DefaultAuthUIStringProvider
+
+    private var navController: NavHostController? = null
+    private var lastState: EmailAuthContentState? = null
+    private var pressBack: (() -> Unit)? = null
+
+    @Before
+    fun setUp() {
+        applicationContext = ApplicationProvider.getApplicationContext()
+        stringProvider = DefaultAuthUIStringProvider(applicationContext)
+        FirebaseAuthUI.clearInstanceCache()
+        FirebaseApp.getApps(applicationContext).forEach { it.delete() }
+        val app = FirebaseApp.initializeApp(
+            applicationContext,
+            FirebaseOptions.Builder()
+                .setApiKey("fake-api-key")
+                .setApplicationId("fake-app-id")
+                .setProjectId("fake-project-id")
+                .build()
+        )
+        val auth = mock(FirebaseAuth::class.java)
+        `when`(auth.app).thenReturn(app)
+        authUI = FirebaseAuthUI.create(app, auth)
+    }
+
+    @After
+    fun tearDown() {
+        navController = null
+        lastState = null
+        pressBack = null
+        FirebaseAuthUI.clearInstanceCache()
+        FirebaseApp.getApps(applicationContext).forEach {
+            try {
+                it.delete()
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    // User-initiated switches
+
+    @Test
+    fun `going to sign-up pushes the sign-up destination carrying the typed address`() {
+        start()
+        typeEmail(TYPED_EMAIL)
+
+        goTo(EmailAuthMode.SignUp)
+
+        assertThat(currentRoute()).isEqualTo(AuthRoute.Email.SignUp.routePattern)
+        assertThat(currentEmailArgument()).isEqualTo(TYPED_EMAIL)
+        assertThat(renderedEmail()).isEqualTo(TYPED_EMAIL)
+        assertThat(backStackRoutes()).containsExactly(
+            AuthRoute.Email.SignIn.routePattern,
+            AuthRoute.Email.SignUp.routePattern,
+        ).inOrder()
+    }
+
+    @Test
+    fun `the typed address survives every mode switch`() {
+        start()
+        typeEmail(TYPED_EMAIL)
+
+        listOf(
+            EmailAuthMode.SignUp,
+            EmailAuthMode.ResetPassword,
+            EmailAuthMode.EmailLinkSignIn,
+            EmailAuthMode.SignIn,
+        ).forEach { target ->
+            goTo(target)
+
+            assertThat(currentRoute()).isEqualTo(AuthRoute.Email.stepFor(target).routePattern)
+            assertThat(currentEmailArgument()).isEqualTo(TYPED_EMAIL)
+            assertThat(renderedEmail()).isEqualTo(TYPED_EMAIL)
+        }
+    }
+
+    @Test
+    fun `the exposed mode always matches the active destination`() {
+        start()
+
+        EmailAuthMode.entries.forEach { target ->
+            goTo(target)
+
+            assertThat(currentRoute()).isEqualTo(AuthRoute.Email.stepFor(target).routePattern)
+            assertThat(renderedMode()).isEqualTo(target)
+        }
+    }
+
+    @Test
+    fun `system back walks the modes in reverse order of the pushes`() {
+        start()
+        typeEmail(TYPED_EMAIL)
+        goTo(EmailAuthMode.SignUp)
+        goTo(EmailAuthMode.ResetPassword)
+
+        back()
+        assertThat(currentRoute()).isEqualTo(AuthRoute.Email.SignUp.routePattern)
+
+        back()
+        assertThat(currentRoute()).isEqualTo(AuthRoute.Email.SignIn.routePattern)
+    }
+
+    /**
+     * `launchSingleTop` alone only de-duplicates a target already on top, so toggling between two
+     * steps must not add an entry per tap.
+     */
+    @Test
+    fun `toggling sign-in and sign-up keeps the back stack bounded`() {
+        start()
+        typeEmail(TYPED_EMAIL)
+
+        repeat(6) {
+            goTo(EmailAuthMode.SignUp)
+            assertThat(backStackRoutes()).containsExactly(
+                AuthRoute.Email.SignIn.routePattern,
+                AuthRoute.Email.SignUp.routePattern,
+            ).inOrder()
+
+            goTo(EmailAuthMode.SignIn)
+            assertThat(backStackRoutes())
+                .containsExactly(AuthRoute.Email.SignIn.routePattern)
+        }
+    }
+
+    /**
+     * Switching to a step already beneath the current one pops back to it instead of stacking a
+     * second copy, and the address just typed wins over the one that entry was created with.
+     */
+    @Test
+    fun `switching back to a step already on the stack keeps the newest address`() {
+        start()
+        goTo(EmailAuthMode.SignUp)
+        typeEmail(TYPED_EMAIL)
+
+        goTo(EmailAuthMode.SignIn)
+
+        assertThat(backStackRoutes()).containsExactly(AuthRoute.Email.SignIn.routePattern)
+        assertThat(currentEmailArgument()).isEqualTo(TYPED_EMAIL)
+        assertThat(renderedEmail()).isEqualTo(TYPED_EMAIL)
+    }
+
+    /** The other half of re-pushing: a switch clears the password, a pop-back would restore it. */
+    @Test
+    fun `a switch clears the password even when the target step was already on the stack`() {
+        start()
+        typeEmail(TYPED_EMAIL)
+        composeTestRule.runOnIdle { requireNotNull(lastState).onPasswordChange("hunter2") }
+        composeTestRule.waitForIdle()
+
+        goTo(EmailAuthMode.SignUp)
+        goTo(EmailAuthMode.SignIn)
+
+        assertThat(composeTestRule.runOnIdle { lastState?.password }).isEmpty()
+    }
+
+    // Argument encoding
+
+    /**
+     * The address travels in the route's query string, so every character a local part or domain
+     * may legally hold has to survive `Uri.encode` on the way out and the decode on the way in.
+     */
+    @Test
+    fun `awkward addresses round-trip through the route argument unchanged`() {
+        start()
+
+        listOf(
+            "user+tag@example.com",
+            "user name@example.com",
+            "user#hash@example.com",
+            "user?query=1@example.com",
+            "user&more@example.com",
+            "ada@königsberg.example",
+            "用户@例え.jp",
+        ).forEach { address ->
+            typeEmail(address)
+            goTo(EmailAuthMode.SignUp)
+
+            assertThat(currentEmailArgument()).isEqualTo(address)
+            assertThat(renderedEmail()).isEqualTo(address)
+
+            goTo(EmailAuthMode.SignIn)
+        }
+    }
+
+    // Errors belong to the host
+
+    /**
+     * `AuthState.Error` is one event on a shared flow. A hosted step neither moves the flow nor
+     * raises the dialog, so it cannot race the host's own recovery actions.
+     */
+    @Test
+    fun `a hosted step neither navigates nor raises a dialog on an error`() {
+        start()
+        typeEmail(TYPED_EMAIL)
+
+        composeTestRule.runOnIdle {
+            authUI.updateAuthState(
+                AuthState.Error(AuthException.UserNotFoundException(message = "no such user"))
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        assertThat(backStackRoutes()).containsExactly(AuthRoute.Email.SignIn.routePattern)
+        assertThat(renderedEmail()).isEqualTo(TYPED_EMAIL)
+        composeTestRule.onAllNodesWithText(stringProvider.errorDialogTitle).assertCountEquals(0)
+    }
+
+    // Steps the configuration does not offer
+
+    @Test
+    fun `reauthentication cannot switch to sign-up`() {
+        start(configuration = reauthConfiguration())
+        typeEmail(TYPED_EMAIL)
+
+        goTo(EmailAuthMode.SignUp)
+
+        assertThat(currentRoute()).isEqualTo(AuthRoute.Email.SignIn.routePattern)
+    }
+
+    @Test
+    fun `reauthentication cannot switch to email-link sign-in`() {
+        start(configuration = reauthConfiguration())
+        typeEmail(TYPED_EMAIL)
+
+        goTo(EmailAuthMode.EmailLinkSignIn)
+
+        assertThat(currentRoute()).isEqualTo(AuthRoute.Email.SignIn.routePattern)
+    }
+
+    @Test
+    fun `a provider without email-link sign-in cannot switch to it`() {
+        start(configuration = emailConfiguration(isEmailLinkSignInEnabled = false))
+        typeEmail(TYPED_EMAIL)
+
+        goTo(EmailAuthMode.EmailLinkSignIn)
+
+        assertThat(currentRoute()).isEqualTo(AuthRoute.Email.SignIn.routePattern)
+    }
+
+    /**
+     * `AuthSuccessUiContext.onNavigate` takes any [AuthRoute], so a host — or a restored back
+     * stack — can reach a step the configuration switched off. The bounce keeps it unreachable,
+     * and keeps the address.
+     */
+    @Test
+    fun `the sign-up destination bounces to sign-in when account creation is not offered`() {
+        start(configuration = reauthConfiguration())
+
+        navigateDirectlyTo(AuthRoute.Email.SignUp)
+
+        assertThat(currentRoute()).isEqualTo(AuthRoute.Email.SignIn.routePattern)
+        assertThat(currentEmailArgument()).isEqualTo(TYPED_EMAIL)
+        // Gone, not left underneath, where back would return to it and bounce again.
+        assertThat(backStackRoutes()).containsExactly(AuthRoute.Email.SignIn.routePattern)
+    }
+
+    /** The same exposure, and now the same guard, for a provider with email-link disabled. */
+    @Test
+    fun `the email-link destination bounces to sign-in when the provider disables it`() {
+        start(configuration = emailConfiguration(isEmailLinkSignInEnabled = false))
+
+        navigateDirectlyTo(AuthRoute.Email.EmailLinkSignIn)
+
+        assertThat(currentRoute()).isEqualTo(AuthRoute.Email.SignIn.routePattern)
+        assertThat(currentEmailArgument()).isEqualTo(TYPED_EMAIL)
+        assertThat(backStackRoutes()).containsExactly(AuthRoute.Email.SignIn.routePattern)
+    }
+
+    /**
+     * The redirect is not instant: against the configured 700 ms cross-fade the bounced step is on
+     * screen for the whole transition, so it must render something.
+     */
+    @Test
+    fun `a step that is redirecting out of itself still renders something`() {
+        composeTestRule.setContent {
+            CompositionLocalProvider(
+                LocalAuthUIStringProvider provides stringProvider
+            ) {
+                RedirectingStep()
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        // No test tag: main-source tags come from the public FirebaseAuthTestTags registry only.
+        composeTestRule
+            .onNode(hasProgressBarRangeInfo(ProgressBarRangeInfo.Indeterminate))
+            .assertIsDisplayed()
+    }
+
+    // Resets
+
+    /**
+     * [resetBackStackTo] is what every reset in
+     * [com.firebase.ui.auth.ui.screens.FirebaseAuthScreen] goes through — success, cancellation
+     * and a genuine idle — and must leave nothing of the flow underneath what it lands on.
+     */
+    @Test
+    fun `a reset clears the flow whatever the back stack holds`() {
+        start()
+        typeEmail(TYPED_EMAIL)
+        goTo(EmailAuthMode.SignUp)
+        goTo(EmailAuthMode.ResetPassword)
+
+        reset(AuthRoute.MethodPicker)
+
+        assertThat(backStackRoutes()).containsExactly(AuthRoute.MethodPicker.routePattern)
+    }
+
+    /** Repeated resets must not pile up either, whichever destination they land on. */
+    @Test
+    fun `repeated resets keep the back stack at a single entry`() {
+        start()
+
+        repeat(4) {
+            reset(AuthRoute.MethodPicker)
+            assertThat(backStackRoutes()).containsExactly(AuthRoute.MethodPicker.routePattern)
+
+            reset(AuthRoute.Email)
+            assertThat(backStackRoutes()).containsExactly(AuthRoute.Email.SignIn.routePattern)
+        }
+    }
+
+    /** A reset lands on a single entry, leaving nothing inside the flow for system back. */
+    @Test
+    fun `system back after a reset has nothing in the flow to return to`() {
+        start()
+        goTo(EmailAuthMode.SignUp)
+        reset(AuthRoute.Email)
+
+        back()
+
+        assertThat(currentRoute()).isEqualTo(AuthRoute.Email.SignIn.routePattern)
+        assertThat(backStackRoutes()).containsExactly(AuthRoute.Email.SignIn.routePattern)
+    }
+
+    // Harness
+
+    private fun emailConfiguration(
+        isEmailLinkSignInEnabled: Boolean = true,
+    ): AuthUIConfiguration = authUIConfiguration {
+        context = applicationContext
+        providers {
+            provider(
+                AuthProvider.Email(
+                    isEmailLinkSignInEnabled = isEmailLinkSignInEnabled,
+                    emailLinkActionCodeSettings = if (isEmailLinkSignInEnabled) {
+                        ActionCodeSettings.newBuilder()
+                            .setUrl("https://example.com")
+                            .setHandleCodeInApp(true)
+                            .setAndroidPackageName("com.test", true, null)
+                            .build()
+                    } else {
+                        null
+                    },
+                    passwordValidationRules = emptyList()
+                )
+            )
+        }
+        isCredentialManagerEnabled = false
+    }
+
+    private fun reauthConfiguration(): AuthUIConfiguration = emailConfiguration().copy(
+        isNewEmailAccountsAllowed = false,
+        isReauthenticationMode = true,
+    )
+
+    private fun start(configuration: AuthUIConfiguration = emailConfiguration()) {
+        composeTestRule.setContent { EmailFlowHost(configuration) }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun typeEmail(email: String) {
+        composeTestRule.runOnIdle { requireNotNull(lastState).onEmailChange(email) }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun goTo(mode: EmailAuthMode) {
+        composeTestRule.runOnIdle {
+            val state = requireNotNull(lastState)
+            when (mode) {
+                EmailAuthMode.SignIn -> state.onGoToSignIn()
+                EmailAuthMode.SignUp -> state.onGoToSignUp()
+                EmailAuthMode.ResetPassword -> state.onGoToResetPassword()
+                EmailAuthMode.EmailLinkSignIn -> state.onGoToEmailLinkSignIn()
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    /** Enters [step] the way a host's `onNavigate` does — bypassing the screen's own guards. */
+    private fun navigateDirectlyTo(step: AuthRoute.Email.Step) {
+        composeTestRule.runOnIdle {
+            requireNotNull(navController).navigate(step.withEmail(TYPED_EMAIL))
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun reset(route: AuthRoute) {
+        composeTestRule.runOnIdle { requireNotNull(navController).resetBackStackTo(route) }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun back() {
+        composeTestRule.runOnUiThread { requireNotNull(pressBack).invoke() }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun currentRoute(): String? =
+        composeTestRule.runOnIdle { navController?.currentBackStackEntry?.destination?.route }
+
+    private fun currentEmailArgument(): String? = composeTestRule.runOnIdle {
+        navController?.currentBackStackEntry?.arguments?.getString(EMAIL_ARG)
+    }
+
+    /**
+     * The composed destinations on the stack, bottom to top, read from the [ComposeNavigator]'s
+     * own back stack. `NavController.currentBackStack` is `@RestrictTo(LIBRARY_GROUP)`.
+     */
+    private fun backStackRoutes(): List<String?> = composeTestRule.runOnIdle {
+        navController?.navigatorProvider?.get(ComposeNavigator::class)
+            ?.backStack?.value
+            ?.map { it.destination.route }
+            .orEmpty()
+    }
+
+    private fun renderedEmail(): String? = composeTestRule.runOnIdle { lastState?.email }
+
+    private fun renderedMode(): EmailAuthMode? = composeTestRule.runOnIdle { lastState?.mode }
+
+    @Composable
+    private fun EmailFlowHost(configuration: AuthUIConfiguration) {
+        val controller = rememberNavController()
+        val dispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+        SideEffect {
+            navController = controller
+            pressBack = dispatcher?.let { { it.onBackPressed() } }
+        }
+
+        val authState by remember(authUI) { authUI.authStateFlow() }.collectAsState(AuthState.Idle)
+        val dialogController = rememberTopLevelDialogController(stringProvider) { authState }
+
+        CompositionLocalProvider(
+            LocalAuthUIStringProvider provides configuration.stringProvider,
+            LocalTopLevelDialogController provides dialogController,
+        ) {
+            NavHost(
+                navController = controller,
+                startDestination = AuthRoute.Email.routePattern,
+                // Transitions would keep two email destinations composed at once.
+                enterTransition = { EnterTransition.None },
+                exitTransition = { ExitTransition.None },
+                popEnterTransition = { EnterTransition.None },
+                popExitTransition = { ExitTransition.None },
+            ) {
+                emailAuthDestinations(
+                    navController = controller,
+                    context = applicationContext,
+                    configuration = configuration,
+                    authUI = authUI,
+                    content = { state -> lastState = state },
+                    onCancel = {},
+                )
+                // Somewhere outside the flow for a reset to land on, standing in for the picker.
+                composable(AuthRoute.MethodPicker.routePattern) { }
+            }
+            dialogController.CurrentDialog()
+        }
+    }
+
+    private companion object {
+        const val TYPED_EMAIL = "user+tag@example.com"
+    }
+}

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreenModeSwitchTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreenModeSwitchTest.kt
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens.email
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.core.app.ApplicationProvider
+import com.firebase.ui.auth.AuthException
+import com.firebase.ui.auth.AuthState
+import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.configuration.AuthUIConfiguration
+import com.firebase.ui.auth.configuration.authUIConfiguration
+import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.configuration.string_provider.DefaultAuthUIStringProvider
+import com.firebase.ui.auth.configuration.string_provider.LocalAuthUIStringProvider
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.auth.ActionCodeSettings
+import com.google.firebase.auth.FirebaseAuth
+import org.junit.After
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * [EmailAuthScreen] used on its own, with nothing outside it driving the mode — the shape
+ * `EmailAuthSlotDemoActivity` and the custom reauthentication content both use.
+ *
+ * Guards that a mode switch clears only the mode-specific secrets and keeps the typed address.
+ *
+ * @suppress Internal test class
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class EmailAuthScreenModeSwitchTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var applicationContext: Context
+    private lateinit var authUI: FirebaseAuthUI
+
+    private var lastState: EmailAuthContentState? = null
+
+    @Before
+    fun setUp() {
+        applicationContext = ApplicationProvider.getApplicationContext()
+        FirebaseAuthUI.clearInstanceCache()
+        FirebaseApp.getApps(applicationContext).forEach { it.delete() }
+        val app = FirebaseApp.initializeApp(
+            applicationContext,
+            FirebaseOptions.Builder()
+                .setApiKey("fake-api-key")
+                .setApplicationId("fake-app-id")
+                .setProjectId("fake-project-id")
+                .build()
+        )
+        authUI = FirebaseAuthUI.create(app, mock(FirebaseAuth::class.java))
+    }
+
+    @After
+    fun tearDown() {
+        lastState = null
+        FirebaseAuthUI.clearInstanceCache()
+        FirebaseApp.getApps(applicationContext).forEach {
+            try {
+                it.delete()
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    @Test
+    fun `the typed address survives every mode switch`() {
+        start()
+        type { it.onEmailChange(TYPED_EMAIL) }
+
+        listOf(
+            EmailAuthMode.SignUp,
+            EmailAuthMode.SignIn,
+            EmailAuthMode.ResetPassword,
+            EmailAuthMode.EmailLinkSignIn,
+            EmailAuthMode.SignIn,
+        ).forEach { target ->
+            goTo(target)
+
+            assertThat(state().mode).isEqualTo(target)
+            assertThat(state().email).isEqualTo(TYPED_EMAIL)
+        }
+    }
+
+    @Test
+    fun `switching modes still clears the password, its confirmation and the display name`() {
+        start()
+        type {
+            it.onEmailChange(TYPED_EMAIL)
+            it.onPasswordChange("hunter2")
+            it.onConfirmPasswordChange("hunter2")
+            it.onDisplayNameChange("Ada")
+        }
+
+        goTo(EmailAuthMode.SignUp)
+
+        assertThat(state().password).isEmpty()
+        assertThat(state().confirmPassword).isEmpty()
+        assertThat(state().displayName).isEmpty()
+    }
+
+    /** Without a host driving it, the screen owns the mode itself. */
+    @Test
+    fun `the unhosted screen drives its own mode from local state`() {
+        start()
+
+        assertThat(state().mode).isEqualTo(EmailAuthMode.SignIn)
+
+        goTo(EmailAuthMode.ResetPassword)
+        assertThat(state().mode).isEqualTo(EmailAuthMode.ResetPassword)
+
+        goTo(EmailAuthMode.SignIn)
+        assertThat(state().mode).isEqualTo(EmailAuthMode.SignIn)
+    }
+
+    /**
+     * The screen never moves itself on an error: unhosted, the user stays on the form with
+     * everything they typed, password included.
+     */
+    @Test
+    fun `an unhosted screen stays put and keeps what was typed when the account is not found`() {
+        start()
+        type {
+            it.onEmailChange(TYPED_EMAIL)
+            it.onPasswordChange("hunter2")
+        }
+
+        composeTestRule.runOnIdle {
+            authUI.updateAuthState(
+                AuthState.Error(AuthException.UserNotFoundException(message = "no such user"))
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        assertThat(state().mode).isEqualTo(EmailAuthMode.SignIn)
+        assertThat(state().email).isEqualTo(TYPED_EMAIL)
+        assertThat(state().password).isEqualTo("hunter2")
+    }
+
+    /** The same for an address already taken. */
+    @Test
+    fun `an unhosted screen stays put when the address is already in use`() {
+        start()
+        goTo(EmailAuthMode.SignUp)
+        type { it.onEmailChange(TYPED_EMAIL) }
+
+        composeTestRule.runOnIdle {
+            authUI.updateAuthState(
+                AuthState.Error(
+                    AuthException.EmailAlreadyInUseException(
+                        message = "already in use",
+                        email = TYPED_EMAIL,
+                    )
+                )
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        assertThat(state().mode).isEqualTo(EmailAuthMode.SignUp)
+        assertThat(state().email).isEqualTo(TYPED_EMAIL)
+    }
+
+    /**
+     * `mode` and `onNavigateToMode` are two halves of one contract; either alone leaves every
+     * switch control silently inert, so it is rejected.
+     */
+    @Test
+    fun `a mode with no way to report a switch is rejected`() {
+        val thrown = assertThrows(IllegalArgumentException::class.java) {
+            startWith(mode = EmailAuthMode.SignUp, onNavigateToMode = null)
+        }
+
+        // The message names both halves, so either omission is identifiable.
+        assertThat(thrown).hasMessageThat().contains("mode")
+        assertThat(thrown).hasMessageThat().contains("onNavigateToMode")
+    }
+
+    /** The message is just as usable when it is `mode` that was forgotten. */
+    @Test
+    fun `a switch callback with no mode to render is rejected`() {
+        val thrown = assertThrows(IllegalArgumentException::class.java) {
+            startWith(mode = null, onNavigateToMode = { _, _ -> })
+        }
+
+        assertThat(thrown).hasMessageThat().contains("mode")
+        assertThat(thrown).hasMessageThat().contains("onNavigateToMode")
+    }
+
+    private fun startWith(
+        mode: EmailAuthMode?,
+        onNavigateToMode: ((EmailAuthMode, String) -> Unit)?,
+    ) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(
+                LocalAuthUIStringProvider provides
+                        DefaultAuthUIStringProvider(applicationContext)
+            ) {
+                EmailAuthScreen(
+                    context = applicationContext,
+                    configuration = configuration(),
+                    authUI = authUI,
+                    onSuccess = {},
+                    onError = {},
+                    onCancel = {},
+                    mode = mode,
+                    onNavigateToMode = onNavigateToMode,
+                    content = { },
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    // Email-link sign-in configured, so all four modes are actually on offer.
+    private fun configuration(): AuthUIConfiguration = authUIConfiguration {
+        context = applicationContext
+        providers {
+            provider(
+                AuthProvider.Email(
+                    isEmailLinkSignInEnabled = true,
+                    emailLinkActionCodeSettings = ActionCodeSettings.newBuilder()
+                        .setUrl("https://example.com")
+                        .setHandleCodeInApp(true)
+                        .setAndroidPackageName("com.test", true, null)
+                        .build(),
+                    passwordValidationRules = emptyList()
+                )
+            )
+        }
+        isCredentialManagerEnabled = false
+    }
+
+    private fun start() {
+        composeTestRule.setContent { EmailScreenUnderTest(configuration()) }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun state(): EmailAuthContentState =
+        composeTestRule.runOnIdle { requireNotNull(lastState) }
+
+    private fun type(block: (EmailAuthContentState) -> Unit) {
+        composeTestRule.runOnIdle { block(requireNotNull(lastState)) }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun goTo(mode: EmailAuthMode) {
+        composeTestRule.runOnIdle {
+            val current = requireNotNull(lastState)
+            when (mode) {
+                EmailAuthMode.SignIn -> current.onGoToSignIn()
+                EmailAuthMode.SignUp -> current.onGoToSignUp()
+                EmailAuthMode.ResetPassword -> current.onGoToResetPassword()
+                EmailAuthMode.EmailLinkSignIn -> current.onGoToEmailLinkSignIn()
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    @Composable
+    private fun EmailScreenUnderTest(configuration: AuthUIConfiguration) {
+        CompositionLocalProvider(
+            LocalAuthUIStringProvider provides DefaultAuthUIStringProvider(applicationContext)
+        ) {
+            EmailAuthScreen(
+                context = applicationContext,
+                configuration = configuration,
+                authUI = authUI,
+                onSuccess = {},
+                onError = {},
+                onCancel = {},
+                content = { state -> lastState = state },
+            )
+        }
+    }
+
+    private companion object {
+        const val TYPED_EMAIL = "user+tag@example.com"
+    }
+}

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreenReauthEmailLockTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreenReauthEmailLockTest.kt
@@ -58,9 +58,8 @@ import org.robolectric.annotation.Config
  * The reauthentication email lock has to survive an [EmailAuthMode] round-trip.
  *
  * [DefaultEmailAuthContent] dispatches modes with a `when`, so leaving [EmailAuthMode.SignIn]
- * *disposes* the [SignInUI] composition group and coming back creates a fresh one. Any lock
- * [SignInUI] inferred from its own (mutable) field value was therefore re-decided on every return —
- * either dropping the lock, or locking an address the library never prefilled.
+ * disposes the [SignInUI] composition group and coming back creates a fresh one. A lock inferred
+ * from the field's own value would be re-decided on every return.
  *
  * @suppress Internal test class
  */
@@ -171,9 +170,8 @@ class EmailAuthScreenReauthEmailLockTest {
     }
 
     /**
-     * Every branch of this screen's `onRetry` is inert in reauthentication mode (sign-up and
-     * mode switches are all vetoed), so an action button on the error dialog could only dismiss —
-     * and it raced the outer screen's `onRetry = null` for the same error.
+     * Unhosted, this screen shows the error but never acts on it, so the dialog explains the
+     * error and renders no action button.
      */
     @Test
     fun `the reauth sub-flow error dialog offers no action button`() {
@@ -202,12 +200,9 @@ class EmailAuthScreenReauthEmailLockTest {
         composeTestRule.onNodeWithTag(FirebaseAuthTestTags.ErrorRecovery.RETRY_BUTTON).assertDoesNotExist()
     }
 
-    /**
-     * Resetting the text fields (the mode switches all do it) must put the locked address back,
-     * not leave the user on an empty read-only field.
-     */
+    /** A mode switch keeps the address, so it can never leave an empty read-only field. */
     @Test
-    fun `the locked email is restored when the text fields are reset`() {
+    fun `the locked email survives a mode switch`() {
         var email: String? = null
         var isEmailLocked: Boolean? = null
         var goToSignIn: (() -> Unit)? = null
@@ -290,11 +285,9 @@ class EmailAuthScreenReauthEmailLockTest {
     }
 
     /**
-     * The two out-of-band email routes are not equivalent during reauthentication. A password reset
-     * email leaves the sheet up and the request armed, so it stays available — blocking it stranded
-     * a user who had forgotten their password with no route but dismissal. An email *link* reopens
-     * the app with nothing armed, so completing it reports an interruption instead of finishing the
-     * pending operation, and it stays hidden.
+     * The two out-of-band email routes are not equivalent during reauthentication: a password
+     * reset leaves the sheet up and the request armed, so it stays available, while an email link
+     * reopens the app with nothing armed and stays hidden.
      */
     @Test
     fun `password recovery is offered while reauthenticating but email-link sign-in is not`() {
@@ -302,7 +295,7 @@ class EmailAuthScreenReauthEmailLockTest {
             EmailAuthScreenUnderTest(reauthConfigurationWithEmailLink(), prefill = prefillEmail)
         }
 
-        // The password field proves this is the reauth SignIn screen, still usable as intended.
+        // The password field proves this is the reauth SignIn screen.
         composeTestRule.onNodeWithText(stringProvider.passwordHint).assertExists()
         composeTestRule.onNodeWithText(stringProvider.troubleSigningIn).assertExists()
         composeTestRule.onNodeWithText(stringProvider.signInWithEmailLink, ignoreCase = true)
@@ -354,7 +347,7 @@ class EmailAuthScreenReauthEmailLockTest {
 
     /**
      * The mirror case: outside reauthentication nothing is locked, so a round-trip must leave the
-     * field editable (and the "sign in" mode switch keeps clearing it as it always did).
+     * field editable.
      */
     @Test
     fun `the email field stays editable across a round-trip outside reauthentication`() {

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/reauth/ReauthPresentationStateSaverTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/reauth/ReauthPresentationStateSaverTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens.reauth
+
+import androidx.compose.runtime.saveable.SaverScope
+import com.firebase.ui.auth.ui.screens.AuthRoute
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * The reauthentication marker is all that survives Activity recreation for a request whose retry
+ * callback is process-local, so what it round-trips has to be exact.
+ *
+ * [AuthRoute.route] is not an identity: a flow entry point shares its start step's route string.
+ * These tests pin that the saver uses explicit ids instead, and pin the collision itself.
+ *
+ * @suppress Internal test class
+ */
+class ReauthPresentationStateSaverTest {
+
+    private val scope = SaverScope { true }
+
+    @Test
+    fun `the marker round-trips with no sub-route`() {
+        val restored = roundTrip(
+            ReauthPresentationState(requestId = "request-1", userUid = "uid-1")
+        )
+
+        assertThat(restored).isEqualTo(
+            ReauthPresentationState(requestId = "request-1", userUid = "uid-1", subRoute = null)
+        )
+    }
+
+    /** Every sub-route the presentation can be restored into comes back as itself. */
+    @Test
+    fun `each presentable sub-route round-trips as itself`() {
+        listOf(AuthRoute.Email, AuthRoute.Phone).forEach { subRoute ->
+            val restored = roundTrip(
+                ReauthPresentationState(
+                    requestId = "request-1",
+                    userUid = "uid-1",
+                    subRoute = subRoute,
+                )
+            )
+
+            assertThat(restored?.subRoute).isSameInstanceAs(subRoute)
+            assertThat(restored?.requestId).isEqualTo("request-1")
+            assertThat(restored?.userUid).isEqualTo("uid-1")
+        }
+    }
+
+    /**
+     * The collision the ids exist to survive: a flow and its start step report the same [route],
+     * so a saver keyed on that string cannot tell the two apart.
+     */
+    @Test
+    fun `a flow and its start step share a route string but not an id`() {
+        assertThat(AuthRoute.Email.route).isEqualTo(AuthRoute.Email.SignIn.route)
+        assertThat(AuthRoute.Phone.route).isEqualTo(AuthRoute.Phone.EnterPhoneNumber.route)
+
+        assertThat(AuthRoute.Email.reauthSubRouteId())
+            .isNotEqualTo(AuthRoute.Phone.reauthSubRouteId())
+        // A step is not a presentable sub-route at all, so it has no id.
+        assertThat(AuthRoute.Email.SignIn.reauthSubRouteId()).isNull()
+        assertThat(AuthRoute.Phone.EnterPhoneNumber.reauthSubRouteId()).isNull()
+    }
+
+    /**
+     * The MFA challenge is not restorable: its resolver lives only in the process-local
+     * `AuthState`, so saving it would restore a challenge screen with nothing to challenge.
+     */
+    @Test
+    fun `the mfa challenge sub-route is not restored`() {
+        assertThat(AuthRoute.MfaChallenge.reauthSubRouteId()).isNull()
+
+        val restored = roundTrip(
+            ReauthPresentationState(
+                requestId = "request-1",
+                userUid = "uid-1",
+                subRoute = AuthRoute.MfaChallenge,
+            )
+        )
+
+        assertThat(restored?.subRoute).isNull()
+        // The request itself still survives — only the sub-route is dropped.
+        assertThat(restored?.requestId).isEqualTo("request-1")
+    }
+
+    /** An unknown id restores as no sub-route rather than throwing on a stale saved bundle. */
+    @Test
+    fun `an unrecognised sub-route id restores as none`() {
+        assertThat(reauthSubRouteForId("something_else")).isNull()
+        assertThat(reauthSubRouteForId(null)).isNull()
+    }
+
+    @Test
+    fun `a null marker round-trips as null`() {
+        with(ReauthPresentationStateSaver) {
+            assertThat(scope.save(null)).isNull()
+        }
+    }
+
+    private fun roundTrip(state: ReauthPresentationState): ReauthPresentationState? =
+        with(ReauthPresentationStateSaver) {
+            val saved = requireNotNull(scope.save(state))
+            restore(saved)
+        }
+}


### PR DESCRIPTION
The multi-step email flow (sign-in, sign-up, reset password, email-link) kept its "which mode" state in local composable state shared across a single destination, so switching modes wiped whatever the user had typed, had no back-stack entry, and never animated. This converts it to one destination per mode, so the typed address survives every switch, system back walks through modes in order, and switches animate with the configured transitions.

`AuthRoute` gains nested per-step routes for all three auth flows and a `routePattern`/`route` distinction, so `MfaEnrollmentScreen` and `PhoneAuthScreen` can adopt the same per-step navigation later with no further public API change (tracked as follow-up PRs). Error-recovery navigation is now owned solely by the host — `EmailAuthScreen` no longer navigates itself on error, only reports.

- `EmailAuthDestinations.kt`: shared `NavGraphBuilder` extension registering the four email destinations, used by both `FirebaseAuthScreen` and the reauthentication sheet.
- `EmailAuthScreen`: gained `mode`/`onNavigateToMode` (paired — passing one without the other throws at composition) and `onEmailTyped`; `onContinueWithProvider` removed (the host owns provider hand-off now).
- `ReauthPresentationState`: route round-trip switched from an order-dependent `when` to an explicit route-string-to-id map, since a flow and its start step can now share a route string.

Added `EmailAuthRouteNavigationTest`, `FirebaseAuthScreenEmailRecoveryTest`, `EmailAuthScreenModeSwitchTest`, `EmailAuthHostDestinationsTest` and `ReauthPresentationStateSaverTest` covering preservation across switches and Activity recreation, back-stack bounding, error-recovery push/replace, and both hosts registering identical destinations.

## ⚠️ Breaking Changes

- `AuthRoute` gained nested per-step routes (6 subclasses → 16). An else-less exhaustive `when (route)` no longer compiles.
- Route string values changed: `auth_email` → `auth_email_signin`, `auth_phone` → `auth_phone_number`, `auth_mfa_enrollment` → `auth_mfa_enrollment_select_factor`.
- `EmailAuthScreen.onContinueWithProvider` removed.

## Usage

```kotlin
EmailAuthScreen(
    ...,
    mode = currentBackStackEntry.mode,      // driven by your own NavHost
    onNavigateToMode = { mode, email, replace -> navController.navigate(...) },
)
```

---
Maintainer note: Fixes internal CPRN-403