### PR TITLE
feat(auth)!: migrate auth navigation to Navigation 3

### DIFF
--- a/app/src/main/java/com/firebaseui/android/demo/auth/HighLevelApiDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/HighLevelApiDemoActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -105,10 +106,15 @@ class HighLevelApiDemoActivity : ComponentActivity() {
                 isMfaEnabled = false
                 stringProvider = customStringProvider
                 transitions = AuthUITransitions(
-                    enterTransition = { slideInHorizontally { it } },
-                    exitTransition = { slideOutHorizontally { -it } },
-                    popEnterTransition = { slideInHorizontally { -it } },
-                    popExitTransition = { slideOutHorizontally { it } }
+                    transitionSpec = {
+                        slideInHorizontally { it } togetherWith slideOutHorizontally { -it }
+                    },
+                    popTransitionSpec = {
+                        slideInHorizontally { -it } togetherWith slideOutHorizontally { it }
+                    },
+                    predictivePopTransitionSpec = { _ ->
+                        slideInHorizontally { -it } togetherWith slideOutHorizontally { it }
+                    },
                 )
                 providers {
                     provider(AuthProvider.Anonymous)
@@ -330,8 +336,6 @@ private fun AppAuthenticatedContent(
                             try {
                                 uiContext.authUI.delete(context)
                             } catch (e: AuthException.InvalidCredentialsException) {
-                                // Reauthentication.Required state was emitted —
-                                // FirebaseAuthScreen navigates to the reauth flow automatically.
                                 Log.d("HighLevelApiDemoActivity", "Reauth required before delete")
                             } catch (e: AuthException) {
                                 Log.e("HighLevelApiDemoActivity", "Delete failed", e)

--- a/auth/build.gradle.kts
+++ b/auth/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
     id("com.vanniktech.maven.publish")
     id("org.jetbrains.kotlin.android")
     alias(libs.plugins.kotlin.compose)
+    // Navigation 3 back-stack keys are @Serializable — that is how rememberNavBackStack persists
+    // them across configuration change and process death.
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -102,7 +105,18 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.android)
-    api(libs.compose.navigation)
+    // Navigation 3. `api`, not `implementation`: AuthUITransitions' lambdas are typed over
+    // androidx.navigation3.scene.Scene and AuthRoute's destinations are NavKeys, so both types are
+    // part of this library's public surface. Deliberately no lifecycle-viewmodel-navigation3 —
+    // auth/src/main is ViewModel-free.
+    api(libs.androidx.navigation3.runtime)
+    api(libs.androidx.navigation3.ui)
+    // No kotlinx-serialization declaration here on purpose. auth/src/main uses exactly one symbol
+    // from it — `@Serializable` on the AuthRoute keys — which lives in kotlinx-serialization-core,
+    // and navigation3-runtime publishes core in its own `api` variant, so the `api` above already
+    // puts it on this module's *and* every consumer's compile classpath. Declaring it again would
+    // only pin a higher core than navigation3 resolves, for every consumer, to no benefit. The
+    // `-json` runtime is a test-only dependency (see testImplementation below).
     implementation(libs.zxing.core)
     annotationProcessor(libs.androidx.lifecycle.compiler)
 
@@ -126,6 +140,15 @@ dependencies {
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.androidx.credentials)
     testImplementation(libs.compose.ui.test.junit4)
+    // Only the route test needs a concrete format, to round-trip a key's address the way saved
+    // state does. Nothing in auth/src/main touches `Json`.
+    //
+    // Its version is pinned to navigation3-runtime's own kotlinx-serialization-core (see the
+    // catalog): `-json` pulls a matching `-core`, Gradle resolves the highest on a classpath, and
+    // this is the only test that exercises the @Serializable codegen at runtime — so a higher
+    // `-json` here would silently move that test onto a core version no consumer of this library
+    // ever runs.
+    testImplementation(libs.kotlinx.serialization.json)
 
     debugImplementation(project(":internal:lintchecks"))
 }

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/AuthUITransitions.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/AuthUITransitions.kt
@@ -15,21 +15,35 @@
 package com.firebase.ui.auth.configuration
 
 import androidx.compose.animation.AnimatedContentTransitionScope
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
-import androidx.navigation.NavBackStackEntry
+import androidx.compose.animation.ContentTransform
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.scene.Scene
 
 /**
  * Container for screen transition animations used in Firebase Auth UI.
- * 
- * @property enterTransition Transition when entering a new screen
- * @property exitTransition Transition when exiting current screen
- * @property popEnterTransition Transition when returning to previous screen (back navigation)
- * @property popExitTransition Transition when exiting during back navigation
+ *
+ * Each spec is an [AnimatedContentTransitionScope] receiver on [Scene]`<`[NavKey]`>` returning a
+ * single [ContentTransform], pairing the enter and exit halves with `togetherWith`. To vary the
+ * animation per destination, read [com.firebase.ui.auth.ui.screens.authRoute] off `initialState`
+ * / `targetState`.
+ *
+ * @property transitionSpec Forward navigation.
+ * @property popTransitionSpec Back navigation.
+ * @property predictivePopTransitionSpec Predictive-back gesture. Its `Int` is the swipe edge:
+ * [androidx.navigationevent.NavigationEvent.EDGE_LEFT] (`0`),
+ * [androidx.navigationevent.NavigationEvent.EDGE_RIGHT] (`1`) or
+ * [androidx.navigationevent.NavigationEvent.EDGE_NONE] (`2`) for a back from no edge at all. Left
+ * null it falls back to the library's default cross-fade, not to [popTransitionSpec]. It runs when
+ * the gesture **starts**, not when a back navigation completes, so any side effect placed in it
+ * (analytics, logging a screen change) also fires for gestures the user goes on to cancel.
+ *
+ * @since 10.0.0
  */
 data class AuthUITransitions(
-    val enterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition)? = null,
-    val exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition)? = null,
-    val popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition)? = null,
-    val popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition)? = null,
+    val transitionSpec:
+    (AnimatedContentTransitionScope<Scene<NavKey>>.() -> ContentTransform)? = null,
+    val popTransitionSpec:
+    (AnimatedContentTransitionScope<Scene<NavKey>>.() -> ContentTransform)? = null,
+    val predictivePopTransitionSpec:
+    (AnimatedContentTransitionScope<Scene<NavKey>>.(Int) -> ContentTransform)? = null,
 )

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/AuthRoute.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/AuthRoute.kt
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens
+
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.NavMetadataKey
+import androidx.navigation3.runtime.get
+import androidx.navigation3.runtime.metadata
+import androidx.navigation3.scene.Scene
+import com.firebase.ui.auth.mfa.MfaEnrollmentStep
+import com.firebase.ui.auth.ui.screens.email.EmailAuthMode
+import kotlinx.serialization.Serializable
+
+/**
+ * A destination the library's navigation back stack can be told to go to.
+ *
+ * * **[Destination]** — a real back-stack entry, and therefore a Navigation 3 [NavKey]. Every one
+ *   is registered on both hosts' entry providers, so navigating to it always resolves. All are
+ *   `@Serializable`, which is what lets [androidx.navigation3.runtime.rememberNavBackStack]
+ *   persist the stack — and any field a step carries, today only [Email.Step.email] — across
+ *   configuration change *and* process death.
+ * * **[FlowEntry]** — [Email], [Phone] and [MfaEnrollment]. Naming one means "enter this flow";
+ *   [FlowEntry.startKey] resolves it to the step the flow opens on, so callers never have to name
+ *   a step. Deliberately **not** a [NavKey]: it can never be put on a back stack, and [toKey] is
+ *   the one way to turn it into something that can be.
+ *
+ * [Phone] registers its steps, but [com.firebase.ui.auth.ui.screens.phone.PhoneAuthScreen] still
+ * drives its own step internally, so every step of that flow renders the same screen.
+ *
+ * @since 10.0.0
+ */
+@Serializable
+sealed interface AuthRoute {
+
+    /** An [AuthRoute] that is a real destination, and therefore a Navigation 3 back-stack key. */
+    sealed interface Destination : AuthRoute, NavKey
+
+    /**
+     * An [AuthRoute] that names a *flow* rather than a destination. [startKey] converts it to the
+     * destination entering the flow lands on; [toKey] applies that to any [AuthRoute].
+     */
+    sealed interface FlowEntry : AuthRoute {
+        /** The destination entering this flow lands on. */
+        fun startKey(): Destination
+    }
+
+    @Serializable
+    data object MethodPicker : Destination
+
+    @Serializable
+    data object Success : Destination
+
+    @Serializable
+    data object MfaChallenge : Destination
+
+    /** Email and password, password recovery, and email-link sign-in. Starts at [SignIn]. */
+    object Email : FlowEntry {
+        override fun startKey(): Destination = SignIn()
+
+        /**
+         * One step per [EmailAuthMode], carrying the address typed so far as a field on the key,
+         * which is what preserves it across a switch: the step being left is disposed along with
+         * everything it held in composition state.
+         *
+         * Two instances of the same step with different addresses are **different keys**, so
+         * [com.firebase.ui.auth.ui.screens.email.navigateToEmailStep] asks "already on the stack?"
+         * of the step's *type*, not of the key.
+         */
+        @Serializable
+        sealed interface Step : Destination {
+            /** The address this step was entered with, or null. */
+            val email: String?
+
+            /** This step carrying [email] instead. */
+            fun withEmail(email: String?): Step
+        }
+
+        @Serializable
+        data class SignIn(override val email: String? = null) : Step {
+            override fun withEmail(email: String?): Step = copy(email = email)
+        }
+
+        @Serializable
+        data class SignUp(override val email: String? = null) : Step {
+            override fun withEmail(email: String?): Step = copy(email = email)
+        }
+
+        @Serializable
+        data class ResetPassword(override val email: String? = null) : Step {
+            override fun withEmail(email: String?): Step = copy(email = email)
+        }
+
+        @Serializable
+        data class EmailLinkSignIn(override val email: String? = null) : Step {
+            override fun withEmail(email: String?): Step = copy(email = email)
+        }
+
+        /** The flow's start step carrying [email]. */
+        fun startKey(email: String?): Step = SignIn(email)
+
+        internal val steps: List<Step>
+            get() = listOf(SignIn(), SignUp(), ResetPassword(), EmailLinkSignIn())
+
+        internal fun stepFor(mode: EmailAuthMode, email: String? = null): Step = when (mode) {
+            EmailAuthMode.SignIn -> SignIn(email)
+            EmailAuthMode.SignUp -> SignUp(email)
+            EmailAuthMode.ResetPassword -> ResetPassword(email)
+            EmailAuthMode.EmailLinkSignIn -> EmailLinkSignIn(email)
+        }
+
+        /** Whether [key] — a live back-stack key — belongs to this flow. */
+        internal fun isStep(key: NavKey?): Boolean = key is Step
+    }
+
+    /** Phone number verification. Starts at [EnterPhoneNumber]. */
+    object Phone : FlowEntry {
+        override fun startKey(): Destination = EnterPhoneNumber
+
+        /**
+         * One step per screen the phone flow walks through. Public API, and kept even though
+         * [com.firebase.ui.auth.ui.screens.phone.PhoneAuthScreen] drives its own step internally.
+         */
+        @Serializable
+        sealed interface Step : Destination
+
+        @Serializable
+        data object EnterPhoneNumber : Step
+
+        @Serializable
+        data object EnterVerificationCode : Step
+
+        internal val steps: List<Step>
+            get() = listOf(EnterPhoneNumber, EnterVerificationCode)
+    }
+
+    /**
+     * Second-factor enrolment. Starts at [SelectFactor], or straight at the only allowed factor's
+     * step — resolved at flow entry by
+     * [com.firebase.ui.auth.ui.screens.mfa.mfaEnrollmentStartStep].
+     */
+    object MfaEnrollment : FlowEntry {
+        override fun startKey(): Destination = SelectFactor
+
+        /**
+         * One step per screen the enrolment flow walks through. The internal
+         * `AuthRoute.MfaEnrollment.Step.enrollmentStep` extension maps a live key to the
+         * [MfaEnrollmentStep] [com.firebase.ui.auth.ui.screens.mfa.MfaEnrollmentScreen] renders.
+         */
+        @Serializable
+        sealed interface Step : Destination
+
+        @Serializable
+        data object SelectFactor : Step
+
+        @Serializable
+        data object ConfigureSms : Step
+
+        @Serializable
+        data object ConfigureTotp : Step
+
+        @Serializable
+        data object VerifyFactor : Step
+
+        internal val steps: List<Step>
+            get() = listOf(SelectFactor, ConfigureSms, ConfigureTotp, VerifyFactor)
+
+        internal fun stepFor(enrollmentStep: MfaEnrollmentStep): Step =
+            steps.first { it.enrollmentStep == enrollmentStep }
+    }
+}
+
+/** Which [EmailAuthMode] the hosted screen renders for this step. */
+internal val AuthRoute.Email.Step.mode: EmailAuthMode
+    get() = when (this) {
+        is AuthRoute.Email.SignIn -> EmailAuthMode.SignIn
+        is AuthRoute.Email.SignUp -> EmailAuthMode.SignUp
+        is AuthRoute.Email.ResetPassword -> EmailAuthMode.ResetPassword
+        is AuthRoute.Email.EmailLinkSignIn -> EmailAuthMode.EmailLinkSignIn
+    }
+
+/** Which [MfaEnrollmentStep] the hosted screen renders for this step. */
+internal val AuthRoute.MfaEnrollment.Step.enrollmentStep: MfaEnrollmentStep
+    get() = when (this) {
+        AuthRoute.MfaEnrollment.SelectFactor -> MfaEnrollmentStep.SelectFactor
+        AuthRoute.MfaEnrollment.ConfigureSms -> MfaEnrollmentStep.ConfigureSms
+        AuthRoute.MfaEnrollment.ConfigureTotp -> MfaEnrollmentStep.ConfigureTotp
+        AuthRoute.MfaEnrollment.VerifyFactor -> MfaEnrollmentStep.VerifyFactor
+    }
+
+/**
+ * Every value a caller can hand the back stack, flow entry points included. Built from the same
+ * per-flow `steps` lists the hosts register from.
+ */
+internal val allAuthRoutes: List<AuthRoute>
+    get() = listOf(AuthRoute.MethodPicker, AuthRoute.Success, AuthRoute.MfaChallenge) +
+            listOf(AuthRoute.Email) + AuthRoute.Email.steps +
+            listOf(AuthRoute.Phone) + AuthRoute.Phone.steps +
+            listOf(AuthRoute.MfaEnrollment) + AuthRoute.MfaEnrollment.steps
+
+/**
+ * Resolves [this] to the key to actually push: a [AuthRoute.FlowEntry]'s start step, or the
+ * destination itself. Every push goes through this, or it would push a key nothing registered.
+ */
+internal fun AuthRoute.toKey(): AuthRoute.Destination = when (this) {
+    is AuthRoute.FlowEntry -> startKey()
+    is AuthRoute.Destination -> this
+}
+
+/**
+ * Whether [this] — a live back-stack key, or null for an empty stack — is *at* [route], ignoring
+ * any argument the key carries.
+ *
+ * Compares runtime classes, not keys: `SignIn("bob@x.com") != SignIn(null)` as keys, but both are
+ * the same destination, which is what makes "is the flow already on its start step?" independent
+ * of what has been typed into it.
+ */
+internal fun NavKey?.isAt(route: AuthRoute): Boolean =
+    this != null && this::class == route.toKey()::class
+
+/**
+ * Sends the flow back to [route] as the only thing on the back stack: exactly one entry, and it is
+ * [route]'s resolved key, whatever the stack held before.
+ *
+ * Adds before trimming, so no single write leaves the stack empty. The pushed key is newly
+ * constructed, but a key `==` to one already on the stack keeps its saved composition state — do
+ * not rely on a reset to blank a form.
+ */
+internal fun NavBackStack<NavKey>.resetBackStackTo(route: AuthRoute) {
+    add(route.toKey())
+    while (size > 1) removeAt(0)
+}
+
+/**
+ * Pushes [route]'s key, guaranteeing it ends up on top **exactly once** — two keys that are `==`
+ * are one entry to Navigation 3, and a duplicate either crashes inside `runtime-saveable` or
+ * silently shares one instance of the screen.
+ *
+ * A push whose key is already on the stack therefore **moves** it, dropping everything that was
+ * above it: `[A,B]` push `B` → `[A,B]`, and `[A,B,C]` push `B` → `[A,B]`. Every call site relies on
+ * the target never being buried, so that trim never happens today; a new one must uphold that or
+ * accept the trim.
+ */
+internal fun NavBackStack<NavKey>.pushUnique(route: AuthRoute) {
+    val existing = indexOf(route.toKey())
+    add(route.toKey())
+    if (existing >= 0) {
+        while (size > existing + 1) removeAt(existing)
+    }
+}
+
+/**
+ * Pops one entry, unless that would empty the stack. Returns whether anything was popped. The
+ * guard is needed because `NavDisplay` throws on an empty back stack, and throws from
+ * recomposition rather than from the call that emptied it, so it cannot be caught at the call site.
+ */
+internal fun NavBackStack<NavKey>.popOrNull(): Boolean =
+    if (size > 1) {
+        removeAt(size - 1)
+        true
+    } else {
+        false
+    }
+
+/**
+ * Metadata slot the library stamps its own key into on every entry it registers, so that a
+ * [Scene] can be asked which [AuthRoute] it is showing — see [authRoute].
+ *
+ * @since 10.0.0
+ */
+object AuthRouteMetadataKey : NavMetadataKey<AuthRoute>
+
+/** Per-key metadata stamping [route] into [AuthRouteMetadataKey]. */
+internal fun authRouteMetadata(route: AuthRoute): Map<String, Any> =
+    metadata { put(AuthRouteMetadataKey, route) }
+
+/**
+ * The [AuthRoute] this [Scene] is showing, or `null` for a scene the library did not register.
+ *
+ * This is what a [com.firebase.ui.auth.configuration.AuthUITransitions] lambda reads off
+ * `initialState` / `targetState` to vary the animation per destination:
+ *
+ * ```kotlin
+ * AuthUITransitions(
+ *     transitionSpec = {
+ *         if (targetState.authRoute() is AuthRoute.Success) {
+ *             fadeIn() togetherWith fadeOut()
+ *         } else {
+ *             slideInHorizontally { it } togetherWith slideOutHorizontally { -it }
+ *         }
+ *     },
+ * )
+ * ```
+ *
+ * Read from the entry metadata the library stamps itself (see [AuthRouteMetadataKey]); prefer it
+ * over [Scene.key], which mid-transition still reports the outgoing destination. A scene showing
+ * several entries reports the topmost.
+ *
+ * @since 10.0.0
+ */
+fun Scene<NavKey>.authRoute(): AuthRoute? =
+    entries.lastOrNull()?.metadata?.get(AuthRouteMetadataKey)

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
@@ -14,12 +14,12 @@
 
 package com.firebase.ui.auth.ui.screens
 
-import android.net.Uri
 import android.util.Log
 import androidx.activity.compose.LocalActivity
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -59,10 +59,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.BuildConfig
@@ -120,6 +119,8 @@ import com.google.firebase.auth.MultiFactorResolver
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 
+private const val DEFAULT_TRANSITION_DURATION_MS = 700
+
 /**
  * High-level authentication screen that wires together provider selection, individual provider
  * flows, error handling, and multi-factor enrollment/challenge flows. Back navigation is driven by
@@ -174,7 +175,6 @@ fun FirebaseAuthScreen(
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val stringProvider = remember(context) { DefaultAuthUIStringProvider(context) }
-    val navController = rememberNavController()
 
     val observedAuthState by remember(authUI) { authUI.authStateFlow() }
         .collectAsState(initial = null as AuthState?)
@@ -183,9 +183,7 @@ fun FirebaseAuthScreen(
     val lastSuccessfulUserId = remember { mutableStateOf<String?>(null) }
     val pendingLinkingCredential = remember { mutableStateOf<AuthCredential?>(null) }
     val pendingResolver = remember { mutableStateOf<MultiFactorResolver?>(null) }
-    // Above the NavHost, so a step switch cannot dispose it.
     val mfaEnrollmentFlowState = rememberMfaEnrollmentFlowState()
-    // FirebaseAuthUI only folds ordinary states into an armed request while a drainer is present.
     DisposableEffect(authUI) {
         authUI.addReauthenticationDrainer()
         onDispose { authUI.removeReauthenticationDrainer() }
@@ -221,22 +219,20 @@ fun FirebaseAuthScreen(
             }
         }
     val reauthErrorMessage = reauthException?.let { getRecoveryMessage(it, stringProvider) }
-    // The challenge is a reauth sub-flow, not an outer-NavHost destination under the modal.
     val reauthMfa = reauthState as? AuthState.Reauthentication.RequiresMfa
     val emailLinkFromDifferentDevice = remember { mutableStateOf<String?>(null) }
-    // The address in play. Read only from callbacks, never during composition.
     val typedEmail = rememberSaveable { mutableStateOf<String?>(null) }
     val reauthPrefillEmail = remember(authUI, configuration.isReauthenticationMode) {
         if (configuration.isReauthenticationMode) authUI.auth.currentUser?.email else null
     }
     val lastSignInPreference =
         remember { mutableStateOf<SignInPreferenceManager.SignInPreference?>(null) }
-    // Lets the Idle branch below tell a genuine reset apart from consuming a notification.
     val previousAuthState = remember { mutableStateOf<AuthState?>(null) }
     val startRoute = remember(configuration.providers, configuration.isProviderChoiceAlwaysShown) {
         getStartRoute(configuration)
     }
     val skipsMethodPicker = startRoute != AuthRoute.MethodPicker
+    val backStack = rememberNavBackStack(startRoute.toKey())
 
     LaunchedEffect(authState) {
         lastSignInPreference.value = SignInPreferenceManager.getLastSignIn(context)
@@ -250,9 +246,10 @@ fun FirebaseAuthScreen(
         config = configuration,
         onNavigate = { route ->
             if (route == AuthRoute.Email) {
-                navController.navigateToEmailStep(AuthRoute.Email.SignIn, typedEmail.value)
+                backStack.navigateToEmailStep(AuthRoute.Email.SignIn(typedEmail.value))
             } else {
-                navController.navigate(route.route)
+                // pushUnique invariant: the picker is the only entry, so nothing can be buried.
+                backStack.pushUnique(route)
             }
         },
         onUnknownProvider = { provider ->
@@ -267,7 +264,6 @@ fun FirebaseAuthScreen(
         },
         onSignInFailure = onSignInFailure,
     )
-    // rememberOnProviderSelected returns a fresh lambda each time; hold it so the picker is stable.
     val currentOuterProviderSelected = rememberUpdatedState(onOuterProviderSelected)
     val currentReauthState = rememberUpdatedState(reauthState)
     val onProviderSelected: (AuthProvider) -> Unit = remember {
@@ -291,23 +287,26 @@ fun FirebaseAuthScreen(
                 .fillMaxSize()
                 .exposeTestTagsAsResourceIds()
         ) {
-            NavHost(
-                navController = navController,
-                startDestination = startRoute.routePattern,
-                enterTransition = configuration.transitions?.enterTransition ?: {
-                    fadeIn(animationSpec = tween(700))
+            NavDisplay(
+                backStack = backStack,
+                onBack = { backStack.popOrNull() },
+                transitionSpec = configuration.transitions?.transitionSpec ?: {
+                    fadeIn(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MS)) togetherWith
+                            fadeOut(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MS))
                 },
-                exitTransition = configuration.transitions?.exitTransition ?: {
-                    fadeOut(animationSpec = tween(700))
+                popTransitionSpec = configuration.transitions?.popTransitionSpec ?: {
+                    fadeIn(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MS)) togetherWith
+                            fadeOut(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MS))
                 },
-                popEnterTransition = configuration.transitions?.popEnterTransition ?: {
-                    fadeIn(animationSpec = tween(700))
-                },
-                popExitTransition = configuration.transitions?.popExitTransition ?: {
-                    fadeOut(animationSpec = tween(700))
-                }
-            ) {
-                composable(AuthRoute.MethodPicker.routePattern) {
+                predictivePopTransitionSpec =
+                    configuration.transitions?.predictivePopTransitionSpec ?: {
+                        fadeIn(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MS)) togetherWith
+                                fadeOut(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MS))
+                    },
+                entryProvider = entryProvider {
+                entry<AuthRoute.MethodPicker>(
+                    metadata = authRouteMetadata(AuthRoute.MethodPicker)
+                ) {
                     if (customMethodPickerLayout != null) {
                         Box(modifier = Modifier.fillMaxSize()) {
                             customMethodPickerLayout(configuration.providers, onProviderSelected)
@@ -338,12 +337,11 @@ fun FirebaseAuthScreen(
                 }
 
                 emailAuthDestinations(
-                    navController = navController,
+                    backStack = backStack,
                     context = context,
                     configuration = configuration,
                     authUI = authUI,
                     content = emailContent,
-                    // Only the address the library itself fixed; the user's own travels on the route.
                     prefillEmail = { reauthPrefillEmail },
                     credentialForLinking = { pendingLinkingCredential.value },
                     emailLinkFromDifferentDevice = { emailLinkFromDifferentDevice.value },
@@ -352,42 +350,37 @@ fun FirebaseAuthScreen(
                     onError = { exception -> onSignInFailure(exception) },
                     onCancel = {
                         pendingLinkingCredential.value = null
-                        if (!skipsMethodPicker && !navController.popBackStack()) {
-                            navController.navigate(AuthRoute.MethodPicker.route) {
-                                popUpTo(AuthRoute.MethodPicker.routePattern) { inclusive = true }
-                                launchSingleTop = true
-                            }
+                        if (!skipsMethodPicker && !backStack.popOrNull()) {
+                            backStack.resetBackStackTo(AuthRoute.MethodPicker)
                         }
                     },
                 )
 
-                // One destination per step so every public AuthRoute is navigable, all one screen.
-                AuthRoute.Phone.steps.forEach { step ->
-                    composable(step.routePattern) {
-                        PhoneAuthScreen(
-                            context = context,
-                            configuration = configuration,
-                            authUI = authUI,
-                            content = phoneContent,
-                            onSuccess = {},
-                            onError = { exception ->
-                                onSignInFailure(exception)
-                            },
-                            onCancel = {
-                                if (!skipsMethodPicker && !navController.popBackStack()) {
-                                    navController.navigate(AuthRoute.MethodPicker.route) {
-                                        popUpTo(AuthRoute.MethodPicker.routePattern) {
-                                            inclusive = true
-                                        }
-                                        launchSingleTop = true
-                                    }
-                                }
+                val phoneStep: @Composable () -> Unit = {
+                    PhoneAuthScreen(
+                        context = context,
+                        configuration = configuration,
+                        authUI = authUI,
+                        content = phoneContent,
+                        onSuccess = {},
+                        onError = { exception ->
+                            onSignInFailure(exception)
+                        },
+                        onCancel = {
+                            if (!skipsMethodPicker && !backStack.popOrNull()) {
+                                backStack.resetBackStackTo(AuthRoute.MethodPicker)
                             }
-                        )
-                    }
+                        }
+                    )
                 }
+                entry<AuthRoute.Phone.EnterPhoneNumber>(
+                    metadata = authRouteMetadata(AuthRoute.Phone.EnterPhoneNumber)
+                ) { phoneStep() }
+                entry<AuthRoute.Phone.EnterVerificationCode>(
+                    metadata = authRouteMetadata(AuthRoute.Phone.EnterVerificationCode)
+                ) { phoneStep() }
 
-                composable(AuthRoute.Success.routePattern) {
+                entry<AuthRoute.Success>(metadata = authRouteMetadata(AuthRoute.Success)) {
                     val uiContext = remember(authState, stringProvider) {
                         AuthSuccessUiContext(
                             authUI = authUI,
@@ -397,7 +390,6 @@ fun FirebaseAuthScreen(
                                 coroutineScope.launch {
                                     try {
                                         authUI.signOut(context)
-                                        // Keep sign-in preference for "Continue as..." on next launch
                                     } catch (e: Exception) {
                                         onSignInFailure(AuthException.from(e, stringProvider))
                                     } finally {
@@ -407,12 +399,10 @@ fun FirebaseAuthScreen(
                                 }
                             },
                             onManageMfa = {
-                                // Inert while armed: this content stays composed beneath the slot.
                                 if (reauthState == null) {
                                     if (configuration.isMfaEnabled) {
-                                        navController.navigate(
-                                            mfaEnrollmentStartStep(mfaConfiguration).route
-                                        )
+                                        // pushUnique invariant: Success is one entry — nothing to bury.
+                                        backStack.pushUnique(mfaEnrollmentStartStep(mfaConfiguration))
                                     } else {
                                         val exception = AuthException.AuthCancelledException(
                                             message = "Multi-factor authentication is disabled in the configuration. " +
@@ -451,15 +441,12 @@ fun FirebaseAuthScreen(
                                 }
                             },
                             onNavigate = { route ->
-                                // Inert while armed: this content stays composed beneath the slot.
                                 if (reauthState == null) {
-                                    // MfaEnrollment.route names SelectFactor; one factor skips it.
                                     if (route == AuthRoute.MfaEnrollment) {
-                                        navController.navigate(
-                                            mfaEnrollmentStartStep(mfaConfiguration).route
-                                        )
+                                        backStack.pushUnique(mfaEnrollmentStartStep(mfaConfiguration))
                                     } else {
-                                        navController.navigate(route.route)
+                                        // pushUnique invariant: `route` is consumer-supplied; safe only as Success is one entry.
+                                        backStack.pushUnique(route)
                                     }
                                 }
                             }
@@ -479,21 +466,22 @@ fun FirebaseAuthScreen(
                 }
 
                 mfaEnrollmentDestinations(
-                    navController = navController,
+                    backStack = backStack,
                     configuration = mfaConfiguration,
                     authConfiguration = configuration,
                     authUI = authUI,
                     flowState = mfaEnrollmentFlowState,
                     content = mfaEnrollmentContent,
-                    onComplete = { navController.exitMfaEnrollment() },
-                    onSkip = { navController.exitMfaEnrollment() },
+                    onComplete = { backStack.exitMfaEnrollment() },
+                    onSkip = { backStack.exitMfaEnrollment() },
                     onError = { exception ->
                         onSignInFailure(AuthException.from(exception, stringProvider))
                     }
                 )
 
-                composable(AuthRoute.MfaChallenge.routePattern) {
-                    // Retained for this entry: onSuccess clears pendingResolver, blanking the exit.
+                entry<AuthRoute.MfaChallenge>(
+                    metadata = authRouteMetadata(AuthRoute.MfaChallenge)
+                ) {
                     val resolver = remember { pendingResolver.value }
                     if (resolver != null) {
                         MfaChallengeScreen(
@@ -502,26 +490,26 @@ fun FirebaseAuthScreen(
                             content = mfaChallengeContent,
                             onSuccess = { result ->
                                 pendingResolver.value = null
-                                // Same path as every other provider, so onSignInSuccess sees the result.
                                 authUI.updateAuthStateWithResult(result)
                             },
+                            // Load-bearing pop: Cancelled below then sees the start step, so it skips a reset that blanks the address.
                             onCancel = {
                                 pendingResolver.value = null
                                 authUI.updateAuthState(AuthState.Cancelled)
-                                navController.popBackStack()
+                                backStack.popOrNull()
                             },
                             onError = { exception ->
                                 onSignInFailure(AuthException.from(exception, stringProvider))
                             }
                         )
                     } else {
-                        navController.popBackStack()
+                        LaunchedEffect(Unit) { backStack.popOrNull() }
                     }
                 }
-            }
+                },
+            )
 
             LaunchedEffect(emailLink) {
-                // A link arriving while armed would sign in on the non-reauth configuration.
                 if (emailLink != null && emailProvider != null && reauthState == null) {
                     try {
                         val savedEmail =
@@ -540,7 +528,7 @@ fun FirebaseAuthScreen(
                                 context = context,
                                 config = configuration,
                                 provider = emailProvider,
-                                email = "", // Empty email triggers cross-device detection
+                                email = "",
                                 emailLink = emailLink
                             )
                         }
@@ -554,10 +542,10 @@ fun FirebaseAuthScreen(
                 val state = observedAuthState ?: return@LaunchedEffect
                 val previous = previousAuthState.value
                 previousAuthState.value = state
-                val currentRoute = navController.currentBackStackEntry?.destination?.route
+                // Guards below use `isAt` (runtime class), not `==`: keys carry arguments, so `==` blanks a live form.
+                val currentKey = backStack.lastOrNull()
                 val savedPresentation = reauthPresentation.value
 
-                // A saved marker with no matching AuthState means process death lost the callback.
                 if (savedPresentation != null &&
                     state !is AuthState.Reauthentication &&
                     state !is AuthState.Aborted
@@ -589,8 +577,8 @@ fun FirebaseAuthScreen(
                             }
                         }
 
-                        if (currentRoute != AuthRoute.Success.routePattern) {
-                            navController.resetBackStackTo(AuthRoute.Success)
+                        if (currentKey != AuthRoute.Success) {
+                            backStack.resetBackStackTo(AuthRoute.Success)
                         }
                     }
 
@@ -647,7 +635,6 @@ fun FirebaseAuthScreen(
                             )
                             return@LaunchedEffect
                         }
-                        // Claimed before the first suspension point, so a recreation cannot rerun it.
                         val retry = request.claimRetryOperation()
                         if (retry == null) {
                             clearReauthPresentation()
@@ -695,7 +682,6 @@ fun FirebaseAuthScreen(
                     }
 
                     is AuthState.Reauthentication -> {
-                        // Activity recreation may resume in any in-flight reauthentication phase.
                         val currentPresentation = reauthPresentation.value
                         if (currentPresentation?.requestId != state.requestId) {
                             reauthPresentation.value = ReauthPresentationState(
@@ -710,17 +696,16 @@ fun FirebaseAuthScreen(
                         -> {
                         pendingResolver.value = null
                         pendingLinkingCredential.value = null
-                        if (currentRoute != AuthRoute.Success.routePattern) {
-                            navController.resetBackStackTo(AuthRoute.Success)
+                        if (currentKey != AuthRoute.Success) {
+                            backStack.resetBackStackTo(AuthRoute.Success)
                         }
                     }
 
                     is AuthState.RequiresMfa -> {
                         pendingResolver.value = state.resolver
-                        if (currentRoute != AuthRoute.MfaChallenge.routePattern) {
-                            navController.navigate(AuthRoute.MfaChallenge.route) {
-                                launchSingleTop = true
-                            }
+                        // pushUnique invariant: nothing is pushed on top of the challenge, so this covers the buried case.
+                        if (currentKey != AuthRoute.MfaChallenge) {
+                            backStack.pushUnique(AuthRoute.MfaChallenge)
                         }
                     }
 
@@ -729,17 +714,15 @@ fun FirebaseAuthScreen(
                         pendingResolver.value = null
                         pendingLinkingCredential.value = null
                         lastSuccessfulUserId.value = null
-                        // Left behind, it would be carried by the next session's recovery.
                         typedEmail.value = null
-                        if (currentRoute != startRoute.routePattern) {
-                            navController.resetBackStackTo(startRoute)
+                        if (!currentKey.isAt(startRoute)) {
+                            backStack.resetBackStackTo(startRoute)
                         }
                         onSignInCancelled()
                         authUI.updateAuthState(AuthState.Idle)
                     }
 
                     is AuthState.Aborted -> {
-                        // FirebaseAuthActivity's own collector already finishes and resets on Aborted.
                         if (activity !is FirebaseAuthActivity) {
                             clearReauthPresentation()
                             pendingResolver.value = null
@@ -751,15 +734,14 @@ fun FirebaseAuthScreen(
                     }
 
                     is AuthState.Idle -> {
-                        // A notification's reset to Idle is not a request to leave the current screen.
                         if (previous != null && !previous.isNotification) {
                             clearReauthPresentation()
                             pendingResolver.value = null
                             pendingLinkingCredential.value = null
                             lastSuccessfulUserId.value = null
                             typedEmail.value = null
-                            if (currentRoute != startRoute.routePattern) {
-                                navController.resetBackStackTo(startRoute)
+                            if (!currentKey.isAt(startRoute)) {
+                                backStack.resetBackStackTo(startRoute)
                             }
                         }
                     }
@@ -781,7 +763,6 @@ fun FirebaseAuthScreen(
 
                 else -> false
             }
-            // Derived from the state, not the marker: the resolver lives only in the state.
             val reauthSubRoute = if (reauthMfa != null) {
                 AuthRoute.MfaChallenge
             } else {
@@ -798,7 +779,6 @@ fun FirebaseAuthScreen(
                     val exception = reauthException ?: return@LaunchedEffect
                     dialogController.showErrorDialog(
                         exception = exception,
-                        // The latched failure is never the live Error; without this a stale dialog re-shows.
                         errorState = AuthState.Error(reauthAttemptFailure.exception),
                         onRetry = null,
                         onRecover = null,
@@ -806,31 +786,18 @@ fun FirebaseAuthScreen(
                 }
             }
 
-            /**
-             * Moves the flow to [target] unless it is already the current destination. This screen
-             * is the only place a recoverable error moves the flow; the email steps observe the
-             * same shared error event and leave it alone.
-             *
-             * Whether the recovery replaces the form that failed or pushes on top of it follows
-             * from the one rule in [NavHostController.navigateToEmailStep].
-             *
-             * @param address the address the failure itself names, when it names one. It beats
-             * [typedEmail], because a recovery can start from a provider attempt that never went
-             * through an email step at all.
-             */
             fun navigateToEmailStep(target: AuthRoute.Email.Step, address: String? = null) {
-                val currentRoute = navController.currentBackStackEntry?.destination?.route
-                if (currentRoute == target.routePattern) return
+                if (backStack.lastOrNull().isAt(target)) return
                 val carriedEmail = address?.takeIf { it.isNotEmpty() } ?: typedEmail.value
-                navController.navigateToEmailStep(target, carriedEmail)
+                backStack.navigateToEmailStep(target, carriedEmail)
             }
 
-            // The same predicate the step guards with, so a recovery cannot aim at a bounce.
-            val emailLinkRecoveryStep = if (configuration.isEmailLinkSignInOffered()) {
-                AuthRoute.Email.EmailLinkSignIn
-            } else {
-                AuthRoute.Email.SignIn
-            }
+            val emailLinkRecoveryStep: AuthRoute.Email.Step =
+                if (configuration.isEmailLinkSignInOffered()) {
+                    AuthRoute.Email.EmailLinkSignIn()
+                } else {
+                    AuthRoute.Email.SignIn()
+                }
 
             val errorState = authState as? AuthState.Error
             if (errorState != null) {
@@ -844,27 +811,25 @@ fun FirebaseAuthScreen(
                         exception = exception,
                         errorState = errorState,
                         onRetry = null,
-                        // Reauthenticating, no recovery may be offered: the dialog is dismiss-only.
                         onRecover = if (configuration.isReauthenticationMode) {
                             null
                         } else when (exception) {
-                            // Names no address, so the recovery falls back to the typed one.
                             is AuthException.UserNotFoundException -> {
                                 if (configuration.isEmailSignUpOffered()) {
-                                    { navigateToEmailStep(AuthRoute.Email.SignUp) }
+                                    { navigateToEmailStep(AuthRoute.Email.SignUp()) }
                                 } else {
                                     null
                                 }
                             }
 
                             is AuthException.EmailAlreadyInUseException -> {
-                                { navigateToEmailStep(AuthRoute.Email.SignIn, exception.email) }
+                                { navigateToEmailStep(AuthRoute.Email.SignIn(), exception.email) }
                             }
 
                             is AuthException.AccountLinkingRequiredException -> {
                                 {
                                     pendingLinkingCredential.value = exception.credential
-                                    navigateToEmailStep(AuthRoute.Email.SignIn, exception.email)
+                                    navigateToEmailStep(AuthRoute.Email.SignIn(), exception.email)
                                 }
                             }
 
@@ -901,7 +866,6 @@ fun FirebaseAuthScreen(
                         onDismiss = {
                         }
                     )
-                    // Consumed immediately so this doesn't leak to a freshly created screen.
                     authUI.updateAuthState(AuthState.Idle)
                 }
             }
@@ -921,13 +885,11 @@ fun FirebaseAuthScreen(
                 LoadingDialog(loadingMessage ?: stringProvider.progressDialogLoading)
             }
 
-            // Keyed on authUI only: onSignInCancelled is usually unremembered and would defeat it.
             val currentOnSignInCancelled = rememberUpdatedState(onSignInCancelled)
             val onReauthDismiss: () -> Unit = remember(authUI, clearReauthPresentation) {
                 {
                     clearReauthPresentation()
                     authUI.finishReauthentication(AuthState.Idle)
-                    // Abandoning reauthentication drops the pending operation for good.
                     currentOnSignInCancelled.value()
                 }
             }
@@ -946,7 +908,6 @@ fun FirebaseAuthScreen(
                 }
             val onReauthMfaError: (Exception) -> Unit = remember(authUI) {
                 { exception ->
-                    // Cleared so the failure lands on the slot, not back inside the sub-flow.
                     reauthPresentation.value = reauthPresentation.value?.copy(subRoute = null)
                     authUI.updateAuthState(AuthState.Error(exception))
                 }
@@ -965,7 +926,6 @@ fun FirebaseAuthScreen(
                         mfaChallengeContent = mfaChallengeContent,
                         mfaResolver = reauthMfa?.resolver,
                         isLoading = authState is AuthState.Reauthentication.Authenticating,
-                        // The same string ErrorRecoveryDialog would have shown for this failure.
                         error = reauthErrorMessage,
                         exception = reauthException,
                         activeSubRoute = reauthSubRoute,
@@ -1003,164 +963,12 @@ fun FirebaseAuthScreen(
 }
 
 /**
- * Name of the optional argument every [AuthRoute.Email] step carries: the address the user has
- * typed so far, which travels with the navigation — see [AuthRoute.Email.Step.withEmail].
+ * Where the flow starts, from the configuration alone: a single email or phone provider opens
+ * that flow directly, anything else opens the method picker.
+ *
+ * Returns an [AuthRoute] rather than an [AuthRoute.Destination], because a single-provider
+ * configuration names a *flow*; [toKey] is what resolves it to the step to actually push.
  */
-internal const val EMAIL_ARG = "email"
-
-/**
- * A destination the library's navigation graph can be told to go to.
- *
- * Values come in two kinds:
- *
- * * **Flow entry points** — [Email], [Phone] and [MfaEnrollment]. Naming one means "enter this
- *   flow" and resolves to that flow's start step, so callers — [getStartRoute], the method
- *   picker, [AuthSuccessUiContext.onNavigate] — never have to name a step.
- * * **Steps** — the objects nested inside each flow, one per screen the flow walks through, each
- *   with its flow's own `Step` supertype. Every one is registered on the graph, so navigating to
- *   any of them resolves and gets its own back-stack entry. Switching between [Email] steps is
- *   navigation, so it animates with the configured transitions and is undone by system back.
- *   [Phone] and [MfaEnrollment] register their steps, but their screens drive their own step
- *   internally, so every step of those flows renders the same screen as the flow's start step.
- *
- * @property route What to *navigate* with. **Not an identity:** a flow entry point shares its
- * start step's string, so two different values can report the same [route] and code must never
- * map a route string back to an `AuthRoute` by scanning for a match.
- * @property routePattern What the destination is *registered* with, and what a live
- * `NavDestination.route` (and therefore `popUpTo`) is compared against. It differs from [route]
- * only for a destination that takes arguments, which means the [Email] steps and their optional
- * `?email={email}`. Unlike [route] it does identify a destination, since the flow entry points are
- * not registered as destinations of their own.
- *
- * @since 10.0.0
- */
-sealed class AuthRoute {
-    abstract val route: String
-
-    open val routePattern: String get() = route
-
-    object MethodPicker : AuthRoute() {
-        override val route: String get() = "auth_method_picker"
-    }
-
-    object Success : AuthRoute() {
-        override val route: String get() = "auth_success"
-    }
-
-    object MfaChallenge : AuthRoute() {
-        override val route: String get() = "auth_mfa_challenge"
-    }
-
-    /** Email and password, password recovery, and email-link sign-in. Starts at [SignIn]. */
-    object Email : AuthRoute() {
-        override val route: String get() = SignIn.route
-        override val routePattern: String get() = SignIn.routePattern
-
-        /**
-         * One step per [EmailAuthMode]. Every step carries the typed address as an optional
-         * [EMAIL_ARG], which is what preserves it across a switch.
-         */
-        sealed class Step(
-            private val id: String,
-            internal val mode: EmailAuthMode,
-        ) : AuthRoute() {
-            override val route: String get() = id
-            override val routePattern: String get() = "$id?$EMAIL_ARG={$EMAIL_ARG}"
-
-            /** [route] pre-filled with [email], for `NavController.navigate`. */
-            fun withEmail(email: String?): String =
-                if (email.isNullOrEmpty()) route else "$route?$EMAIL_ARG=${Uri.encode(email)}"
-        }
-
-        object SignIn : Step("auth_email_signin", EmailAuthMode.SignIn)
-        object SignUp : Step("auth_email_signup", EmailAuthMode.SignUp)
-        object ResetPassword : Step("auth_email_reset_password", EmailAuthMode.ResetPassword)
-        object EmailLinkSignIn : Step("auth_email_link_signin", EmailAuthMode.EmailLinkSignIn)
-
-        // Computed: a stored list is built while Email is still initialising and captures nulls.
-        internal val steps: List<Step>
-            get() = listOf(SignIn, SignUp, ResetPassword, EmailLinkSignIn)
-
-        internal fun stepFor(mode: EmailAuthMode): Step = steps.first { it.mode == mode }
-
-        /** Whether [route] — a live `NavDestination.route` — belongs to this flow. */
-        internal fun isStep(route: String?): Boolean = steps.any { it.routePattern == route }
-    }
-
-    /** Phone number verification. Starts at [EnterPhoneNumber]. */
-    object Phone : AuthRoute() {
-        override val route: String get() = EnterPhoneNumber.route
-
-        /** One step per screen the phone flow walks through. */
-        sealed class Step(private val id: String) : AuthRoute() {
-            override val route: String get() = id
-        }
-
-        object EnterPhoneNumber : Step("auth_phone_number")
-
-        object EnterVerificationCode : Step("auth_phone_verification_code")
-
-        // Computed for the same reason [Email.steps] is.
-        internal val steps: List<Step>
-            get() = listOf(EnterPhoneNumber, EnterVerificationCode)
-    }
-
-    /** Second-factor enrolment. Starts at [SelectFactor]. */
-    object MfaEnrollment : AuthRoute() {
-        override val route: String get() = SelectFactor.route
-
-        /**
-         * One step per screen the enrolment flow walks through. [enrollmentStep] is the
-         * [MfaEnrollmentStep] the screen renders for this destination.
-         */
-        sealed class Step(
-            private val id: String,
-            internal val enrollmentStep: MfaEnrollmentStep,
-        ) : AuthRoute() {
-            override val route: String get() = id
-        }
-
-        object SelectFactor : Step("auth_mfa_enrollment_select_factor", MfaEnrollmentStep.SelectFactor)
-
-        object ConfigureSms : Step("auth_mfa_enrollment_configure_sms", MfaEnrollmentStep.ConfigureSms)
-
-        object ConfigureTotp : Step("auth_mfa_enrollment_configure_totp", MfaEnrollmentStep.ConfigureTotp)
-
-        object VerifyFactor : Step("auth_mfa_enrollment_verify_factor", MfaEnrollmentStep.VerifyFactor)
-
-        internal val steps: List<Step>
-            get() = listOf(SelectFactor, ConfigureSms, ConfigureTotp, VerifyFactor)
-
-        internal fun stepFor(enrollmentStep: MfaEnrollmentStep): Step =
-            steps.first { it.enrollmentStep == enrollmentStep }
-
-        /** Whether [route] — a live `NavDestination.route` — belongs to this flow. */
-        internal fun isStep(route: String?): Boolean = steps.any { it.routePattern == route }
-    }
-
-    internal companion object {
-        /** Every value a caller can hand the graph, flow entry points included. */
-        val all: List<AuthRoute>
-            get() = listOf(MethodPicker, Success, MfaChallenge) +
-                    listOf(Email) + Email.steps +
-                    listOf(Phone) + Phone.steps +
-                    listOf(MfaEnrollment) + MfaEnrollment.steps
-    }
-}
-
-/**
- * Sends the flow back to [route] as the only thing on the back stack.
- *
- * Clears the graph rather than popping up to `graph.findStartDestination()`: androidx.navigation
- * silently ignores a `popUpTo` whose target is not on the current back stack, which would leave
- * the form that had just failed underneath the new destination for system back to return to.
- */
-internal fun NavHostController.resetBackStackTo(route: AuthRoute) {
-    navigate(route.route) {
-        popUpTo(graph.id) { inclusive = true }
-    }
-}
-
 internal fun getStartRoute(configuration: AuthUIConfiguration): AuthRoute {
     if (configuration.isProviderChoiceAlwaysShown || configuration.providers.size != 1) {
         return AuthRoute.MethodPicker
@@ -1258,7 +1066,6 @@ private fun AuthSuccessContent(
                     TooltipAnchorPosition.Above
                 ),
                 tooltip = {
-                    // A popup is its own semantics owner, so it needs its own flag.
                     PlainTooltip(modifier = Modifier.exposeTestTagsAsResourceIds()) {
                         Text(stringProvider.mfaDisabledTooltip)
                     }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthDestinations.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthDestinations.kt
@@ -24,37 +24,45 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.navigation.NavGraphBuilder
-import androidx.navigation.NavHostController
-import androidx.navigation.NavType
-import androidx.navigation.compose.composable
-import androidx.navigation.navArgument
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.FirebaseAuthUI
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
 import com.firebase.ui.auth.ui.screens.AuthRoute
-import com.firebase.ui.auth.ui.screens.EMAIL_ARG
+import com.firebase.ui.auth.ui.screens.authRouteMetadata
+import com.firebase.ui.auth.ui.screens.mode
+import com.firebase.ui.auth.ui.screens.popOrNull
 import com.google.firebase.auth.AuthCredential
 import com.google.firebase.auth.AuthResult
 
 /**
- * Registers the email flow's steps on [this] graph.
+ * Registers the email flow's steps on [this] entry provider. Every host that offers email sign-in
+ * installs this same extension, so the destinations and the rules for moving between them are
+ * identical in the main [com.firebase.ui.auth.ui.screens.FirebaseAuthScreen] display and in the
+ * reauthentication sheet.
  *
  * Each step hosts an [EmailAuthScreen] pinned to its own [EmailAuthMode], turning mode switches
- * into navigation through [navigateToEmailStep]; the address travels as [EMAIL_ARG] so it survives
- * a switch. Errors are not acted on here: moving the flow on an
- * [com.firebase.ui.auth.AuthState.Error] is the host's job alone.
+ * into navigation through [navigateToEmailStep]; the address travels as a field on the key
+ * ([AuthRoute.Email.Step.email]) so it survives a switch. Errors are not acted on here — moving the
+ * flow on an [com.firebase.ui.auth.AuthState.Error] is the host's job alone.
  *
+ * [authRouteMetadata] is stamped per key rather than per type, because an email step's key carries
+ * the address.
+ *
+ * @param backStack The host's back stack, which is what a mode switch mutates.
  * @param onCancel Invoked when the flow is *left*, not when stepping between email steps.
- * @param prefillEmail The address already fixed for this flow, used to seed a step entered without
- * [EMAIL_ARG]. Read during a step's composition, so it must not be state that changes while that
- * step is on screen.
- * @param onEmailTyped Reports the address as the user edits it, so a host-driven recovery that
- * does not itself know the address can carry the live value.
+ * @param prefillEmail The address already fixed for this flow (e.g. a reauthenticating user's own),
+ * seeding a step entered with no address on its key. Must not be state that changes while a step is
+ * on screen, since it is read during that step's composition.
+ * @param onEmailTyped Reports the address as the user edits it, so a host-driven recovery that does
+ * not know the address (e.g. [com.firebase.ui.auth.AuthException.UserNotFoundException]) can carry
+ * the live value.
  */
-internal fun NavGraphBuilder.emailAuthDestinations(
-    navController: NavHostController,
+internal fun EntryProviderScope<NavKey>.emailAuthDestinations(
+    backStack: NavBackStack<NavKey>,
     context: Context,
     configuration: AuthUIConfiguration,
     authUI: FirebaseAuthUI,
@@ -67,48 +75,34 @@ internal fun NavGraphBuilder.emailAuthDestinations(
     onSuccess: (AuthResult) -> Unit = {},
     onError: (AuthException) -> Unit = {},
 ) {
-    AuthRoute.Email.steps.forEach { step ->
-        composable(
-            route = step.routePattern,
-            arguments = listOf(
-                navArgument(EMAIL_ARG) {
-                    type = NavType.StringType
-                    defaultValue = ""
-                }
-            ),
-        ) { entry ->
-            val routeEmail = entry.arguments?.getString(EMAIL_ARG).orEmpty()
-
-            if (!configuration.isEmailStepOffered(step)) {
-                // Keyed on Unit: the redirect must run at most once per back-stack entry.
-                LaunchedEffect(Unit) {
-                    // Pop first; navigating alone leaves the unreachable step for back to return to.
-                    navController.popBackStack(step.routePattern, inclusive = true)
-                    navController.navigateToEmailStep(AuthRoute.Email.SignIn, routeEmail)
-                }
-                RedirectingStep()
-                return@composable
+    val body: @Composable (AuthRoute.Email.Step) -> Unit = { step ->
+        if (!configuration.isEmailStepOffered(step)) {
+            LaunchedEffect(step) {
+                // Push before dropping: no point in this pair leaves the stack empty for a later edit to stop at.
+                backStack.navigateToEmailStep(AuthRoute.Email.SignIn(step.email))
+                backStack.remove(step)
             }
-
+            RedirectingStep()
+        } else {
             EmailAuthScreen(
                 context = context,
                 configuration = configuration,
                 authUI = authUI,
-                prefillEmail = routeEmail.ifEmpty { prefillEmail() },
+                prefillEmail = step.email?.ifEmpty { null } ?: prefillEmail(),
                 credentialForLinking = credentialForLinking(),
                 emailLinkFromDifferentDevice = emailLinkFromDifferentDevice(),
                 content = content,
                 mode = step.mode,
                 onNavigateToMode = { targetMode, email ->
-                    navController.navigateToEmailStep(AuthRoute.Email.stepFor(targetMode), email)
+                    backStack.navigateToEmailStep(AuthRoute.Email.stepFor(targetMode, email))
                 },
                 onEmailTyped = onEmailTyped,
                 onSuccess = onSuccess,
                 onError = onError,
                 onCancel = {
-                    val previous = navController.previousBackStackEntry
-                    if (previous != null && AuthRoute.Email.isStep(previous.destination.route)) {
-                        navController.popBackStack()
+                    val below = backStack.getOrNull(backStack.lastIndex - 1)
+                    if (AuthRoute.Email.isStep(below)) {
+                        backStack.popOrNull()
                     } else {
                         onCancel()
                     }
@@ -116,31 +110,44 @@ internal fun NavGraphBuilder.emailAuthDestinations(
             )
         }
     }
+
+    entry<AuthRoute.Email.SignIn>(metadata = { authRouteMetadata(it) }) { body(it) }
+    entry<AuthRoute.Email.SignUp>(metadata = { authRouteMetadata(it) }) { body(it) }
+    entry<AuthRoute.Email.ResetPassword>(metadata = { authRouteMetadata(it) }) { body(it) }
+    entry<AuthRoute.Email.EmailLinkSignIn>(metadata = { authRouteMetadata(it) }) { body(it) }
 }
 
 /**
- * Moves the flow to [step], carrying [email] so the typed address survives the step being left.
+ * Moves the flow to [step], carrying the address on the key so the typed value survives the step
+ * being left disposing whatever it held.
  *
- * Pops any existing entry for [step], then pushes a fresh one:
+ * Drops any existing entry *of the same step type* — and everything above it — then leaves a fresh
+ * one on top. So a step already on the stack is replaced, and one that is not is pushed, leaving
+ * the origin reachable. The fresh entry means the address just typed wins over the stale one the
+ * old entry held.
  *
- * * **Already on the stack — replaces.** Toggling sign-in ↔ sign-up cannot grow the stack, and a
- *   recovery removes the form that just failed rather than leaving it for back to return to.
- * * **Not on the stack — pushes.** The origin stays reachable.
- *
- * Pushing rather than only popping means the address just typed wins over the stale one the old
- * entry held, and saved state is not restored, so a mode switch's password clear survives. System
- * back is the one case that does restore it.
- *
- * The push always leaves an entry for [step], so the graph's start destination can never be popped
- * out from under it.
+ * Adds before removing, so no single write leaves the stack empty. Compares the step's *type*, not
+ * the key: a key carries the address, so `SignIn("a@b")` and `SignIn("c@d")` are different keys.
  */
-internal fun NavHostController.navigateToEmailStep(step: AuthRoute.Email.Step, email: String?) {
-    navigate(step.withEmail(email)) {
-        popUpTo(step.routePattern) { inclusive = true }
+internal fun NavBackStack<NavKey>.navigateToEmailStep(step: AuthRoute.Email.Step) {
+    val existing = indexOfFirst { it::class == step::class }
+    add(step)
+    if (existing >= 0) {
+        // Drops the old entry and all above it, stopping below the one just pushed, so a buried step is reached.
+        while (size > existing + 1) removeAt(existing)
     }
 }
 
-/** Shown for as long as a redirect off a step that cannot render itself takes. */
+/** Overload for callers that name the step and the address separately. */
+internal fun NavBackStack<NavKey>.navigateToEmailStep(
+    step: AuthRoute.Email.Step,
+    email: String?,
+) = navigateToEmailStep(step.withEmail(email))
+
+/**
+ * Shown for as long as a redirect off a step that cannot render itself takes. Rendering nothing
+ * leaves a hole on screen for the whole of the configured cross-fade, not for a single frame.
+ */
 @Composable
 internal fun RedirectingStep() {
     Box(
@@ -153,17 +160,22 @@ internal fun RedirectingStep() {
     }
 }
 
-/** Whether [step] is reachable at all in this configuration. */
+/**
+ * Whether [step] is reachable at all in this configuration. Asked of every step rather than only
+ * sign-up, because `AuthSuccessUiContext.onNavigate` accepts any
+ * [com.firebase.ui.auth.ui.screens.AuthRoute].
+ */
 internal fun AuthUIConfiguration.isEmailStepOffered(step: AuthRoute.Email.Step): Boolean =
     when (step) {
-        AuthRoute.Email.SignUp -> isEmailSignUpOffered()
-        AuthRoute.Email.EmailLinkSignIn -> isEmailLinkSignInOffered()
-        AuthRoute.Email.SignIn, AuthRoute.Email.ResetPassword -> true
+        is AuthRoute.Email.SignUp -> isEmailSignUpOffered()
+        is AuthRoute.Email.EmailLinkSignIn -> isEmailLinkSignInOffered()
+        is AuthRoute.Email.SignIn, is AuthRoute.Email.ResetPassword -> true
     }
 
 /**
- * Whether the email flow may offer account creation. False while reauthenticating, and whenever
- * the configuration or the email provider itself disables new accounts.
+ * Whether the email flow may offer account creation. False while reauthenticating — proving an
+ * existing identity can never end in a new account — and whenever the configuration or the email
+ * provider itself disables new accounts.
  */
 internal fun AuthUIConfiguration.isEmailSignUpOffered(): Boolean {
     if (isReauthenticationMode || !isNewEmailAccountsAllowed) return false
@@ -174,7 +186,8 @@ internal fun AuthUIConfiguration.isEmailSignUpOffered(): Boolean {
 
 /**
  * Whether the email flow may offer email-link sign-in. False while reauthenticating: a link
- * reopens the app with nothing armed, so completing one there reports an interruption.
+ * reopens the app with nothing armed, so completing one there reports an interruption instead of
+ * finishing the pending operation.
  */
 internal fun AuthUIConfiguration.isEmailLinkSignInOffered(): Boolean {
     if (isReauthenticationMode) return false

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentDestinations.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentDestinations.kt
@@ -22,9 +22,9 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.navigation.NavGraphBuilder
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.composable
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
 import com.firebase.ui.auth.FirebaseAuthUI
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.configuration.MfaConfiguration
@@ -37,28 +37,30 @@ import com.firebase.ui.auth.mfa.SmsEnrollmentSession
 import com.firebase.ui.auth.mfa.SmsEnrollmentSessionSaver
 import com.firebase.ui.auth.mfa.TotpSecret
 import com.firebase.ui.auth.ui.screens.AuthRoute
+import com.firebase.ui.auth.ui.screens.authRouteMetadata
 import com.firebase.ui.auth.ui.screens.email.RedirectingStep
+import com.firebase.ui.auth.ui.screens.enrollmentStep
+import com.firebase.ui.auth.ui.screens.popOrNull
+import com.firebase.ui.auth.ui.screens.pushUnique
 import com.firebase.ui.auth.ui.screens.resetBackStackTo
 import com.firebase.ui.auth.util.CountryUtils
 
 /**
  * Everything an [MfaEnrollmentScreen] step needs that must outlive the step being left.
  *
- * Remembered by the host *above* the [androidx.navigation.compose.NavHost] and handed to every
- * step through [mfaEnrollmentDestinations], so a step reads and writes this instead of its own
- * local state and the data is still there when the flow returns to it.
+ * Moving between steps disposes whatever the step being left held in composition, which would
+ * otherwise take the typed phone number and the fetched TOTP secret with it. Remembered by the host
+ * *above* the [androidx.navigation3.ui.NavDisplay] and handed to every step through
+ * [mfaEnrollmentDestinations], this is what a step reads and writes instead of its own local state.
  *
  * [selectedFactor], [phoneNumber], [verificationCode], [resendTimerSeconds], [smsSession] and
  * [selectedCountry] are backed by [rememberSaveable] in [rememberMfaEnrollmentFlowState] and
- * survive Activity recreation. [totpSecret], [totpQrCodeUrl] and [totpSecretExpiredMessage] are
- * backed by plain [remember] and are lost: [TotpSecret] wraps `com.google.firebase.auth.TotpSecret`,
- * an interface with no public reconstruction API, so there is no `Saver` to write for it.
- *
- * That loss is recovered rather than fatal: [MfaEnrollmentScreen]'s `LaunchedEffect(currentStep)`
- * fetches a fresh secret when [totpSecret] is null on [MfaEnrollmentStep.ConfigureTotp], and
- * bounces back to `ConfigureTotp` with [totpSecretExpiredMessage] set when the user was already
- * past it. A new secret means a new QR code, so this is a user-visible re-scan, not a seamless
- * recovery.
+ * survive Activity recreation. [totpSecret] and [totpQrCodeUrl] do not — they are backed by plain
+ * [remember], since `com.google.firebase.auth.TotpSecret` cannot be reconstructed. That loss is
+ * recovered: [MfaEnrollmentScreen] detects a null [totpSecret] on [MfaEnrollmentStep.ConfigureTotp]
+ * or [MfaEnrollmentStep.VerifyFactor] and fetches a fresh one, bouncing back to `ConfigureTotp`
+ * with [totpSecretExpiredMessage] set when the user was already past it, since a new secret means a
+ * new QR code to scan.
  *
  * @since 10.0.0
  */
@@ -76,8 +78,8 @@ class MfaEnrollmentFlowState internal constructor(
 
 /**
  * Creates and remembers the [MfaEnrollmentFlowState] a host installs [mfaEnrollmentDestinations]
- * with. Call once, above the `NavHost`, so the same instance is handed to every step — see
- * [MfaEnrollmentFlowState] for which of its fields survive Activity recreation.
+ * with. Called once, above the `NavDisplay`, so the same instance is handed to every step — see
+ * [MfaEnrollmentFlowState] for which of its fields actually survive Activity recreation.
  */
 @Composable
 fun rememberMfaEnrollmentFlowState(): MfaEnrollmentFlowState {
@@ -112,16 +114,16 @@ fun rememberMfaEnrollmentFlowState(): MfaEnrollmentFlowState {
 /**
  * Registers the MFA enrolment flow's steps on [this] graph.
  *
- * Every move between steps **pushes**; this flow never replaces a destination. No enrolment or
- * verification failure moves the user off the step they are on — each sets
- * [MfaEnrollmentContentState.error] and stays put.
+ * Every move between steps **pushes**; there is no destination this flow ever *replaces* another
+ * with. No enrolment or verification failure here moves the user off the step they are on — every
+ * one sets [MfaEnrollmentContentState.error] and stays put.
  *
  * @param flowState The state that must outlive a step switch — see [MfaEnrollmentFlowState].
  * Shared by every step this registers, and expected to be `remember`-ed by the host once, above
- * the `NavHost`.
+ * the `NavDisplay`.
  */
-internal fun NavGraphBuilder.mfaEnrollmentDestinations(
-    navController: NavHostController,
+internal fun EntryProviderScope<NavKey>.mfaEnrollmentDestinations(
+    backStack: NavBackStack<NavKey>,
     configuration: MfaConfiguration,
     authConfiguration: AuthUIConfiguration?,
     authUI: FirebaseAuthUI,
@@ -131,17 +133,9 @@ internal fun NavGraphBuilder.mfaEnrollmentDestinations(
     onSkip: () -> Unit = {},
     onError: (Exception) -> Unit = {},
 ) {
-    AuthRoute.MfaEnrollment.steps.forEach { step ->
-        composable(route = step.routePattern) {
-            val user = authUI.getCurrentUser()
-            if (user == null) {
-                // Every step is registered, so one reached with no signed-in user leaves the flow.
-                // An effect, since leaving mutates the back stack; Unit runs it once per entry.
-                LaunchedEffect(Unit) { navController.exitMfaEnrollment() }
-                RedirectingStep()
-                return@composable
-            }
-
+    val body: @Composable (AuthRoute.MfaEnrollment.Step) -> Unit = { step ->
+        val user = authUI.getCurrentUser()
+        if (user != null) {
             MfaEnrollmentScreen(
                 user = user,
                 auth = authUI.auth,
@@ -150,45 +144,70 @@ internal fun NavGraphBuilder.mfaEnrollmentDestinations(
                 content = content,
                 step = step.enrollmentStep,
                 onNavigateToStep = { target ->
-                    navController.navigateToMfaStep(AuthRoute.MfaEnrollment.stepFor(target))
+                    backStack.navigateToMfaStep(AuthRoute.MfaEnrollment.stepFor(target))
                 },
-                onNavigateBack = { navController.popBackStack() },
+                onNavigateBack = { backStack.popOrNull() },
                 flowState = flowState,
                 onComplete = onComplete,
                 onSkip = onSkip,
                 onError = onError,
             )
+        } else {
+            // A single pop here cascades: the step below composes with a null user and pops again.
+            LaunchedEffect(Unit) { backStack.exitMfaEnrollment() }
+            RedirectingStep()
         }
     }
-}
 
-/** Pushes [step] onto the back stack. Always a push, never a pop-then-push. */
-internal fun NavHostController.navigateToMfaStep(step: AuthRoute.MfaEnrollment.Step) {
-    navigate(step.route)
+    entry<AuthRoute.MfaEnrollment.SelectFactor>(
+        metadata = authRouteMetadata(AuthRoute.MfaEnrollment.SelectFactor)
+    ) { body(it) }
+    entry<AuthRoute.MfaEnrollment.ConfigureSms>(
+        metadata = authRouteMetadata(AuthRoute.MfaEnrollment.ConfigureSms)
+    ) { body(it) }
+    entry<AuthRoute.MfaEnrollment.ConfigureTotp>(
+        metadata = authRouteMetadata(AuthRoute.MfaEnrollment.ConfigureTotp)
+    ) { body(it) }
+    entry<AuthRoute.MfaEnrollment.VerifyFactor>(
+        metadata = authRouteMetadata(AuthRoute.MfaEnrollment.VerifyFactor)
+    ) { body(it) }
 }
 
 /**
- * Leaves the MFA enrolment flow, popping a step at a time until the top of the back stack is not
- * one.
+ * Pushes [step] onto the back stack. Always a push, never a pop-then-push.
  *
- * Pops nothing when the flow is already left, so exiting twice leaves what is underneath — and
- * its entry-scoped state — untouched. Resets to [AuthRoute.Success] only when the flow was the
- * entire back stack and popping it emptied the stack.
+ * Upholds [pushUnique]'s precondition: this flow only ever moves *forward* through here —
+ * `SelectFactor` → a `Configure…` step → `VerifyFactor` — and every backward move goes through
+ * [popOrNull] instead, so a step this pushes is never already buried. A step that could be
+ * re-entered from above would take [pushUnique]'s buried-case trim.
  */
-internal fun NavHostController.exitMfaEnrollment() {
-    var onStep = AuthRoute.MfaEnrollment.isStep(currentDestination?.route)
-    while (onStep && popBackStack()) {
-        onStep = AuthRoute.MfaEnrollment.isStep(currentDestination?.route)
+internal fun NavBackStack<NavKey>.navigateToMfaStep(step: AuthRoute.MfaEnrollment.Step) {
+    pushUnique(step)
+}
+
+/**
+ * Leaves the MFA enrolment flow from whatever depth it reached, in one write: truncates to the
+ * lowest step on the stack rather than popping repeatedly, so it does not matter how deep the flow
+ * went, which step it started on, or whether it was entered more than once.
+ *
+ * A no-op when no step is on the stack, so leaving twice cannot disturb what is underneath. Resets
+ * to [AuthRoute.Success] when the flow is the whole stack — `NavDisplay` throws on an empty one.
+ */
+internal fun NavBackStack<NavKey>.exitMfaEnrollment() {
+    val lowestStep = indexOfFirst { it is AuthRoute.MfaEnrollment.Step }
+    when {
+        lowestStep < 0 -> return
+        lowestStep == 0 -> resetBackStackTo(AuthRoute.Success)
+        else -> while (size > lowestStep) removeAt(size - 1)
     }
-    if (onStep) resetBackStackTo(AuthRoute.Success)
 }
 
 /**
  * Where entering the MFA enrolment flow should land, resolved once at flow entry.
  *
  * A configuration offering exactly one factor has nothing to choose, so the flow starts on that
- * factor's own configuration step directly, never visiting
- * [AuthRoute.MfaEnrollment.SelectFactor].
+ * factor's own configuration step directly. [MfaEnrollmentScreen] still fetches the TOTP secret the
+ * first time [AuthRoute.MfaEnrollment.ConfigureTotp] is entered, whichever way it was reached.
  */
 internal fun mfaEnrollmentStartStep(configuration: MfaConfiguration): AuthRoute.MfaEnrollment.Step {
     return when (configuration.allowedFactors.singleOrNull()) {

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/reauth/CustomReauthContent.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/reauth/CustomReauthContent.kt
@@ -183,7 +183,7 @@ internal fun CustomReauthContent(
             LaunchedEffect(subRoute) {
                 Log.w(
                     "FirebaseAuthScreen",
-                    "No reauth sub-flow for ${subRoute.route}; staying on the slot"
+                    "No reauth sub-flow for $subRoute; staying on the slot"
                 )
                 onActiveSubRouteChange(null)
             }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/reauth/ReauthSheetContent.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/reauth/ReauthSheetContent.kt
@@ -17,6 +17,7 @@ package com.firebase.ui.auth.ui.screens.reauth
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -26,9 +27,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
 import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.FirebaseAuthUI
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
@@ -37,12 +39,17 @@ import com.firebase.ui.auth.mfa.MfaChallengeContentState
 import com.firebase.ui.auth.ui.exposeTestTagsAsResourceIds
 import com.firebase.ui.auth.ui.method_picker.AuthMethodPicker
 import com.firebase.ui.auth.ui.screens.AuthRoute
+import com.firebase.ui.auth.ui.screens.authRouteMetadata
 import com.firebase.ui.auth.ui.screens.email.EmailAuthContentState
 import com.firebase.ui.auth.ui.screens.email.emailAuthDestinations
 import com.firebase.ui.auth.ui.screens.getStartRoute
 import com.firebase.ui.auth.ui.screens.mfa.MfaChallengeScreen
 import com.firebase.ui.auth.ui.screens.phone.PhoneAuthContentState
+import com.firebase.ui.auth.ui.screens.popOrNull
+import com.firebase.ui.auth.ui.screens.pushUnique
 import com.firebase.ui.auth.ui.screens.rememberOnProviderSelected
+import com.firebase.ui.auth.ui.screens.resetBackStackTo
+import com.firebase.ui.auth.ui.screens.toKey
 import com.google.firebase.auth.MultiFactorResolver
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -61,107 +68,123 @@ internal fun ReauthSheetContent(
     customMethodPickerLayout: (@Composable (List<AuthProvider>, (AuthProvider) -> Unit) -> Unit)?,
     onDismiss: () -> Unit,
 ) {
-    val sheetNavController = rememberNavController()
     val startRoute = remember(reauthConfig) { getStartRoute(reauthConfig) }
     val skipsMethodPicker = startRoute != AuthRoute.MethodPicker
+    val sheetBackStack = rememberNavBackStack(startRoute.toKey())
     val onProviderSelected = authUI.rememberOnProviderSelected(
         context = context,
         activity = activity,
         config = reauthConfig,
-        onNavigate = { route -> sheetNavController.navigate(route.route) },
+        // pushUnique invariant: the picker is this stack's only entry, so nothing can be buried.
+        onNavigate = { route -> sheetBackStack.pushUnique(route) },
     )
     val returnToProviderSelection: () -> Unit = {
-        sheetNavController.navigate(startRoute.route) {
-            // popUpTo matches a registered destination, so it takes the pattern, not the route.
-            popUpTo(startRoute.routePattern) { inclusive = true }
-            launchSingleTop = true
-        }
+        sheetBackStack.resetBackStackTo(startRoute)
     }
-    // Must be the sheet's own NavHost: on the outer one the challenge renders under this modal.
     LaunchedEffect(mfaResolver) {
-        if (mfaResolver != null) {
-            sheetNavController.navigate(AuthRoute.MfaChallenge.route) { launchSingleTop = true }
+        // pushUnique invariant: nothing is pushed on top of the challenge here either.
+        if (mfaResolver != null && sheetBackStack.lastOrNull() != AuthRoute.MfaChallenge) {
+            sheetBackStack.pushUnique(AuthRoute.MfaChallenge)
         }
     }
 
-    NavHost(
-        navController = sheetNavController,
-        startDestination = startRoute.routePattern,
-        enterTransition = { fadeIn(animationSpec = tween(700)) },
-        exitTransition = { fadeOut(animationSpec = tween(700)) },
-        popEnterTransition = { fadeIn(animationSpec = tween(700)) },
-        popExitTransition = { fadeOut(animationSpec = tween(700)) },
-    ) {
-        composable(AuthRoute.MethodPicker.routePattern) {
-            if (customMethodPickerLayout != null) {
-                Box(modifier = Modifier.fillMaxSize()) {
-                    customMethodPickerLayout(reauthConfig.providers, onProviderSelected)
-                }
-            } else {
-                Scaffold(modifier = Modifier.exposeTestTagsAsResourceIds()) { innerPadding ->
-                    AuthMethodPicker(
-                        modifier = Modifier.padding(innerPadding),
-                        providers = reauthConfig.providers,
-                        onProviderSelected = onProviderSelected,
-                    )
-                }
-            }
+    /**
+     * Leaving an email or phone sub-flow that has nothing left underneath it.
+     *
+     * The size test sits *above* the branch, and the dismissing branch never pops at all: on this
+     * surface an exhausted stack means the sheet should stop existing, and `NavDisplay` keeps
+     * composing until the dismiss animation finishes, so a list emptied on the way out would throw
+     * during that window.
+     */
+    val leaveOrCancel: () -> Unit = {
+        if (skipsMethodPicker || sheetBackStack.size <= 1) {
+            onDismiss()
+        } else {
+            sheetBackStack.popOrNull()
+            authUI.updateReauthentication(requestId) { it.attemptCancelled() }
         }
+    }
 
-        emailAuthDestinations(
-            navController = sheetNavController,
+    val phoneStep: @Composable () -> Unit = {
+        com.firebase.ui.auth.ui.screens.phone.PhoneAuthScreen(
             context = context,
             configuration = reauthConfig,
             authUI = authUI,
-            content = emailContent,
-            prefillEmail = { prefillEmail },
-            onCancel = {
-                if (skipsMethodPicker || !sheetNavController.popBackStack()) {
-                    onDismiss()
-                } else {
-                    authUI.updateReauthentication(requestId) { it.attemptCancelled() }
-                }
-            },
+            content = phoneContent,
+            onSuccess = {},
+            onError = {},
+            onCancel = leaveOrCancel,
         )
-
-        // Every phone step, as on the main graph; registering only the start step strands the rest.
-        AuthRoute.Phone.steps.forEach { step ->
-            composable(step.routePattern) {
-                com.firebase.ui.auth.ui.screens.phone.PhoneAuthScreen(
-                    context = context,
-                    configuration = reauthConfig,
-                    authUI = authUI,
-                    content = phoneContent,
-                    onSuccess = {},
-                    onError = {},
-                    onCancel = {
-                        if (skipsMethodPicker || !sheetNavController.popBackStack()) {
-                            onDismiss()
-                        } else {
-                            authUI.updateReauthentication(requestId) { it.attemptCancelled() }
-                        }
-                    }
-                )
-            }
-        }
-
-        composable(AuthRoute.MfaChallenge.routePattern) {
-            if (mfaResolver != null) {
-                MfaChallengeScreen(
-                    resolver = mfaResolver,
-                    auth = authUI.auth,
-                    content = mfaChallengeContent,
-                    onSuccess = { authUI.publishReauthenticationSuccess() },
-                    onCancel = {
-                        returnToProviderSelection()
-                        authUI.updateReauthentication(requestId) { it.attemptCancelled() }
-                    },
-                    onError = { exception ->
-                        returnToProviderSelection()
-                        authUI.updateAuthState(AuthState.Error(exception))
-                    },
-                )
-            }
-        }
     }
+
+    NavDisplay(
+        backStack = sheetBackStack,
+        onBack = { sheetBackStack.popOrNull() },
+        transitionSpec = {
+            fadeIn(animationSpec = tween(700)) togetherWith fadeOut(animationSpec = tween(700))
+        },
+        popTransitionSpec = {
+            fadeIn(animationSpec = tween(700)) togetherWith fadeOut(animationSpec = tween(700))
+        },
+        predictivePopTransitionSpec = {
+            fadeIn(animationSpec = tween(700)) togetherWith fadeOut(animationSpec = tween(700))
+        },
+        entryProvider = entryProvider {
+            entry<AuthRoute.MethodPicker>(
+                metadata = authRouteMetadata(AuthRoute.MethodPicker)
+            ) {
+                if (customMethodPickerLayout != null) {
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        customMethodPickerLayout(reauthConfig.providers, onProviderSelected)
+                    }
+                } else {
+                    Scaffold(modifier = Modifier.exposeTestTagsAsResourceIds()) { innerPadding ->
+                        AuthMethodPicker(
+                            modifier = Modifier.padding(innerPadding),
+                            providers = reauthConfig.providers,
+                            onProviderSelected = onProviderSelected,
+                        )
+                    }
+                }
+            }
+
+            emailAuthDestinations(
+                backStack = sheetBackStack,
+                context = context,
+                configuration = reauthConfig,
+                authUI = authUI,
+                content = emailContent,
+                prefillEmail = { prefillEmail },
+                onCancel = leaveOrCancel,
+            )
+
+            entry<AuthRoute.Phone.EnterPhoneNumber>(
+                metadata = authRouteMetadata(AuthRoute.Phone.EnterPhoneNumber)
+            ) { phoneStep() }
+            entry<AuthRoute.Phone.EnterVerificationCode>(
+                metadata = authRouteMetadata(AuthRoute.Phone.EnterVerificationCode)
+            ) { phoneStep() }
+
+            entry<AuthRoute.MfaChallenge>(
+                metadata = authRouteMetadata(AuthRoute.MfaChallenge)
+            ) {
+                if (mfaResolver != null) {
+                    MfaChallengeScreen(
+                        resolver = mfaResolver,
+                        auth = authUI.auth,
+                        content = mfaChallengeContent,
+                        onSuccess = { authUI.publishReauthenticationSuccess() },
+                        onCancel = {
+                            returnToProviderSelection()
+                            authUI.updateReauthentication(requestId) { it.attemptCancelled() }
+                        },
+                        onError = { exception ->
+                            returnToProviderSelection()
+                            authUI.updateAuthState(AuthState.Error(exception))
+                        },
+                    )
+                }
+            }
+        },
+    )
 }

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenEmailRecoveryTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenEmailRecoveryTest.kt
@@ -32,7 +32,9 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
-import androidx.navigation.NavBackStackEntry
+import androidx.compose.animation.togetherWith
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.scene.Scene
 import androidx.test.core.app.ApplicationProvider
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
@@ -42,6 +44,7 @@ import com.firebase.ui.auth.configuration.AuthUITransitions
 import com.firebase.ui.auth.configuration.authUIConfiguration
 import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
 import com.firebase.ui.auth.configuration.string_provider.DefaultAuthUIStringProvider
+import com.firebase.ui.auth.mfa.MfaChallengeContentState
 import com.firebase.ui.auth.ui.FirebaseAuthTestTags
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.FirebaseApp
@@ -50,6 +53,10 @@ import com.google.firebase.auth.ActionCodeSettings
 import com.google.firebase.auth.EmailAuthProvider
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.MultiFactorInfo
+import com.google.firebase.auth.MultiFactorResolver
+import com.google.firebase.auth.MultiFactorSession
+import com.google.firebase.auth.TotpMultiFactorInfo
 import com.google.firebase.auth.UserInfo
 import org.junit.After
 import org.junit.Before
@@ -62,13 +69,14 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /**
- * [FirebaseAuthScreen] is the single owner of the navigation an error recovery performs; the email
- * steps observe the same [AuthState.Error] and leave it alone.
+ * [FirebaseAuthScreen] is the single owner of the navigation an error recovery performs: the email
+ * steps observe the same [AuthState.Error] but deliberately leave it alone, so what the user is
+ * offered cannot depend on which of the two composed first.
  *
- * Every test here runs on the email-only configuration, where the flow's sign-in step is the
- * graph's start destination. That is the shape the back-stack hazards live in: a recovery that
- * destroyed the start entry makes every later reset silently do nothing, because
- * androidx.navigation ignores a `popUpTo` whose target is not on the stack.
+ * Every test here runs on the **email-only** configuration, where the flow's sign-in step *is* the
+ * graph's start destination. That is the shape the back-stack hazards live in: if a recovery that
+ * destroyed the start entry could make a later reset — success, cancellation, a genuine idle — do
+ * nothing, system back would return a signed-in user to the form they had just left.
  *
  * @suppress Internal test class
  */
@@ -86,6 +94,7 @@ class FirebaseAuthScreenEmailRecoveryTest {
 
     private var pressBack: (() -> Unit)? = null
     private var lastUiContext: AuthSuccessUiContext? = null
+    private var challengeState: MfaChallengeContentState? = null
 
     @Before
     fun setUp() {
@@ -112,6 +121,7 @@ class FirebaseAuthScreenEmailRecoveryTest {
     fun tearDown() {
         pressBack = null
         lastUiContext = null
+        challengeState = null
         FirebaseAuthUI.clearInstanceCache()
         FirebaseApp.getApps(applicationContext).forEach {
             try {
@@ -121,7 +131,9 @@ class FirebaseAuthScreenEmailRecoveryTest {
         }
     }
 
+    // =============================================================================================
     // Recovery moves the flow, and only from here
+    // =============================================================================================
 
     @Test
     fun `no account for the address recovers to sign-up and keeps what was typed`() {
@@ -135,8 +147,13 @@ class FirebaseAuthScreenEmailRecoveryTest {
     }
 
     /**
-     * A recovery pushes when the step it starts from stays useful: "no account for this address"
-     * leaves the sign-in form underneath, address intact, as where a mistyped one gets fixed.
+     * One half of the rule the two recoveries deliberately split on: a recovery **pushes** when the
+     * step it starts from stays useful. "There is no account for this address" leaves the sign-in
+     * form as exactly where a mistyped address gets fixed, so it stays underneath and back returns
+     * to it — with the address intact, which is what carrying it in the route buys.
+     *
+     * The other half is `an address already in use recovers to the sign-in step`. Both fall out of
+     * the single rule in `navigateToEmailStep`; neither is a special case there.
      */
     @Test
     fun `back from the recovery target returns to the sign-in step`() {
@@ -151,9 +168,9 @@ class FirebaseAuthScreenEmailRecoveryTest {
     }
 
     /**
-     * A recovery must not pop the graph's start destination: the later reset's
-     * `popUpTo(startDestination)` would then match nothing and leave the form under the success
-     * screen for back to return to.
+     * The regression this whole file exists for: a recovery pops the graph's start destination, so
+     * a reset that keyed off that entry would leave the success screen sitting *on top of* the
+     * sign-up form instead of replacing it, and back would hand a signed-in user the form again.
      */
     @Test
     fun `back after a success cannot return to the form recovery moved to`() {
@@ -196,8 +213,10 @@ class FirebaseAuthScreenEmailRecoveryTest {
     }
 
     /**
-     * A recovery replaces when the step it starts from is a dead end: an address that already has
-     * an account makes the sign-up form useless, so the move pops back rather than burying it.
+     * The other half of the rule: a recovery **replaces** when the step it starts from is a dead
+     * end. An address that already has an account makes the sign-up form useless, so returning to
+     * it would be returning to a form that cannot succeed — sign-in is already beneath it, and the
+     * move pops back to it rather than burying it.
      */
     @Test
     fun `an address already in use recovers to the sign-in step`() {
@@ -213,10 +232,112 @@ class FirebaseAuthScreenEmailRecoveryTest {
         )
 
         composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
-        // The dead-end form is gone rather than buried.
+        // The dead-end form is gone rather than buried, so back has nothing inside the flow left
+        // to return to.
         back()
         composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
         composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.EMAIL_FIELD).assertDoesNotExist()
+    }
+
+    /**
+     * The reset guards ask "is the flow already at its start step?", and that question has to
+     * ignore the address the key carries. A key comparison — `currentKey != startRoute.toKey()` —
+     * would be strictly finer: `SignIn("user+tag@example.com") != SignIn(null)`. The guard would
+     * *fire*, the reset would push a differently-keyed entry, the `SaveableStateHolder` would have
+     * no state for it, and the address the user is looking at would vanish.
+     *
+     * That is the exact stack this test builds. `an address already in use recovers to the sign-in
+     * step` leaves the stack at `[SignIn(TYPED_EMAIL)]` — one entry, carrying an address, and the
+     * start step. A cancellation arriving there must change nothing.
+     */
+    @Test
+    fun `a cancellation on the start step keeps the address the recovery carried`() {
+        start()
+        typeSignInEmail()
+        goToSignUp()
+        recoverFrom(
+            AuthException.EmailAlreadyInUseException(
+                message = "already in use",
+                email = TYPED_EMAIL,
+            )
+        )
+        composeTestRule.onNodeWithText(TYPED_EMAIL).assertIsDisplayed()
+
+        // Cancelled, and then the Idle the Cancelled branch itself publishes — both guards.
+        composeTestRule.runOnIdle { authUI.updateAuthState(AuthState.Cancelled) }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+        composeTestRule.onNodeWithText(TYPED_EMAIL).assertIsDisplayed()
+    }
+
+    /**
+     * The same stack, reached the way a user actually reaches it: not by publishing
+     * [AuthState.Cancelled] directly, but by the MFA challenge being raised on top of the recovered
+     * sign-in step and then cancelled.
+     *
+     * This is what makes the `popOrNull()` in the challenge's `onCancel` load-bearing. The pop is
+     * synchronous inside the click handler and the `LaunchedEffect(observedAuthState)` collector
+     * runs a frame later, so by the time the `Cancelled` branch reads the top of the stack it sees
+     * `SignIn(TYPED_EMAIL)` — the start step — and skips its reset. Without the pop it sees
+     * [AuthRoute.MfaChallenge], which is never a start step, so the reset always fires and pushes a
+     * differently-keyed `SignIn(null)`; the old entry leaves the stack, the `SaveableStateHolder`
+     * drops its state, and the address the recovery carried disappears.
+     */
+    @Test
+    fun `cancelling an MFA challenge keeps the address the recovery carried`() {
+        start()
+        typeSignInEmail()
+        goToSignUp()
+        recoverFrom(
+            AuthException.EmailAlreadyInUseException(
+                message = "already in use",
+                email = TYPED_EMAIL,
+            )
+        )
+        composeTestRule.onNodeWithText(TYPED_EMAIL).assertIsDisplayed()
+
+        composeTestRule.runOnIdle { authUI.updateAuthState(AuthState.RequiresMfa(mfaResolver())) }
+        composeTestRule.waitForIdle()
+        val challenge = requireNotNull(composeTestRule.runOnIdle { challengeState })
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertDoesNotExist()
+
+        composeTestRule.runOnIdle {
+            challengeState = null
+            challenge.onCancelClick()
+        }
+        composeTestRule.waitForIdle()
+
+        assertThat(composeTestRule.runOnIdle { challengeState }).isNull()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+        composeTestRule.onNodeWithText(TYPED_EMAIL).assertIsDisplayed()
+    }
+
+    /**
+     * The same guard on the `Idle` branch, reached without a `Cancelled` in front of it: a
+     * sign-out publishes `Loading` and then `Idle`, and `Idle` resets through the identical
+     * comparison one branch down.
+     */
+    @Test
+    fun `an idle on the start step keeps the address the recovery carried`() {
+        start()
+        typeSignInEmail()
+        goToSignUp()
+        recoverFrom(
+            AuthException.EmailAlreadyInUseException(
+                message = "already in use",
+                email = TYPED_EMAIL,
+            )
+        )
+        composeTestRule.onNodeWithText(TYPED_EMAIL).assertIsDisplayed()
+
+        composeTestRule.runOnIdle { authUI.updateAuthState(AuthState.Loading()) }
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnIdle { authUI.updateAuthState(AuthState.Idle) }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+        composeTestRule.onNodeWithText(TYPED_EMAIL).assertIsDisplayed()
     }
 
     @Test
@@ -236,7 +357,9 @@ class FirebaseAuthScreenEmailRecoveryTest {
             .assertDoesNotExist()
     }
 
+    // =============================================================================================
     // The email-link recovery step, both branches
+    // =============================================================================================
 
     @Test
     fun `a suggested email-link method recovers to the email-link step when it is enabled`() {
@@ -251,7 +374,9 @@ class FirebaseAuthScreenEmailRecoveryTest {
 
     /**
      * Without email-link sign-in configured there is no such step to offer, so the recovery falls
-     * back to password sign-in rather than rendering a form the provider cannot complete.
+     * back to password sign-in rather than rendering a form the provider cannot complete. The
+     * screen's own handler used to switch to the email-link mode with no such guard at all; that
+     * handler is gone, which makes this the single deterministic outcome.
      */
     @Test
     fun `a suggested email-link method recovers to the sign-in step when it is disabled`() {
@@ -266,17 +391,22 @@ class FirebaseAuthScreenEmailRecoveryTest {
             .assertDoesNotExist()
     }
 
+    // =============================================================================================
     // The address the recovery carries
+    // =============================================================================================
 
     /**
-     * A recovery can start from a provider attempt, which never went through an email step: the
-     * failure names the address, and the recovery must use it rather than open an empty form.
+     * A recovery can start from a *provider* attempt, which never went through an email step at
+     * all: nothing was typed, and tapping a provider in the picker clears whatever a previous
+     * "Continue as" had seeded. The failure itself names the address in that case, so the recovery
+     * has to prefer it over the host's own record rather than landing the user on an empty form.
      */
     @Test
     fun `a recovery with nothing typed uses the address the failure names`() {
         start(configuration = emailAndPhoneConfiguration())
 
-        // Still on the method picker, so the host has no typed address to fall back on.
+        // Still on the method picker: no email step has ever been composed, so the host has no
+        // typed address of its own to fall back on.
         composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertDoesNotExist()
 
         recoverFrom(
@@ -291,8 +421,10 @@ class FirebaseAuthScreenEmailRecoveryTest {
     }
 
     /**
-     * When both are available the failure still wins: the typed address can be the one that
-     * provoked the failure rather than the one it is about.
+     * And when both are available the failure still wins. The address the user typed can be the
+     * one that *provoked* the failure rather than the one it is about — an anonymous upgrade or a
+     * credential link reports the address already holding the account, which is the one the
+     * recovery form has to open on.
      */
     @Test
     fun `the address the failure names beats the one the host recorded`() {
@@ -314,11 +446,16 @@ class FirebaseAuthScreenEmailRecoveryTest {
         composeTestRule.onNodeWithText(TYPED_EMAIL).assertDoesNotExist()
     }
 
+    // =============================================================================================
     // Activity recreation
+    // =============================================================================================
 
     /**
-     * The address the host tracks has to be saveable: a recovery decided after a recreation has
-     * only the route argument to fall back on, and the start destination carries the empty default.
+     * The step's own field restores itself, but the host's record of the address does not come for
+     * free: a recovery decided *after* a recreation has only the route argument left to fall back
+     * on, and the graph's start destination carries the empty default. The address the host tracks
+     * therefore has to be saveable, or the very first recovery after a rotation lands the user on
+     * an empty form.
      */
     @Test
     fun `a recovery after an Activity recreation still carries the typed address`() {
@@ -339,7 +476,7 @@ class FirebaseAuthScreenEmailRecoveryTest {
         restorationTester.emulateSavedInstanceStateRestore()
         composeTestRule.waitForIdle()
 
-        // The field itself survives on its own.
+        // The field itself survives on its own; the point of the test is what follows.
         composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
         composeTestRule.onNodeWithText(TYPED_EMAIL).assertIsDisplayed()
 
@@ -351,8 +488,10 @@ class FirebaseAuthScreenEmailRecoveryTest {
     }
 
     /**
-     * Surviving a recreation must not mean surviving a sign-out: the next session's user must not
-     * be handed the previous one's address, on the form or through a recovery.
+     * The other direction of the same state. Surviving a recreation must not mean surviving a
+     * sign-out: signing out publishes Loading and then a genuine Idle, which resets the flow to
+     * its start step. The next session's user must not be handed the previous one's address, on
+     * the form or through a recovery.
      */
     @Test
     fun `signing out drops the address for both the form and the next recovery`() {
@@ -361,7 +500,8 @@ class FirebaseAuthScreenEmailRecoveryTest {
         signIn()
         composeTestRule.onNodeWithTag(AUTHENTICATED_TAG).assertIsDisplayed()
 
-        // What signOut publishes: Loading (not a notification, so the Idle is a real reset), Idle.
+        // What FirebaseAuthUI.signOut publishes: a Loading (not a notification, so the Idle that
+        // follows is a real reset) and then Idle.
         composeTestRule.runOnIdle { authUI.updateAuthState(AuthState.Loading()) }
         composeTestRule.waitForIdle()
         composeTestRule.runOnIdle { authUI.updateAuthState(AuthState.Idle) }
@@ -377,14 +517,19 @@ class FirebaseAuthScreenEmailRecoveryTest {
         composeTestRule.onNodeWithText(TYPED_EMAIL).assertDoesNotExist()
     }
 
+    // =============================================================================================
     // Reauthentication
+    // =============================================================================================
 
     /**
-     * The invariant the recovery veto rests on: while a request is armed,
-     * `FirebaseAuthUI.contextualizeReauthenticationState` folds every `AuthState.Error` into
-     * `AuthState.Reauthentication.AttemptFailed`, so the branch offering recovery is unreachable
-     * while a reauthentication surface is up. Were that to stop, a recovery could navigate the
-     * outer graph out from under the sheet with the request still armed.
+     * The invariant the recovery veto above rests on. `onRecover` is withheld on
+     * `configuration.isReauthenticationMode` alone, which does not cover a reauthentication this
+     * screen is *presenting* — there the outer configuration is an ordinary one. It does not need
+     * to: while a request is armed, `FirebaseAuthUI.contextualizeReauthenticationState` folds every
+     * `AuthState.Error` into `AuthState.Reauthentication.AttemptFailed`, so the branch that offers
+     * recovery is unreachable while a reauthentication surface is up. If that folding ever stopped,
+     * a recovery could navigate the outer graph out from under the sheet with the request still
+     * armed — so the folding is asserted here rather than guarded against with a dead branch.
      */
     @Test
     fun `an error raised while a reauth request is armed never surfaces as an error state`() {
@@ -395,7 +540,8 @@ class FirebaseAuthScreenEmailRecoveryTest {
         `when`(user.email).thenReturn(TYPED_EMAIL)
         `when`(user.uid).thenReturn("reauth-user-uid")
 
-        // A second collector, so the folded state can be read directly.
+        // A second collector on the same flow, so the folded state can be read directly rather
+        // than inferred from what the dialog happens to render.
         val seen = mutableListOf<AuthState>()
         composeTestRule.setContent {
             LaunchedEffect(authUI) { authUI.authStateFlow().collect { seen += it } }
@@ -425,15 +571,17 @@ class FirebaseAuthScreenEmailRecoveryTest {
 
         assertThat(composeTestRule.runOnIdle { seen.lastOrNull() })
             .isInstanceOf(AuthState.Reauthentication.AttemptFailed::class.java)
-        // No action button on the dialog, and the outer graph did not move behind the sheet.
+        // Which is what keeps the recovery out of reach: no action button on the dialog, and the
+        // outer graph was not moved to a sign-up form behind the sheet.
         composeTestRule.onNodeWithTag(FirebaseAuthTestTags.ErrorRecovery.RETRY_BUTTON)
             .assertDoesNotExist()
         composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.EMAIL_FIELD).assertDoesNotExist()
     }
 
     /**
-     * Every recovery either moves the flow to an email step or starts a fresh provider sign-in,
-     * neither of which may happen while reauthenticating, so the dialog offers nothing.
+     * Every recovery either moves the flow to an email step, vetoed while reauthenticating, or
+     * starts a fresh provider sign-in, which would sign someone in while a sensitive operation
+     * is still waiting to be proved. So the dialog explains the error and offers nothing else.
      */
     @Test
     fun `reauthentication offers no recovery action`() {
@@ -453,26 +601,32 @@ class FirebaseAuthScreenEmailRecoveryTest {
         composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.EMAIL_FIELD).assertDoesNotExist()
     }
 
+    // =============================================================================================
     // Every route the public API exposes is a registered destination
+    // =============================================================================================
 
     /**
      * `AuthSuccessUiContext.onNavigate` takes any [AuthRoute] and hands it straight to the
-     * controller, which throws for a destination nothing registered, so every value must resolve.
+     * controller, which throws for a destination nothing registered. Every value the sealed
+     * hierarchy exposes therefore has to resolve — including the step objects of the flows whose
+     * screens have not been converted yet.
      */
     @Test
     fun `every AuthRoute resolves to a registered destination`() {
-        // Both provider flows configured: a phone step composes the phone screen.
+        // Both provider flows configured: a phone step composes the phone screen, which needs its
+        // own provider present, and the point here is the destination resolving rather than a
+        // single-provider graph.
         start(configuration = emailAndPhoneConfiguration())
         signIn()
 
         val uiContext = requireNotNull(composeTestRule.runOnIdle { lastUiContext })
         val unresolved = mutableListOf<String>()
-        AuthRoute.all.forEach { route ->
+        allAuthRoutes.forEach { route ->
             composeTestRule.runOnIdle {
                 try {
                     uiContext.onNavigate(route)
                 } catch (e: IllegalArgumentException) {
-                    unresolved += "${route.route}: ${e.message}"
+                    unresolved += "$route: ${e.message}"
                 }
             }
             composeTestRule.waitForIdle()
@@ -481,11 +635,60 @@ class FirebaseAuthScreenEmailRecoveryTest {
         assertThat(unresolved).isEmpty()
     }
 
+    /**
+     * The precondition that makes `AuthSuccessUiContext.onNavigate` safe.
+     *
+     * That callback hands a **consumer-supplied** [AuthRoute] straight to `pushUnique`, which is
+     * the one call site whose argument the library does not choose. `pushUnique` behaves sharply
+     * when the key it is given is already *buried* on the stack: it moves that entry to the top and
+     * drops everything that was above it. Here that case cannot arise, because [AuthRoute.Success]
+     * is only ever reached through `resetBackStackTo`, whose postcondition is a one-entry stack —
+     * nothing can be buried under a stack that holds one thing.
+     *
+     * Asserted rather than left to reading, because the invariant lives in a different part of the
+     * screen from the function that depends on it. The flow is deliberately taken *deeper* than one
+     * entry first, so a reset that stopped clearing would leave something for back to find.
+     */
+    @Test
+    fun `the success destination has nothing beneath it, so a route pushed from it lands directly on top`() {
+        start()
+        typeSignInEmail()
+        goToSignUp()
+
+        signIn()
+        composeTestRule.onNodeWithTag(AUTHENTICATED_TAG).assertIsDisplayed()
+
+        // Nothing underneath: root back belongs to the host, not the display, so the signed-in
+        // user stays put rather than reappearing on the form they just left.
+        back()
+        composeTestRule.onNodeWithTag(AUTHENTICATED_TAG).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.EMAIL_FIELD).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertDoesNotExist()
+
+        // So a route pushed through the public callback sits directly on Success, with exactly one
+        // entry beneath it for back to return to.
+        val uiContext = requireNotNull(composeTestRule.runOnIdle { lastUiContext })
+        composeTestRule.runOnIdle { uiContext.onNavigate(AuthRoute.Email) }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+
+        back()
+        composeTestRule.onNodeWithTag(AUTHENTICATED_TAG).assertIsDisplayed()
+    }
+
+    // =============================================================================================
     // Configured transitions
+    // =============================================================================================
 
     /**
-     * A step-to-step move is real navigation, animated by whatever the caller configured: the
-     * graph asks the transition lambdas, naming the two step routes it moves between.
+     * Splitting the modes into destinations is only worth anything if a step-to-step move is real
+     * navigation, animated by whatever the caller configured. The transition lambdas are the
+     * observable proof: the display asks them, naming the two steps it is moving between.
+     *
+     * A forward move now asks **one** lambda (`transitionSpec`) for a single `ContentTransform`,
+     * so the two separate enter/exit observations collapse into one. The scene names the
+     * destination through `Scene<NavKey>.authRoute()`, which is also the only supported way a
+     * consumer can do this — see [com.firebase.ui.auth.ui.screens.AuthRouteMetadataKey].
      */
     @Test
     fun `the configured transitions drive a step-to-step move`() {
@@ -494,13 +697,63 @@ class FirebaseAuthScreenEmailRecoveryTest {
 
         goToSignUp()
 
-        val signIn = AuthRoute.Email.SignIn.routePattern
-        val signUp = AuthRoute.Email.SignUp.routePattern
-        assertThat(observed).contains("enter:$signIn->$signUp")
-        assertThat(observed).contains("exit:$signIn->$signUp")
+        val signIn = AuthRoute.Email.SignIn::class.simpleName
+        val signUp = AuthRoute.Email.SignUp::class.simpleName
+        assertThat(observed).contains("transition:$signIn->$signUp")
     }
 
+    /**
+     * The reverse move, which is a different lambda: `NavDisplay` takes one `ContentTransform` per
+     * direction, so `popTransitionSpec` needs its own observation — a wiring that fed
+     * `transitionSpec` to both directions would satisfy the test above and still be wrong.
+     *
+     * `predictivePopTransitionSpec` is deliberately **not** asserted here. It is only consulted
+     * while a predictive-back gesture is in progress, which needs a real
+     * `OnBackPressedDispatcher.dispatchOnBackStarted`/`OnBackProgressed` sequence from a platform
+     * back gesture; Robolectric's dispatcher delivers only the completed `onBackPressed` that
+     * [back] triggers, which is the plain pop path. It is new public API with no unit coverage,
+     * and this comment is the honest record of that rather than a test that appears to cover it.
+     */
+    @Test
+    fun `the configured pop transition drives a move back`() {
+        val observed = mutableListOf<String>()
+        start(configuration = emailConfiguration(transitions = recordingTransitions(observed)))
+
+        goToSignUp()
+        observed.clear()
+        back()
+
+        val signIn = AuthRoute.Email.SignIn::class.simpleName
+        val signUp = AuthRoute.Email.SignUp::class.simpleName
+        assertThat(observed).contains("popTransition:$signUp->$signIn")
+        // The forward spec is not what a pop asks.
+        assertThat(observed.none { it.startsWith("transition:") }).isTrue()
+    }
+
+    /**
+     * The public accessor the reshaped [AuthUITransitions] depends on. Navigation 3 exposes no
+     * supported way to ask a `Scene` which destination it shows — `NavEntry` has no public key
+     * accessor, `contentKey` is opaque and re-wrapped mid-life, and `Scene.key` is stale on the
+     * target side mid-transition — so the library stamps the key into entry metadata itself. If
+     * that stamping were dropped, a consumer's per-destination animation would silently degrade to
+     * "null on both sides" rather than fail to compile.
+     */
+    @Test
+    fun `a scene reports the AuthRoute it is showing on both sides of a move`() {
+        val observed = mutableListOf<String>()
+        start(configuration = emailConfiguration(transitions = recordingTransitions(observed)))
+
+        goToSignUp()
+
+        // `none {}` is vacuously true on an empty list, so the lambdas having fired at all is half
+        // the assertion: drop the metadata stamping *and* the transitions and this would still pass.
+        assertThat(observed).isNotEmpty()
+        assertThat(observed.none { it.contains("null") }).isTrue()
+    }
+
+    // =============================================================================================
     // Harness
+    // =============================================================================================
 
     private fun emailConfiguration(
         isEmailLinkSignInEnabled: Boolean = false,
@@ -553,14 +806,27 @@ class FirebaseAuthScreenEmailRecoveryTest {
     }
 
     private fun recordingTransitions(into: MutableList<String>) = AuthUITransitions(
-        enterTransition = { into += "enter:${label()}"; EnterTransition.None },
-        exitTransition = { into += "exit:${label()}"; ExitTransition.None },
-        popEnterTransition = { into += "popEnter:${label()}"; EnterTransition.None },
-        popExitTransition = { into += "popExit:${label()}"; ExitTransition.None },
+        transitionSpec = {
+            into += "transition:${label()}"
+            EnterTransition.None togetherWith ExitTransition.None
+        },
+        popTransitionSpec = {
+            into += "popTransition:${label()}"
+            EnterTransition.None togetherWith ExitTransition.None
+        },
+        predictivePopTransitionSpec = { _ ->
+            into += "predictivePop:${label()}"
+            EnterTransition.None togetherWith ExitTransition.None
+        },
     )
 
-    private fun AnimatedContentTransitionScope<NavBackStackEntry>.label(): String =
-        "${initialState.destination.route}->${targetState.destination.route}"
+    /**
+     * The transition scope is over [Scene], which carries no route of its own, so the label comes
+     * from `Scene.authRoute()`.
+     */
+    private fun AnimatedContentTransitionScope<Scene<NavKey>>.label(): String =
+        "${initialState.authRoute()?.let { it::class.simpleName }}->" +
+                "${targetState.authRoute()?.let { it::class.simpleName }}"
 
     private fun differentSignInMethodRequired() =
         AuthException.DifferentSignInMethodRequiredException(
@@ -583,9 +849,22 @@ class FirebaseAuthScreenEmailRecoveryTest {
                     SideEffect { lastUiContext = uiContext }
                     Text("authenticated", modifier = Modifier.testTag(AUTHENTICATED_TAG))
                 },
+                mfaChallengeContent = { state -> challengeState = state },
             )
         }
         composeTestRule.waitForIdle()
+    }
+
+    /** A resolver with a single TOTP hint — enough for the challenge step to compose. */
+    private fun mfaResolver(): MultiFactorResolver {
+        val session = mock(MultiFactorSession::class.java)
+        val hint = mock(TotpMultiFactorInfo::class.java)
+        `when`(hint.factorId).thenReturn("totp")
+        `when`(hint.uid).thenReturn("totp-factor-uid")
+        val resolver = mock(MultiFactorResolver::class.java)
+        `when`(resolver.session).thenReturn(session)
+        `when`(resolver.hints).thenReturn(listOf<MultiFactorInfo>(hint))
+        return resolver
     }
 
     @Composable

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenMfaChallengeCancelTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenMfaChallengeCancelTest.kt
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import com.firebase.ui.auth.AuthState
+import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.configuration.authUIConfiguration
+import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.mfa.MfaChallengeContentState
+import com.firebase.ui.auth.ui.FirebaseAuthTestTags
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.MultiFactorInfo
+import com.google.firebase.auth.MultiFactorResolver
+import com.google.firebase.auth.MultiFactorSession
+import com.google.firebase.auth.TotpMultiFactorInfo
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Pins what cancelling the MFA challenge does to the flow underneath it.
+ *
+ * **What these two tests do not discriminate on.** `onCancel` publishes [AuthState.Cancelled] and
+ * *then* pops the challenge. Both tests here reach the challenge from a stack of `[SignIn(null)]`,
+ * and on that shape the pop is invisible: dropping it would leave
+ * the [AuthState.Cancelled] branch observing [AuthRoute.MfaChallenge], which is never a start step,
+ * so its reset fires — but `resetBackStackTo` adds before it trims, and the `SignIn(null)` it adds
+ * is `==` to the entry already there, so that entry never leaves composition and its saved state
+ * survives (see `resetBackStackTo`'s clause 5). Both tests pass with the pop removed.
+ *
+ * That is a property of *this* stack shape, not of the pop. On a stack whose start entry carries an
+ * argument — `[SignIn("bob@x.com")]`, which the email recovery really does build — the reset pushes
+ * a differently-keyed `SignIn(null)`, the old entry leaves the stack, and the address vanishes. The
+ * pop is what stops that, and `FirebaseAuthScreenEmailRecoveryTest`'s `cancelling an MFA challenge
+ * keeps the address the recovery carried` is the test that fails without it.
+ *
+ * Ordering of the two writes before the pop is unobservable, and not merely because Robolectric
+ * cannot see it: `updateAuthState` is `_authStateFlow.value = …` and the resolver clear is a
+ * snapshot-state write, both synchronous inside one click handler, and the only reader of either is
+ * `LaunchedEffect(observedAuthState)` behind a `collectAsState`, which cannot run until the handler
+ * returns. The pop rides on that same gap — it lands before the collector reads the stack.
+ *
+ * So this file asserts the outcomes that *are* observable on this shape, and asserts them against
+ * the **live** composition rather than against captured state left over from an earlier frame —
+ * which is the one thing the first version of it got wrong.
+ *
+ * @suppress Internal test class
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class FirebaseAuthScreenMfaChallengeCancelTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Mock
+    private lateinit var mockFirebaseAuth: FirebaseAuth
+
+    @Mock
+    private lateinit var mockResolver: MultiFactorResolver
+
+    @Mock
+    private lateinit var mockSession: MultiFactorSession
+
+    @Mock
+    private lateinit var mockTotpHint: TotpMultiFactorInfo
+
+    private lateinit var authUI: FirebaseAuthUI
+
+    private var challengeState: MfaChallengeContentState? = null
+    private var cancelledCount = 0
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        FirebaseAuthUI.clearInstanceCache()
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        FirebaseApp.getApps(context).forEach { it.delete() }
+        val app = FirebaseApp.initializeApp(
+            context,
+            FirebaseOptions.Builder()
+                .setApiKey("fake-api-key")
+                .setApplicationId("fake-app-id")
+                .setProjectId("fake-project-id")
+                .build()
+        )!!
+        `when`(mockFirebaseAuth.app).thenReturn(app)
+        authUI = FirebaseAuthUI.create(app, mockFirebaseAuth)
+
+        `when`(mockResolver.session).thenReturn(mockSession)
+        `when`(mockResolver.hints).thenReturn(listOf<MultiFactorInfo>(mockTotpHint))
+        `when`(mockTotpHint.factorId).thenReturn("totp")
+        `when`(mockTotpHint.uid).thenReturn("totp-factor-uid")
+    }
+
+    @After
+    fun tearDown() {
+        challengeState = null
+        cancelledCount = 0
+        FirebaseAuthUI.clearInstanceCache()
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        FirebaseApp.getApps(context).forEach {
+            try {
+                it.delete()
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    /**
+     * Cancelling leaves the challenge and puts the flow back on its start step, exactly once.
+     *
+     * The email step is asserted through the **live semantics tree**, not through a captured
+     * `EmailAuthContentState`. A capture is set by whichever frame composed the slot and is never
+     * unset, so it reports that the step composed *at some point* — which stays true both with the
+     * challenge still on screen and with a later reset having moved the flow somewhere else
+     * entirely. That is what made the first version of this test unable to fail. `challengeState`
+     * is still a capture, but it is cleared immediately before the action, so it answers "did the
+     * challenge compose again after the cancel?" rather than "ever?".
+     */
+    @Test
+    fun `cancelling the challenge returns to the start step`() {
+        start()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD)
+            .performTextInput(TYPED_EMAIL)
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(TYPED_EMAIL).assertIsDisplayed()
+
+        composeTestRule.runOnIdle { authUI.updateAuthState(AuthState.RequiresMfa(mockResolver)) }
+        composeTestRule.waitForIdle()
+        val challenge = requireNotNull(composeTestRule.runOnIdle { challengeState })
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertDoesNotExist()
+
+        composeTestRule.runOnIdle {
+            challengeState = null
+            challenge.onCancelClick()
+        }
+        composeTestRule.waitForIdle()
+
+        // The destination on screen when everything has settled is the email start step, and the
+        // challenge is not composed again.
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+        assertThat(composeTestRule.runOnIdle { challengeState }).isNull()
+        // The host was told, once.
+        assertThat(cancelledCount).isEqualTo(1)
+        // And the step it returned to is the one the user had been using: the flow does not hand
+        // back a start step that lost what was typed into it. (See the class KDoc for why this
+        // survives on this stack shape even without the pop — the shape that discriminates is
+        // FirebaseAuthScreenEmailRecoveryTest's.)
+        composeTestRule.onNodeWithText(TYPED_EMAIL).assertIsDisplayed()
+    }
+
+    /**
+     * Cancelling twice does not tell the host twice, and does not leave a second challenge behind.
+     * The second `RequiresMfa` has to re-add the challenge — the guard at the `RequiresMfa` branch
+     * is a top-of-stack test, and after the first cancellation the challenge is not on the stack
+     * at all.
+     */
+    @Test
+    fun `the challenge can be raised and cancelled again`() {
+        start()
+
+        repeat(2) { round ->
+            composeTestRule.runOnIdle {
+                challengeState = null
+                authUI.updateAuthState(AuthState.RequiresMfa(mockResolver))
+            }
+            composeTestRule.waitForIdle()
+            val challenge = requireNotNull(composeTestRule.runOnIdle { challengeState }) {
+                "round $round did not compose the challenge"
+            }
+
+            composeTestRule.runOnIdle {
+                challengeState = null
+                challenge.onCancelClick()
+            }
+            composeTestRule.waitForIdle()
+
+            assertThat(composeTestRule.runOnIdle { challengeState }).isNull()
+            composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD)
+                .assertIsDisplayed()
+            assertThat(cancelledCount).isEqualTo(round + 1)
+        }
+    }
+
+    private fun start() {
+        val configuration = authUIConfiguration {
+            context = ApplicationProvider.getApplicationContext()
+            providers {
+                provider(
+                    AuthProvider.Email(
+                        emailLinkActionCodeSettings = null,
+                        passwordValidationRules = emptyList()
+                    )
+                )
+            }
+            isCredentialManagerEnabled = false
+        }
+
+        composeTestRule.setContent {
+            FirebaseAuthScreen(
+                configuration = configuration,
+                authUI = authUI,
+                onSignInSuccess = {},
+                onSignInFailure = {},
+                onSignInCancelled = { cancelledCount++ },
+                mfaChallengeContent = { state -> challengeState = state },
+            )
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    private companion object {
+        const val TYPED_EMAIL = "user+tag@example.com"
+    }
+}

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenMfaEnrollmentExitTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenMfaEnrollmentExitTest.kt
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.core.app.ApplicationProvider
+import com.firebase.ui.auth.AuthState
+import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.configuration.MfaFactor
+import com.firebase.ui.auth.configuration.authUIConfiguration
+import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.mfa.MfaEnrollmentContentState
+import com.firebase.ui.auth.mfa.MfaEnrollmentStep
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.MultiFactor
+import com.google.firebase.auth.MultiFactorSession
+import com.google.firebase.auth.TotpMultiFactorAssertion
+import com.google.firebase.auth.TotpMultiFactorGenerator
+import com.google.firebase.auth.TotpSecret as FirebaseTotpSecret
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockStatic
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Pins the two exits [FirebaseAuthScreen] itself wires the MFA enrolment flow to — the `onComplete`
+ * and `onSkip` arguments it hands
+ * [com.firebase.ui.auth.ui.screens.mfa.mfaEnrollmentDestinations].
+ *
+ * `MfaEnrollmentRouteNavigationTest` covers what
+ * [com.firebase.ui.auth.ui.screens.mfa.exitMfaEnrollment] does, but through that file's own host,
+ * which supplies its own `onComplete` and `onSkip` — so it would stay green with the production
+ * lines reverted to a single pop. These two tests drive the real screen, whose back stack is not
+ * reachable from a test, and read the exit off what is on screen afterwards instead.
+ *
+ * @suppress Internal test class
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class FirebaseAuthScreenMfaEnrollmentExitTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Mock
+    private lateinit var mockAuth: FirebaseAuth
+
+    @Mock
+    private lateinit var mockUser: FirebaseUser
+
+    @Mock
+    private lateinit var mockMultiFactor: MultiFactor
+
+    private lateinit var authUI: FirebaseAuthUI
+
+    private var mfaState: MfaEnrollmentContentState? = null
+    private var manageMfa: (() -> Unit)? = null
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        FirebaseAuthUI.clearInstanceCache()
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        FirebaseApp.getApps(context).forEach { it.delete() }
+        val app = FirebaseApp.initializeApp(
+            context,
+            FirebaseOptions.Builder()
+                .setApiKey("fake-api-key")
+                .setApplicationId("fake-app-id")
+                .setProjectId("fake-project-id")
+                .build()
+        )!!
+        `when`(mockAuth.app).thenReturn(app)
+        `when`(mockAuth.currentUser).thenReturn(mockUser)
+        `when`(mockUser.uid).thenReturn("mfa-exit-user")
+        `when`(mockUser.email).thenReturn("user@example.com")
+        `when`(mockUser.isEmailVerified).thenReturn(true)
+        `when`(mockUser.multiFactor).thenReturn(mockMultiFactor)
+        `when`(mockMultiFactor.enrolledFactors).thenReturn(emptyList())
+        authUI = FirebaseAuthUI.create(app, mockAuth)
+    }
+
+    @After
+    fun tearDown() {
+        mfaState = null
+        manageMfa = null
+        FirebaseAuthUI.clearInstanceCache()
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        FirebaseApp.getApps(context).forEach {
+            try {
+                it.delete()
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    /**
+     * Skipping from the second step of the flow. One pop would leave
+     * [MfaEnrollmentStep.SelectFactor] on screen, which is what the user was trying to get away
+     * from.
+     */
+    @Test
+    fun `skipping enrolment from a step below the first leaves the flow entirely`() {
+        startSignedIn()
+        enterEnrollment()
+        selectFactor(MfaFactor.Sms)
+        assertStepShown(MfaEnrollmentStep.ConfigureSms)
+
+        runOnIdle { requireNotNull(requireNotNull(mfaState).onSkipClick).invoke() }
+
+        assertNoStepShown()
+        composeTestRule.onNodeWithTag(AUTHENTICATED_TAG).assertIsDisplayed()
+    }
+
+    /**
+     * Completing enrolment from [MfaEnrollmentStep.VerifyFactor], three pushes deep. Enrolment
+     * itself is mocked out — the TOTP secret, the assertion and the `enroll` call — since none of
+     * it can happen against a fake project.
+     */
+    @Test
+    fun `completing enrolment from the last step leaves the flow entirely`() {
+        withMockedTotpEnrollment {
+            startSignedIn()
+            enterEnrollment()
+            selectFactor(MfaFactor.Totp)
+            assertStepShown(MfaEnrollmentStep.ConfigureTotp)
+            runOnIdle { requireNotNull(mfaState).onContinueToVerifyClick() }
+            assertStepShown(MfaEnrollmentStep.VerifyFactor)
+
+            runOnIdle { requireNotNull(mfaState).onVerificationCodeChange(VERIFICATION_CODE) }
+            runOnIdle { requireNotNull(mfaState).onVerifyClick() }
+
+            assertNoStepShown()
+            composeTestRule.onNodeWithTag(AUTHENTICATED_TAG).assertIsDisplayed()
+        }
+    }
+
+    // =============================================================================================
+    // Harness
+    // =============================================================================================
+
+    /** Hosts the real screen and puts it on its authenticated destination. */
+    private fun startSignedIn() {
+        val configuration = authUIConfiguration {
+            context = ApplicationProvider.getApplicationContext()
+            providers {
+                provider(
+                    AuthProvider.Email(
+                        emailLinkActionCodeSettings = null,
+                        passwordValidationRules = emptyList()
+                    )
+                )
+            }
+        }
+
+        composeTestRule.setContent {
+            FirebaseAuthScreen(
+                configuration = configuration,
+                authUI = authUI,
+                onSignInSuccess = {},
+                onSignInFailure = {},
+                onSignInCancelled = {},
+                mfaEnrollmentContent = { state ->
+                    mfaState = state
+                    Text(text = "mfa", modifier = Modifier.testTag(stepTag(state.step)))
+                },
+                authenticatedContent = { _, uiContext ->
+                    manageMfa = uiContext.onManageMfa
+                    Text(text = "authenticated", modifier = Modifier.testTag(AUTHENTICATED_TAG))
+                }
+            )
+        }
+
+        runOnIdle {
+            authUI.updateAuthState(
+                AuthState.Success(result = null, user = mockUser, isNewUser = false)
+            )
+        }
+        composeTestRule.onNodeWithTag(AUTHENTICATED_TAG).assertIsDisplayed()
+    }
+
+    /** Enters the flow the way the authenticated destination's "manage MFA" action does. */
+    private fun enterEnrollment() {
+        runOnIdle { requireNotNull(manageMfa).invoke() }
+        assertStepShown(MfaEnrollmentStep.SelectFactor)
+    }
+
+    private fun selectFactor(factor: MfaFactor) {
+        runOnIdle { requireNotNull(mfaState).onFactorSelected(factor) }
+    }
+
+    private fun assertStepShown(step: MfaEnrollmentStep) {
+        composeTestRule.onNodeWithTag(stepTag(step)).assertIsDisplayed()
+    }
+
+    /** No step of the flow is on screen — not the one left, and not one underneath it either. */
+    private fun assertNoStepShown() {
+        MfaEnrollmentStep.entries.forEach { step ->
+            composeTestRule.onNodeWithTag(stepTag(step)).assertDoesNotExist()
+        }
+    }
+
+    private fun runOnIdle(block: () -> Unit) {
+        composeTestRule.runOnIdle(block)
+        composeTestRule.waitForIdle()
+    }
+
+    /**
+     * Stubs the whole TOTP enrolment round trip for the duration of [block]: the multi-factor
+     * session, [TotpMultiFactorGenerator.generateSecret], the enrolment assertion, and
+     * [MultiFactor.enroll].
+     */
+    private fun withMockedTotpEnrollment(block: () -> Unit) {
+        val session = mock(MultiFactorSession::class.java)
+        val firebaseSecret = mock(FirebaseTotpSecret::class.java)
+        val assertion = mock(TotpMultiFactorAssertion::class.java)
+        `when`(mockMultiFactor.session).thenReturn(Tasks.forResult(session))
+        `when`(firebaseSecret.sharedSecretKey).thenReturn(FAKE_SHARED_SECRET)
+        `when`(firebaseSecret.generateQrCodeUrl(any(), any())).thenReturn(FAKE_QR_URL)
+        `when`(mockMultiFactor.enroll(eq(assertion), any())).thenReturn(Tasks.forResult(null))
+
+        mockStatic(TotpMultiFactorGenerator::class.java).use { totpStatic ->
+            totpStatic.`when`<Task<FirebaseTotpSecret>> {
+                TotpMultiFactorGenerator.generateSecret(session)
+            }.thenReturn(Tasks.forResult(firebaseSecret))
+            totpStatic.`when`<TotpMultiFactorAssertion> {
+                TotpMultiFactorGenerator.getAssertionForEnrollment(
+                    firebaseSecret,
+                    VERIFICATION_CODE,
+                )
+            }.thenReturn(assertion)
+
+            block()
+        }
+    }
+
+    private companion object {
+        const val AUTHENTICATED_TAG = "authenticated-destination"
+        const val VERIFICATION_CODE = "123456"
+        const val FAKE_SHARED_SECRET = "JBSWY3DPEHPK3PXP"
+        const val FAKE_QR_URL =
+            "otpauth://totp/test-issuer:user%40example.com?secret=JBSWY3DPEHPK3PXP"
+
+        fun stepTag(step: MfaEnrollmentStep): String = "mfa-step-$step"
+    }
+}

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenReauthContentStateTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenReauthContentStateTest.kt
@@ -597,7 +597,7 @@ class FirebaseAuthScreenReauthContentStateTest {
     }
 
     /**
-     * The error dialog's recovery actions navigate the *outer* NavHost to the non-reauth email
+     * The error dialog's recovery actions navigate the *outer* back stack to the non-reauth email
      * screen. While a reauthentication is armed both `onRecover` and `onRetry` are withheld, so the
      * dialog has no action to offer and must not render an action button that silently dismisses
      * instead of recovering. This is the default-sheet path — with a custom slot the error latches
@@ -632,7 +632,7 @@ class FirebaseAuthScreenReauthContentStateTest {
         composeTestRule.waitForIdle()
 
         // The sheet opens on its method picker (two linked providers), so no password field is on
-        // screen yet. The outer NavHost is still on the method-picker route behind it.
+        // screen yet. The outer back stack is still on the method picker behind it.
         composeTestRule.onAllNodesWithText(stringProvider.passwordHint).assertCountEquals(0)
 
         composeTestRule.runOnIdle {
@@ -648,7 +648,7 @@ class FirebaseAuthScreenReauthContentStateTest {
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText(stringProvider.errorDialogTitle).assertExists()
 
-        // Ungated, onRecover would navigate the outer NavHost to the non-reauth email screen.
+        // Ungated, onRecover would navigate the outer back stack to the non-reauth email screen.
         // With both callbacks withheld the button has nothing to do, so it must not render.
         composeTestRule.onNodeWithTag(FirebaseAuthTestTags.ErrorRecovery.RETRY_BUTTON).assertDoesNotExist()
         composeTestRule.onNodeWithText(stringProvider.dismissAction).assertExists()
@@ -739,7 +739,7 @@ class FirebaseAuthScreenReauthContentStateTest {
 
         composeTestRule.onAllNodesWithText(stringProvider.passwordHint).assertCountEquals(0)
 
-        // Ungated, selecting email navigates the outer NavHost to its non-reauth email screen,
+        // Ungated, selecting email navigates the outer back stack to its non-reauth email screen,
         // surfacing a password field behind the slot.
         composeTestRule.onNodeWithTag("pick_password").performClick()
         composeTestRule.waitForIdle()
@@ -910,7 +910,7 @@ class FirebaseAuthScreenReauthContentStateTest {
     /**
      * A wrong password for an unverified account ends up here: the consumed Error resets to Idle,
      * the combine falls back to the live session, and that yields RequiresEmailVerification. It
-     * navigates with `popUpTo(inclusive = true)`, which would wipe the stack under the armed slot.
+     * resets the back stack to a single entry, which would wipe the stack under the armed slot.
      */
     @Test
     fun `RequiresEmailVerification does not navigate while reauthentication is armed`() {
@@ -970,7 +970,7 @@ class FirebaseAuthScreenReauthContentStateTest {
 
     /**
      * Firebase requires the second factor to complete the reauthentication too, so the challenge
-     * has to be presented *inside* the reauth surface — on the outer NavHost it renders beneath
+     * has to be presented *inside* the reauth surface — on the outer display it renders beneath
      * the modal, unreachable, and the operation stays pending forever.
      */
     @Test
@@ -1027,7 +1027,7 @@ class FirebaseAuthScreenReauthContentStateTest {
     }
 
     /**
-     * The default sheet needs the same sub-flow: its own NavHost, so the challenge replaces the
+     * The default sheet needs the same sub-flow: its own NavDisplay, so the challenge replaces the
      * provider screen inside the modal instead of rendering under it.
      */
     @Test

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenRouteTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenRouteTest.kt
@@ -1,7 +1,7 @@
 package com.firebase.ui.auth.ui.screens
 
 import android.content.Context
-import android.net.Uri
+import androidx.navigation3.runtime.NavKey
 import androidx.test.core.app.ApplicationProvider
 import com.firebase.ui.auth.configuration.authUIConfiguration
 import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
@@ -13,6 +13,8 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import kotlin.reflect.KClass
+import kotlin.reflect.full.createInstance
+import kotlinx.serialization.json.Json
 
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
@@ -119,66 +121,38 @@ class FirebaseAuthScreenRouteTest {
         assertThat(getStartRoute(configuration)).isEqualTo(AuthRoute.MethodPicker)
     }
 
-    // AuthRoute shape — public API.
+    // =============================================================================================
+    // AuthRoute shape — this is public API, and PR-shaped changes to it break every caller.
+    // =============================================================================================
 
-    /**
-     * Naming a flow means "enter this flow", so its route has to be its start step's — both
-     * `route`, which callers navigate with, and `routePattern`, which the graph registers.
-     */
+    /** Naming a flow means "enter this flow", so it must resolve to that flow's start step. */
     @Test
     fun `every flow entry point resolves to its start step`() {
-        assertThat(AuthRoute.Email.route).isEqualTo(AuthRoute.Email.SignIn.route)
-        assertThat(AuthRoute.Email.routePattern).isEqualTo(AuthRoute.Email.SignIn.routePattern)
-
-        assertThat(AuthRoute.Phone.route).isEqualTo(AuthRoute.Phone.EnterPhoneNumber.route)
-        assertThat(AuthRoute.Phone.routePattern)
-            .isEqualTo(AuthRoute.Phone.EnterPhoneNumber.routePattern)
-
-        assertThat(AuthRoute.MfaEnrollment.route)
-            .isEqualTo(AuthRoute.MfaEnrollment.SelectFactor.route)
-        assertThat(AuthRoute.MfaEnrollment.routePattern)
-            .isEqualTo(AuthRoute.MfaEnrollment.SelectFactor.routePattern)
-    }
-
-    /** Only the email steps take an argument, so only they may differ from their pattern. */
-    @Test
-    fun `routePattern equals route for every destination that takes no argument`() {
-        val argumentless = listOf(
-            AuthRoute.MethodPicker,
-            AuthRoute.Success,
-            AuthRoute.MfaChallenge,
-            AuthRoute.Phone,
-            AuthRoute.Phone.EnterPhoneNumber,
-            AuthRoute.Phone.EnterVerificationCode,
-            AuthRoute.MfaEnrollment.SelectFactor,
-            AuthRoute.MfaEnrollment.ConfigureSms,
-            AuthRoute.MfaEnrollment.ConfigureTotp,
-            AuthRoute.MfaEnrollment.VerifyFactor,
-        )
-
-        argumentless.forEach { route ->
-            assertThat(route.routePattern).isEqualTo(route.route)
-        }
-    }
-
-    @Test
-    fun `every email step registers the optional email argument`() {
-        AuthRoute.Email.steps.forEach { step ->
-            assertThat(step.routePattern).isEqualTo("${step.route}?$EMAIL_ARG={$EMAIL_ARG}")
-        }
+        assertThat(AuthRoute.Email.startKey()).isEqualTo(AuthRoute.Email.SignIn())
+        assertThat(AuthRoute.Phone.startKey()).isEqualTo(AuthRoute.Phone.EnterPhoneNumber)
+        assertThat(AuthRoute.MfaEnrollment.startKey())
+            .isEqualTo(AuthRoute.MfaEnrollment.SelectFactor)
     }
 
     /**
-     * The step lists must be computed getters: stored, they would be built before the nested
-     * objects were assigned and capture them as null. Reading a route off each entry catches that.
+     * A flow entry point names a flow, not a destination: it is not a `NavKey`, so it can never be
+     * pushed onto the back stack in place of the step it resolves to.
      */
     @Test
-    fun `the email step list is fully populated and distinct`() {
-        val routes = AuthRoute.Email.steps.map { it.route }
+    fun `a flow entry point is not itself a destination`() {
+        assertThat(AuthRoute.Email).isNotInstanceOf(NavKey::class.java)
+        assertThat(AuthRoute.Phone).isNotInstanceOf(NavKey::class.java)
+        assertThat(AuthRoute.MfaEnrollment).isNotInstanceOf(NavKey::class.java)
+        assertThat(AuthRoute.Email.SignIn()).isInstanceOf(NavKey::class.java)
+    }
 
-        assertThat(routes).hasSize(EmailAuthMode.entries.size)
-        assertThat(routes).containsNoDuplicates()
-        routes.forEach { route -> assertThat(route).isNotEmpty() }
+    @Test
+    fun `the email step list is fully populated and distinct`() {
+        val steps = AuthRoute.Email.steps
+
+        assertThat(steps).hasSize(EmailAuthMode.entries.size)
+        assertThat(steps.map { it::class }).containsNoDuplicates()
+        assertThat(steps.map { it.mode }).containsExactlyElementsIn(EmailAuthMode.entries)
     }
 
     @Test
@@ -188,24 +162,54 @@ class FirebaseAuthScreenRouteTest {
         }
     }
 
+    /** The address is a field on the key, so `withEmail` is a `copy`. */
     @Test
-    fun `withEmail appends an encoded address and omits an empty one`() {
-        val step = AuthRoute.Email.SignUp
+    fun `withEmail puts the address on the key`() {
+        val step = AuthRoute.Email.SignUp()
 
-        assertThat(step.withEmail(null)).isEqualTo(step.route)
-        assertThat(step.withEmail("")).isEqualTo(step.route)
+        assertThat(step.email).isNull()
+        assertThat(step.withEmail(null)).isEqualTo(AuthRoute.Email.SignUp(null))
         assertThat(step.withEmail("user+tag@example.com"))
-            .isEqualTo("${step.route}?$EMAIL_ARG=user%2Btag%40example.com")
+            .isEqualTo(AuthRoute.Email.SignUp("user+tag@example.com"))
+        // Same step, different address: two DIFFERENT keys. This is the whole reason
+        // navigateToEmailStep has to compare step *types* rather than keys.
+        assertThat(AuthRoute.Email.SignUp("a@b.com"))
+            .isNotEqualTo(AuthRoute.Email.SignUp("c@d.com"))
     }
 
     /**
-     * The address goes into a URI query string, so anything a local part or domain may legally
-     * hold has to come back out unchanged — a raw `#` truncates the URI, a raw space invalidates it.
+     * `SignUp("")` and `SignUp(null)` do not collapse into one destination: they are different
+     * keys, so an empty address is a state the flow can genuinely be in. That is what this asserts
+     * — the keys really are distinct, which is the fact `navigateToEmailStep`'s type comparison
+     * exists for.
+     *
+     * The *consequence* — that an empty address on the key still falls back to the prefill, rather
+     * than blanking a field the host had populated — belongs to `EmailAuthDestinations`, which
+     * reads `step.email?.ifEmpty { null } ?: prefillEmail()`. Asserting that expression here would
+     * only test the Kotlin stdlib: it would keep passing with `?.ifEmpty { null }` deleted from the
+     * product. It is pinned against the destination instead, by
+     * `EmailAuthRouteNavigationTest`'s `a step entered with an empty address falls back to the
+     * prefill`.
      */
     @Test
-    fun `withEmail encodes every address so the argument round-trips`() {
-        val step = AuthRoute.Email.SignUp
+    fun `an empty address is a key distinct from a null one`() {
+        val step = AuthRoute.Email.SignUp()
 
+        assertThat(step.withEmail("")).isEqualTo(AuthRoute.Email.SignUp(""))
+        assertThat(step.withEmail("")).isNotEqualTo(step.withEmail(null))
+        assertThat(AuthRoute.Email.stepFor(EmailAuthMode.SignUp, "")).isEqualTo(
+            AuthRoute.Email.SignUp("")
+        )
+        assertThat(AuthRoute.Email.SignUp(TYPED_ADDRESS))
+            .isNotEqualTo(AuthRoute.Email.SignUp(""))
+    }
+
+    /**
+     * The address reaches saved state through kotlinx.serialization, so that round-trip is the one
+     * place an awkward local part could be lost.
+     */
+    @Test
+    fun `awkward addresses round-trip through the key's serializer`() {
         listOf(
             "user+tag@example.com",
             "user name@example.com",
@@ -215,38 +219,44 @@ class FirebaseAuthScreenRouteTest {
             "ada@königsberg.example",
             "用户@例え.jp",
         ).forEach { address ->
-            val encoded = step.withEmail(address)
+            AuthRoute.Email.steps.forEach { prototype ->
+                val step = prototype.withEmail(address)
+                val encoded = Json.encodeToString(
+                    AuthRoute.Email.Step.serializer(),
+                    step,
+                )
+                val decoded = Json.decodeFromString(AuthRoute.Email.Step.serializer(), encoded)
 
-            assertThat(encoded).startsWith("${step.route}?$EMAIL_ARG=")
-            // The encoded form is what travels; nothing that would break the URI survives in it.
-            assertThat(encoded.substringAfter('=')).doesNotContain("#")
-            assertThat(encoded).doesNotContain(" ")
-            assertThat(Uri.parse(encoded).getQueryParameters(EMAIL_ARG))
-                .containsExactly(address)
+                assertThat(decoded).isEqualTo(step)
+                assertThat(decoded.email).isEqualTo(address)
+            }
         }
     }
 
     @Test
     fun `isStep recognises the email steps and nothing else`() {
         AuthRoute.Email.steps.forEach { step ->
-            assertThat(AuthRoute.Email.isStep(step.routePattern)).isTrue()
+            assertThat(AuthRoute.Email.isStep(step)).isTrue()
         }
 
-        assertThat(AuthRoute.Email.isStep(AuthRoute.MethodPicker.routePattern)).isFalse()
-        assertThat(AuthRoute.Email.isStep(AuthRoute.Phone.routePattern)).isFalse()
-        // A live destination.route is always the pattern, never the bare navigation route.
-        assertThat(AuthRoute.Email.isStep(AuthRoute.Email.SignIn.route)).isFalse()
+        assertThat(AuthRoute.Email.isStep(AuthRoute.MethodPicker)).isFalse()
+        assertThat(AuthRoute.Email.isStep(AuthRoute.Phone.EnterPhoneNumber)).isFalse()
         assertThat(AuthRoute.Email.isStep(null)).isFalse()
     }
 
     /**
-     * `AuthRoute.all` has to name every step the sealed hierarchy declares: one left out of its
-     * flow's `steps` list is registered nowhere and throws at whoever navigates to it. Enumerated
-     * from `sealedSubclasses`, since a hand-written list would agree with itself either way.
+     * `allAuthRoutes` is what the reachability test asserts against, built from the same per-flow
+     * `steps` lists the hosts register from.
+     *
+     * Email steps are `data class`es (they carry the address), so `objectInstance` is null for
+     * them and [declaredSteps] falls back to constructing one with default arguments. That is not
+     * a weakening of the check: `createInstance()` throws `IllegalArgumentException("Class should
+     * have a single no-arg constructor: …")` when no fully-defaulted constructor exists, so a step
+     * that grew a required field errors this test loudly rather than dropping out of it.
      */
     @Test
     fun `the full route list names every step the hierarchy declares`() {
-        val all = AuthRoute.all
+        val all = allAuthRoutes
         val standalone = listOf(
             AuthRoute.MethodPicker,
             AuthRoute.Success,
@@ -257,14 +267,12 @@ class FirebaseAuthScreenRouteTest {
                 declaredSteps(AuthRoute.Phone.Step::class) +
                 declaredSteps(AuthRoute.MfaEnrollment.Step::class)
 
-        // Exactly, not at least: the list must not grow a value no host registers either.
         assertThat(all).containsExactlyElementsIn(standalone + flows + declared)
-        // Each flow entry point shares its start step's route, which is the only duplication the
-        // list is allowed to hold — one collision per flow.
-        assertThat(all.map { it.route }.distinct()).hasSize(all.size - flows.size)
+        // A flow entry point and its start step are separate values, so nothing in the list
+        // aliases anything else in it.
+        assertThat(all).containsNoDuplicates()
     }
 
-    /** The same check from the other side: hosts register a flow from its own `steps` list. */
     @Test
     fun `each flow's step list holds exactly the steps it declares`() {
         assertThat(AuthRoute.Email.steps)
@@ -275,16 +283,19 @@ class FirebaseAuthScreenRouteTest {
             .containsExactlyElementsIn(declaredSteps(AuthRoute.MfaEnrollment.Step::class))
     }
 
-    /** Every step object the sealed [stepType] declares, by reflection rather than a literal list. */
+    /**
+     * Every step the sealed [stepType] declares, in its default (address-free) form.
+     *
+     * `objectInstance` alone does not suffice — see the KDoc above. `createInstance()` returns a
+     * non-null `T` or throws, so there is nothing to null-check here.
+     */
     private fun declaredSteps(stepType: KClass<out AuthRoute>): List<AuthRoute> {
         val subclasses = stepType.sealedSubclasses
         assertThat(subclasses).isNotEmpty()
-        return subclasses.map { subclass ->
-            requireNotNull(subclass.objectInstance) {
-                "${subclass.simpleName} is a step but not an object. Steps are named by identity " +
-                        "(the graph registers them, callers pass them), so each has to be a " +
-                        "singleton."
-            }
-        }
+        return subclasses.map { subclass -> subclass.objectInstance ?: subclass.createInstance() }
+    }
+
+    private companion object {
+        const val TYPED_ADDRESS = "user+tag@example.com"
     }
 }

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenSingleProviderBackTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreenSingleProviderBackTest.kt
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.configuration.AuthUIConfiguration
+import com.firebase.ui.auth.configuration.authUIConfiguration
+import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.ui.FirebaseAuthTestTags
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.auth.FirebaseAuth
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The single-provider configurations, where the provider's own step **is** the back stack's only
+ * entry.
+ *
+ * `FirebaseAuthScreen` guards both provider steps' `onCancel` with `!skipsMethodPicker &&`, and
+ * that short-circuit is the only thing standing between an email-only or phone-only configuration
+ * and a back press that has nothing left to pop. Its two halves fail differently:
+ *
+ * * Drop the short-circuit and the flow rebuilds a method picker the configuration never offered —
+ *   a user with one provider is dumped on a one-button chooser they can never leave.
+ * * Drop the "is there anything to pop?" test that `popOrNull` performs before mutating, and the
+ *   back stack empties; `NavDisplay` throws `IllegalArgumentException: NavDisplay backstack cannot
+ *   be empty` from recomposition, so the crash names neither the callback nor this screen.
+ *
+ * @suppress Internal test class
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class FirebaseAuthScreenSingleProviderBackTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var authUI: FirebaseAuthUI
+
+    @Before
+    fun setUp() {
+        FirebaseAuthUI.clearInstanceCache()
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        FirebaseApp.getApps(context).forEach { it.delete() }
+        val app = FirebaseApp.initializeApp(
+            context,
+            FirebaseOptions.Builder()
+                .setApiKey("fake-api-key")
+                .setApplicationId("fake-app-id")
+                .setProjectId("fake-project-id")
+                .build()
+        )!!
+        val auth = mock(FirebaseAuth::class.java)
+        `when`(auth.app).thenReturn(app)
+        authUI = FirebaseAuthUI.create(app, auth)
+    }
+
+    @After
+    fun tearDown() {
+        FirebaseAuthUI.clearInstanceCache()
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        FirebaseApp.getApps(context).forEach {
+            try {
+                it.delete()
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    @Test
+    fun `back at the root of an email-only flow stays on the email step`() {
+        start(emailOnlyConfiguration())
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+
+        // Repeated, not once: a mutation that only *sometimes* empties the stack would pass a
+        // single press. Each press goes through the guarded cancel path.
+        repeat(3) {
+            composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.BACK_BUTTON).performClick()
+            composeTestRule.waitForIdle()
+
+            composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD)
+                .assertIsDisplayed()
+            // The short-circuit held: no method picker was built for a configuration that offers
+            // exactly one provider.
+            composeTestRule.onAllNodesWithTag(FirebaseAuthTestTags.MethodPicker.PROVIDER_LIST)
+                .assertCountEquals(0)
+        }
+    }
+
+    @Test
+    fun `back at the root of a phone-only flow stays on the phone step`() {
+        start(phoneOnlyConfiguration())
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.PhoneNumber.PHONE_NUMBER_FIELD)
+            .assertIsDisplayed()
+
+        repeat(3) {
+            composeTestRule.onNodeWithTag(FirebaseAuthTestTags.PhoneNumber.BACK_BUTTON)
+                .performClick()
+            composeTestRule.waitForIdle()
+
+            composeTestRule.onNodeWithTag(FirebaseAuthTestTags.PhoneNumber.PHONE_NUMBER_FIELD)
+                .assertIsDisplayed()
+            composeTestRule.onAllNodesWithTag(FirebaseAuthTestTags.MethodPicker.PROVIDER_LIST)
+                .assertCountEquals(0)
+        }
+    }
+
+    /**
+     * The other side of the same guard: with the method picker as the root, leaving the email flow
+     * really does return to it, so the short-circuit is not simply suppressing the whole branch.
+     */
+    @Test
+    fun `leaving the email flow returns to the method picker when one is configured`() {
+        start(emailAndPhoneConfiguration())
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.MethodPicker.PROVIDER_LIST)
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText(EMAIL_PROVIDER_LABEL).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.BACK_BUTTON).performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.MethodPicker.PROVIDER_LIST)
+            .assertIsDisplayed()
+    }
+
+    private fun start(configuration: AuthUIConfiguration) {
+        composeTestRule.setContent {
+            FirebaseAuthScreen(
+                configuration = configuration,
+                authUI = authUI,
+                onSignInSuccess = {},
+                onSignInFailure = {},
+                onSignInCancelled = {},
+            )
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun emailOnlyConfiguration(): AuthUIConfiguration = authUIConfiguration {
+        context = ApplicationProvider.getApplicationContext()
+        providers {
+            provider(
+                AuthProvider.Email(
+                    emailLinkActionCodeSettings = null,
+                    passwordValidationRules = emptyList()
+                )
+            )
+        }
+        isCredentialManagerEnabled = false
+    }
+
+    private fun phoneOnlyConfiguration(): AuthUIConfiguration = authUIConfiguration {
+        context = ApplicationProvider.getApplicationContext()
+        providers {
+            provider(
+                AuthProvider.Phone(
+                    defaultNumber = null,
+                    defaultCountryCode = null,
+                    allowedCountries = null
+                )
+            )
+        }
+        isCredentialManagerEnabled = false
+    }
+
+    private fun emailAndPhoneConfiguration(): AuthUIConfiguration = authUIConfiguration {
+        context = ApplicationProvider.getApplicationContext()
+        providers {
+            provider(
+                AuthProvider.Email(
+                    emailLinkActionCodeSettings = null,
+                    passwordValidationRules = emptyList()
+                )
+            )
+            provider(
+                AuthProvider.Phone(
+                    defaultNumber = null,
+                    defaultCountryCode = null,
+                    allowedCountries = null
+                )
+            )
+        }
+        isCredentialManagerEnabled = false
+    }
+
+    private companion object {
+        const val EMAIL_PROVIDER_LABEL = "Sign in with email"
+    }
+}

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/ResetBackStackToTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/ResetBackStackToTest.kt
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens
+
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The contract [resetBackStackTo] has to satisfy, asserted against the helper directly rather than
+ * through a host, so each clause fails on its own.
+ *
+ * Every reset in [FirebaseAuthScreen] and the reauthentication sheet goes through this one
+ * function — success, cancellation, a genuine idle, and the sheet's return to provider selection.
+ * A reset that quietly did nothing would leave a just-failed form underneath the destination it
+ * navigated to, where system back returns a signed-in user to it.
+ *
+ * The two helpers that go with it are asserted here too, for the same reason — [pushUnique], which
+ * is what keeps two `==` keys off one stack, and [isAt], which is the argument-blind destination
+ * test the reset guards ask.
+ *
+ * @suppress Internal test class
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class ResetBackStackToTest {
+
+    /**
+     * Clause 1: an absolute postcondition. Not "pop until you find it" — whatever the stack held,
+     * afterwards it holds exactly the one entry.
+     */
+    @Test
+    fun `a reset always leaves exactly the target entry`() {
+        listOf(
+            listOf(AuthRoute.MethodPicker),
+            listOf(AuthRoute.Email.SignIn()),
+            listOf(AuthRoute.MethodPicker, AuthRoute.Email.SignIn("a@b.com")),
+            listOf(
+                AuthRoute.MethodPicker,
+                AuthRoute.Email.SignIn("a@b.com"),
+                AuthRoute.Email.SignUp("a@b.com"),
+                AuthRoute.Email.ResetPassword("a@b.com"),
+            ),
+            listOf(AuthRoute.Success, AuthRoute.MfaEnrollment.VerifyFactor),
+        ).forEach { initial ->
+            val stack = stackOf(initial)
+
+            stack.resetBackStackTo(AuthRoute.Success)
+
+            assertThat(stack.toList()).containsExactly(AuthRoute.Success)
+        }
+    }
+
+    /**
+     * Clause 2: it can never be a no-op. The hazard is `indexOf(key)` returning `-1`, so a stack
+     * holding nothing resembling the target must still end up holding exactly the target — and a
+     * stack that *already* holds it, buried under other entries, must lose those.
+     */
+    @Test
+    fun `a reset is never a no-op, whether or not the target is already on the stack`() {
+        val targetAbsent = stackOf(
+            listOf(AuthRoute.Email.SignIn(), AuthRoute.Email.SignUp())
+        )
+        targetAbsent.resetBackStackTo(AuthRoute.MethodPicker)
+        assertThat(targetAbsent.toList()).containsExactly(AuthRoute.MethodPicker)
+
+        val targetBuried = stackOf(
+            listOf(AuthRoute.MethodPicker, AuthRoute.Email.SignIn(), AuthRoute.Success)
+        )
+        targetBuried.resetBackStackTo(AuthRoute.MethodPicker)
+        assertThat(targetBuried.toList()).containsExactly(AuthRoute.MethodPicker)
+
+        // Already exactly the target: still one entry afterwards, not two.
+        val targetOnly = stackOf(listOf(AuthRoute.MethodPicker))
+        targetOnly.resetBackStackTo(AuthRoute.MethodPicker)
+        assertThat(targetOnly.toList()).containsExactly(AuthRoute.MethodPicker)
+    }
+
+    /**
+     * Clause 3: the stack is never empty at any single snapshot write.
+     *
+     * `clear()` then `add()` is the evil twin — the same end state, but with a point in the middle
+     * at which stopping leaves the stack empty, and `NavDisplay` throws `IllegalArgumentException:
+     * NavDisplay backstack cannot be empty` from recomposition, far from this call.
+     *
+     * Deliberately *not* claimed: that a recomposition would catch the intermediate. It cannot —
+     * nothing yields between two back-to-back snapshot writes in one synchronous helper, which is
+     * the same fact [pushUnique] relies on to hold two `==` keys between its `add` and its trim.
+     * What is asserted is the code's invariant, by observing every snapshot write the reset
+     * performs and recording the stack's size at each one, so the ordering is pinned rather than
+     * inferred from the end state.
+     */
+    @Test
+    fun `a reset never leaves the stack empty, even momentarily`() {
+        val stack = stackOf(
+            listOf(
+                AuthRoute.MethodPicker,
+                AuthRoute.Email.SignIn("a@b.com"),
+                AuthRoute.Email.SignUp("a@b.com"),
+            )
+        )
+        val sizes = mutableListOf<Int>()
+
+        Snapshot.observe(writeObserver = { sizes += stack.size }) {
+            stack.resetBackStackTo(AuthRoute.Success)
+        }
+
+        assertThat(sizes).isNotEmpty()
+        assertThat(sizes.min()).isAtLeast(1)
+        assertThat(stack.toList()).containsExactly(AuthRoute.Success)
+    }
+
+    /**
+     * Clause 4: a flow entry point resolves to its start step. Two callers pass `startRoute`, which
+     * [getStartRoute] can return as [AuthRoute.Email] or [AuthRoute.Phone] — flow entry points,
+     * which are not registered destinations.
+     */
+    @Test
+    fun `a reset to a flow entry point pushes that flow's start step`() {
+        val toEmail = stackOf(listOf(AuthRoute.Success))
+        toEmail.resetBackStackTo(AuthRoute.Email)
+        assertThat(toEmail.toList()).containsExactly(AuthRoute.Email.SignIn())
+
+        val toPhone = stackOf(listOf(AuthRoute.Success))
+        toPhone.resetBackStackTo(AuthRoute.Phone)
+        assertThat(toPhone.toList()).containsExactly(AuthRoute.Phone.EnterPhoneNumber)
+
+        val toMfa = stackOf(listOf(AuthRoute.Success))
+        toMfa.resetBackStackTo(AuthRoute.MfaEnrollment)
+        assertThat(toMfa.toList()).containsExactly(AuthRoute.MfaEnrollment.SelectFactor)
+    }
+
+    /**
+     * Clause 5, the half this file can actually assert: the *key* left on the stack is the newly
+     * constructed one, not the one that was already there. The `Cancelled` and `Idle` branches
+     * clear the typed address and then reset, expecting a blank start step — a surviving
+     * `SignIn("stale@example.com")` would hand the next session the previous user's address.
+     *
+     * The other half of clause 5 — whether the *composition state* behind that key is fresh — is
+     * conditional (it is only fresh when the pushed key differs from every key already on the
+     * stack) and is not observable here: this test drives the bare list, with no `NavDisplay` and
+     * so no `SaveableStateHolder` to restore anything. `FirebaseAuthScreenEmailRecoveryTest`'s
+     * `a cancellation on the start step keeps the address the recovery carried` covers it
+     * end-to-end, in the direction the product actually depends on.
+     */
+    @Test
+    fun `a reset to the email flow drops the address the old entry carried`() {
+        val stack = stackOf(
+            listOf(
+                AuthRoute.Email.SignIn("stale@example.com"),
+                AuthRoute.Email.SignUp("stale@example.com"),
+            )
+        )
+
+        stack.resetBackStackTo(AuthRoute.Email)
+
+        assertThat(stack.toList()).containsExactly(AuthRoute.Email.SignIn(null))
+    }
+
+    // =============================================================================================
+    // pushUnique — two keys that are == are one entry, so a duplicate must never reach the stack
+    // =============================================================================================
+
+    /**
+     * A push that finds its key already on top must leave the stack unchanged in shape. Two taps
+     * in one frame on any host callback that pushes is the reachable case, and the redundant entry
+     * it would add is a duplicate content key.
+     */
+    @Test
+    fun `pushing the key already on top does not duplicate it`() {
+        val stack = stackOf(listOf(AuthRoute.MethodPicker, AuthRoute.MfaChallenge))
+
+        repeat(3) { stack.pushUnique(AuthRoute.MfaChallenge) }
+
+        assertThat(stack.toList())
+            .containsExactly(AuthRoute.MethodPicker, AuthRoute.MfaChallenge)
+            .inOrder()
+    }
+
+    /**
+     * The buried case: the requested destination ends up on top as the *same* entry rather than a
+     * second copy, so no two keys on the stack are ever `==`, and the entries that sat above its
+     * earlier position go with it. A `NavBackStack` is a plain list and could hold the second copy,
+     * but not safely, so the trim is deliberate. See [pushUnique]'s KDoc for why, and for the
+     * caller-side invariants that keep this case unreachable at every current call site.
+     */
+    @Test
+    fun `pushing a key buried on the stack moves it to the top rather than copying it`() {
+        val stack = stackOf(
+            listOf(
+                AuthRoute.Email.SignIn(),
+                AuthRoute.MfaChallenge,
+                AuthRoute.Email.SignUp("a@b.com"),
+            )
+        )
+
+        stack.pushUnique(AuthRoute.MfaChallenge)
+
+        assertThat(stack.toList()).containsExactly(AuthRoute.Email.SignIn(), AuthRoute.MfaChallenge)
+            .inOrder()
+        assertThat(stack.toList()).containsNoDuplicates()
+    }
+
+    /** A key that is genuinely new is simply pushed, leaving what was there underneath. */
+    @Test
+    fun `pushing an absent key leaves everything underneath it`() {
+        val stack = stackOf(listOf(AuthRoute.MethodPicker))
+
+        stack.pushUnique(AuthRoute.Phone)
+
+        assertThat(stack.toList())
+            .containsExactly(AuthRoute.MethodPicker, AuthRoute.Phone.EnterPhoneNumber)
+            .inOrder()
+    }
+
+    /** Like [resetBackStackTo], a push resolves a flow entry point rather than pushing it. */
+    @Test
+    fun `pushing a flow entry point pushes that flow's start step`() {
+        val stack = stackOf(listOf(AuthRoute.MethodPicker))
+
+        stack.pushUnique(AuthRoute.MfaEnrollment)
+
+        assertThat(stack.last()).isEqualTo(AuthRoute.MfaEnrollment.SelectFactor)
+    }
+
+    /**
+     * The whole point, stated as the invariant rather than as a case list: whatever sequence of
+     * pushes the flow performs, no two keys on the stack are ever equal — because equal keys
+     * produce equal `NavEntry.contentKey`s, and `SaveableStateHolder.SaveableStateProvider`
+     * throws `IllegalArgumentException: Key … was used multiple times` on the second one.
+     */
+    @Test
+    fun `no sequence of pushes can put two equal keys on the stack`() {
+        val stack = stackOf(listOf(AuthRoute.MethodPicker))
+        val pushes = listOf(
+            AuthRoute.Email,
+            AuthRoute.MfaChallenge,
+            AuthRoute.Email,
+            AuthRoute.MfaEnrollment,
+            AuthRoute.MfaEnrollment.VerifyFactor,
+            AuthRoute.MfaEnrollment.VerifyFactor,
+            AuthRoute.MfaChallenge,
+            AuthRoute.Success,
+            AuthRoute.Success,
+            AuthRoute.Phone,
+        )
+
+        pushes.forEach { route ->
+            stack.pushUnique(route)
+
+            assertThat(stack.toList()).containsNoDuplicates()
+            assertThat(stack.last()).isEqualTo(route.toKey())
+            assertThat(stack.size).isAtLeast(1)
+        }
+    }
+
+    // =============================================================================================
+    // isAt — the argument-blind destination test the reset guards ask
+    // =============================================================================================
+
+    /**
+     * `isAt` is what the reset guards ask, and it has to ignore whatever a key carries: a `SignIn`
+     * entry holding an address is still "at" the email flow's start step. A bare `==` on keys is
+     * finer than that and would fire the guard.
+     */
+    @Test
+    fun `isAt ignores the address a step carries`() {
+        assertThat(AuthRoute.Email.SignIn("bob@example.com").isAt(AuthRoute.Email)).isTrue()
+        assertThat(AuthRoute.Email.SignIn().isAt(AuthRoute.Email)).isTrue()
+        assertThat(AuthRoute.Email.SignIn("bob@example.com").isAt(AuthRoute.Email.SignIn()))
+            .isTrue()
+    }
+
+    @Test
+    fun `isAt still separates different destinations, and null is at nothing`() {
+        assertThat(AuthRoute.Email.SignUp("bob@example.com").isAt(AuthRoute.Email)).isFalse()
+        assertThat(AuthRoute.MethodPicker.isAt(AuthRoute.Email)).isFalse()
+        assertThat(AuthRoute.Success.isAt(AuthRoute.MethodPicker)).isFalse()
+        assertThat(AuthRoute.MethodPicker.isAt(AuthRoute.MethodPicker)).isTrue()
+        assertThat(null.isAt(AuthRoute.Email)).isFalse()
+        assertThat(null.isAt(AuthRoute.MethodPicker)).isFalse()
+    }
+
+    private fun stackOf(keys: List<NavKey>): NavBackStack<NavKey> =
+        NavBackStack<NavKey>().apply { addAll(keys) }
+}

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthHostDestinationsTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthHostDestinationsTest.kt
@@ -50,12 +50,12 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /**
- * Both hosts of the email flow install the same destinations through the same
+ * Both hosts of the email flow install the same destinations, through the same
  * [emailAuthDestinations] extension: [FirebaseAuthScreen]'s graph and the reauthentication
- * sheet's own one.
+ * sheet's own one. Registering them in only one place is what lets the two drift.
  *
- * These drive the default email UI, so they also pin the back arrow stepping back through the
- * flow rather than leaving it.
+ * These drive the default email UI, so they also pin what the back arrow does: it steps back
+ * through the flow rather than leaving it, even when email is the flow's start destination.
  *
  * @suppress Internal test class
  */
@@ -123,7 +123,8 @@ class EmailAuthHostDestinationsTest {
         composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.EMAIL_FIELD).assertIsDisplayed()
         composeTestRule.onNodeWithText(TYPED_EMAIL).assertIsDisplayed()
 
-        // Email is this flow's start destination, so sign-in is what lies under sign-up.
+        // Email is this flow's start destination, so before the split there was nothing under
+        // sign-up for the back arrow to reach and it did nothing at all.
         composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.BACK_BUTTON).performClick()
         composeTestRule.waitForIdle()
 
@@ -132,7 +133,9 @@ class EmailAuthHostDestinationsTest {
 
     /**
      * A genuine reset to [com.firebase.ui.auth.AuthState.Idle] sends the flow back to its start
-     * route, which is the sign-in step, so a reset from a sub-step does not keep the sub-step.
+     * route. That start route is now the sign-in *step* rather than the whole email screen, so a
+     * reset from a sub-step no longer silently keeps the sub-step — which is what a multi-provider
+     * flow always did by returning to the method picker.
      */
     @Test
     fun `a genuine idle reset returns to the flow's start step`() {
@@ -151,7 +154,8 @@ class EmailAuthHostDestinationsTest {
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignUp.EMAIL_FIELD).assertIsDisplayed()
 
-        // Loading is not a notification, so the Idle that follows it is a real reset.
+        // Loading is not a notification, so the Idle that follows it is a real reset rather than
+        // a consumed one-shot state.
         composeTestRule.runOnIdle { authUI.updateAuthState(AuthState.Loading()) }
         composeTestRule.waitForIdle()
         composeTestRule.runOnIdle { authUI.updateAuthState(AuthState.Idle) }
@@ -177,7 +181,8 @@ class EmailAuthHostDestinationsTest {
             .performClick()
         composeTestRule.waitForIdle()
 
-        // Reaching it proves the sheet registered it; the address proves the argument carried.
+        // Reaching this destination at all proves the sheet registered it; the address proves it
+        // was reached through the same argument-carrying navigation.
         composeTestRule.onNodeWithTag(FirebaseAuthTestTags.ResetPassword.EMAIL_FIELD)
             .assertIsDisplayed()
         composeTestRule.onNodeWithText(TYPED_EMAIL).assertIsDisplayed()
@@ -191,12 +196,16 @@ class EmailAuthHostDestinationsTest {
     }
 
     /**
-     * "Which flow is open" and "which step the user is on" are different facts. Exactly one thing
-     * records the step: the sheet's own `rememberNavController`, whose back stack Compose saves
-     * and restores, arguments included. `ReauthPresentationState` records the flow, and the
-     * built-in sheet never reads it.
+     * The sheet registers four email destinations rather than one, so "which flow is open" and
+     * "which step the user is on" are different facts. Exactly one thing records the step: the
+     * sheet's own `rememberNavBackStack`, which serializes its keys — the address each carries
+     * included — across recreation.
      *
-     * Pins that the step, and the address it was entered with, survive a recreation.
+     * `ReauthPresentationState` records the *flow*, and the built-in sheet never reads it — that
+     * marker belongs to the custom reauth slot, whose email sub-flow is an unhosted
+     * `EmailAuthScreen` keeping its own mode in `rememberSaveable`. So the two cannot disagree
+     * about a step. This pins the half nothing covered: that the step, and the address it was
+     * entered with, come back after a recreation rather than resetting to the flow's start step.
      */
     @Test
     fun `the reauthentication sheet keeps its email step across a recreation`() {
@@ -223,7 +232,8 @@ class EmailAuthHostDestinationsTest {
         // And the address it was entered with, which travels as the route argument.
         composeTestRule.onNodeWithText(TYPED_EMAIL).assertIsDisplayed()
 
-        // Back still walks the flow, so what was restored is the real stack.
+        // Back still walks the flow rather than leaving it, so what was restored is the real stack
+        // and not a single freshly created entry.
         composeTestRule.onNodeWithTag(FirebaseAuthTestTags.ResetPassword.BACK_BUTTON).performClick()
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.EMAIL_FIELD).assertIsDisplayed()

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthRouteNavigationTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthRouteNavigationTest.kt
@@ -27,15 +27,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.hasProgressBarRangeInfo
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.ComposeNavigator
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
-import androidx.navigation.get
+import androidx.compose.animation.togetherWith
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
 import androidx.test.core.app.ApplicationProvider
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
@@ -48,7 +49,8 @@ import com.firebase.ui.auth.configuration.string_provider.LocalAuthUIStringProvi
 import com.firebase.ui.auth.ui.components.LocalTopLevelDialogController
 import com.firebase.ui.auth.ui.components.rememberTopLevelDialogController
 import com.firebase.ui.auth.ui.screens.AuthRoute
-import com.firebase.ui.auth.ui.screens.EMAIL_ARG
+import com.firebase.ui.auth.ui.screens.mode
+import com.firebase.ui.auth.ui.screens.popOrNull
 import com.firebase.ui.auth.ui.screens.resetBackStackTo
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.FirebaseApp
@@ -66,13 +68,13 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /**
- * Covers the one-destination-per-[EmailAuthMode] email graph.
+ * Covers the email flow's one destination per [EmailAuthMode].
  *
  * The unit under test is [emailAuthDestinations] — the same graph extension both
  * [com.firebase.ui.auth.ui.screens.FirebaseAuthScreen] and the reauthentication sheet install —
- * hosted here in a bare [NavHost] so the back stack, its depth and the arguments it carries can
- * be read directly. The sign-in step is this graph's start destination, the shape a
- * single-provider email configuration produces and the one every back-stack hazard turns on.
+ * hosted here in a bare `NavDisplay` so the back stack and its depth can be read directly. The
+ * flow's sign-in step is this graph's start destination, which is the shape a single-provider
+ * email configuration produces and the one every back-stack hazard here turns on.
  *
  * @suppress Internal test class
  */
@@ -87,9 +89,10 @@ class EmailAuthRouteNavigationTest {
     private lateinit var authUI: FirebaseAuthUI
     private lateinit var stringProvider: DefaultAuthUIStringProvider
 
-    private var navController: NavHostController? = null
+    private var backStack: NavBackStack<NavKey>? = null
     private var lastState: EmailAuthContentState? = null
     private var pressBack: (() -> Unit)? = null
+    private var backDispatcher: androidx.activity.OnBackPressedDispatcher? = null
 
     @Before
     fun setUp() {
@@ -112,9 +115,10 @@ class EmailAuthRouteNavigationTest {
 
     @After
     fun tearDown() {
-        navController = null
+        backStack = null
         lastState = null
         pressBack = null
+        backDispatcher = null
         FirebaseAuthUI.clearInstanceCache()
         FirebaseApp.getApps(applicationContext).forEach {
             try {
@@ -124,7 +128,9 @@ class EmailAuthRouteNavigationTest {
         }
     }
 
+    // =============================================================================================
     // User-initiated switches
+    // =============================================================================================
 
     @Test
     fun `going to sign-up pushes the sign-up destination carrying the typed address`() {
@@ -133,12 +139,12 @@ class EmailAuthRouteNavigationTest {
 
         goTo(EmailAuthMode.SignUp)
 
-        assertThat(currentRoute()).isEqualTo(AuthRoute.Email.SignUp.routePattern)
-        assertThat(currentEmailArgument()).isEqualTo(TYPED_EMAIL)
+        assertThat(currentStep()).isEqualTo(AuthRoute.Email.SignUp(TYPED_EMAIL))
+        assertThat(currentStepEmail()).isEqualTo(TYPED_EMAIL)
         assertThat(renderedEmail()).isEqualTo(TYPED_EMAIL)
-        assertThat(backStackRoutes()).containsExactly(
-            AuthRoute.Email.SignIn.routePattern,
-            AuthRoute.Email.SignUp.routePattern,
+        assertThat(backStackTypes()).containsExactly(
+            AuthRoute.Email.SignIn::class,
+            AuthRoute.Email.SignUp::class,
         ).inOrder()
     }
 
@@ -155,8 +161,8 @@ class EmailAuthRouteNavigationTest {
         ).forEach { target ->
             goTo(target)
 
-            assertThat(currentRoute()).isEqualTo(AuthRoute.Email.stepFor(target).routePattern)
-            assertThat(currentEmailArgument()).isEqualTo(TYPED_EMAIL)
+            assertThat(currentStep()).isEqualTo(AuthRoute.Email.stepFor(target, TYPED_EMAIL))
+            assertThat(currentStepEmail()).isEqualTo(TYPED_EMAIL)
             assertThat(renderedEmail()).isEqualTo(TYPED_EMAIL)
         }
     }
@@ -168,7 +174,7 @@ class EmailAuthRouteNavigationTest {
         EmailAuthMode.entries.forEach { target ->
             goTo(target)
 
-            assertThat(currentRoute()).isEqualTo(AuthRoute.Email.stepFor(target).routePattern)
+            assertThat(currentStep()?.mode).isEqualTo(target)
             assertThat(renderedMode()).isEqualTo(target)
         }
     }
@@ -181,15 +187,15 @@ class EmailAuthRouteNavigationTest {
         goTo(EmailAuthMode.ResetPassword)
 
         back()
-        assertThat(currentRoute()).isEqualTo(AuthRoute.Email.SignUp.routePattern)
+        assertThat(currentStep()).isEqualTo(AuthRoute.Email.SignUp(TYPED_EMAIL))
 
         back()
-        assertThat(currentRoute()).isEqualTo(AuthRoute.Email.SignIn.routePattern)
+        assertThat(currentStep()).isInstanceOf(AuthRoute.Email.SignIn::class.java)
     }
 
     /**
-     * `launchSingleTop` alone only de-duplicates a target already on top, so toggling between two
-     * steps must not add an entry per tap.
+     * Toggling between two steps must not add an entry per tap: the stack holds those two steps
+     * however long the user keeps tapping.
      */
     @Test
     fun `toggling sign-in and sign-up keeps the back stack bounded`() {
@@ -198,20 +204,21 @@ class EmailAuthRouteNavigationTest {
 
         repeat(6) {
             goTo(EmailAuthMode.SignUp)
-            assertThat(backStackRoutes()).containsExactly(
-                AuthRoute.Email.SignIn.routePattern,
-                AuthRoute.Email.SignUp.routePattern,
+            assertThat(backStackTypes()).containsExactly(
+                AuthRoute.Email.SignIn::class,
+                AuthRoute.Email.SignUp::class,
             ).inOrder()
 
             goTo(EmailAuthMode.SignIn)
-            assertThat(backStackRoutes())
-                .containsExactly(AuthRoute.Email.SignIn.routePattern)
+            assertThat(backStackTypes())
+                .containsExactly(AuthRoute.Email.SignIn::class)
         }
     }
 
     /**
      * Switching to a step already beneath the current one pops back to it instead of stacking a
-     * second copy, and the address just typed wins over the one that entry was created with.
+     * second copy — and the address the user has *just* typed wins over the one that entry was
+     * created with, which is what re-pushing it buys.
      */
     @Test
     fun `switching back to a step already on the stack keeps the newest address`() {
@@ -221,8 +228,8 @@ class EmailAuthRouteNavigationTest {
 
         goTo(EmailAuthMode.SignIn)
 
-        assertThat(backStackRoutes()).containsExactly(AuthRoute.Email.SignIn.routePattern)
-        assertThat(currentEmailArgument()).isEqualTo(TYPED_EMAIL)
+        assertThat(backStackTypes()).containsExactly(AuthRoute.Email.SignIn::class)
+        assertThat(currentStepEmail()).isEqualTo(TYPED_EMAIL)
         assertThat(renderedEmail()).isEqualTo(TYPED_EMAIL)
     }
 
@@ -240,14 +247,16 @@ class EmailAuthRouteNavigationTest {
         assertThat(composeTestRule.runOnIdle { lastState?.password }).isEmpty()
     }
 
-    // Argument encoding
+    // =============================================================================================
+    // The address the key carries
+    // =============================================================================================
 
     /**
-     * The address travels in the route's query string, so every character a local part or domain
-     * may legally hold has to survive `Uri.encode` on the way out and the decode on the way in.
+     * Every character a local part or domain may legally hold has to survive being carried on the
+     * key through a live mode switch.
      */
     @Test
-    fun `awkward addresses round-trip through the route argument unchanged`() {
+    fun `awkward addresses survive a mode switch unchanged`() {
         start()
 
         listOf(
@@ -262,18 +271,90 @@ class EmailAuthRouteNavigationTest {
             typeEmail(address)
             goTo(EmailAuthMode.SignUp)
 
-            assertThat(currentEmailArgument()).isEqualTo(address)
+            assertThat(currentStepEmail()).isEqualTo(address)
             assertThat(renderedEmail()).isEqualTo(address)
 
             goTo(EmailAuthMode.SignIn)
         }
     }
 
-    // Errors belong to the host
+    /**
+     * A key carries the address as a field, so `SignIn("")` and `SignIn(null)` are different keys
+     * and an empty address is a state the flow can genuinely be entered in — by
+     * `AuthSuccessUiContext.onNavigate`, by a restored back stack, or by a mode switch made before
+     * anything was typed.
+     *
+     * The destination collapses the two back together, with `step.email?.ifEmpty { null } ?:
+     * prefillEmail()`, so an empty address falls back to the prefill exactly as a null one does
+     * rather than blanking a field the host had populated. Asserted here, against the destination,
+     * because the same claim written as an expression (`SignIn("").email?.ifEmpty { null }`) is a
+     * test of the Kotlin stdlib and survives the product losing `?.ifEmpty { null }` entirely.
+     */
+    @Test
+    fun `a step entered with an empty address falls back to the prefill`() {
+        start(startKey = AuthRoute.Email.SignIn(""), prefillEmail = PREFILL_EMAIL)
+
+        // The key really does carry the empty address — otherwise this would prove nothing.
+        assertThat(currentStepEmail()).isEmpty()
+        assertThat(renderedEmail()).isEqualTo(PREFILL_EMAIL)
+    }
+
+    /** The same fallback for a null address, which is the case the empty one has to match. */
+    @Test
+    fun `a step entered with no address falls back to the prefill`() {
+        start(startKey = AuthRoute.Email.SignIn(null), prefillEmail = PREFILL_EMAIL)
+
+        assertThat(currentStepEmail()).isNull()
+        assertThat(renderedEmail()).isEqualTo(PREFILL_EMAIL)
+    }
+
+    /** The direction that must *not* collapse: a real address on the key beats the prefill. */
+    @Test
+    fun `an address on the key overrides the prefill`() {
+        start(startKey = AuthRoute.Email.SignIn(TYPED_EMAIL), prefillEmail = PREFILL_EMAIL)
+
+        assertThat(renderedEmail()).isEqualTo(TYPED_EMAIL)
+    }
 
     /**
-     * `AuthState.Error` is one event on a shared flow. A hosted step neither moves the flow nor
-     * raises the dialog, so it cannot race the host's own recovery actions.
+     * The address is a field on a `@Serializable` key, restored by `rememberNavBackStack`
+     * serializing the keys — the one place an awkward address could be lost across recreation.
+     *
+     * Driven through a real recreation rather than a direct `Json` round-trip (which
+     * `FirebaseAuthScreenRouteTest` covers separately), so what is asserted is the back stack the
+     * user actually comes back to.
+     */
+    @Test
+    fun `the address on a key survives Activity recreation`() {
+        val restorationTester = StateRestorationTester(composeTestRule)
+        restorationTester.setContent { EmailFlowHost(emailConfiguration()) }
+        composeTestRule.waitForIdle()
+
+        typeEmail(AWKWARD_EMAIL)
+        goTo(EmailAuthMode.SignUp)
+        assertThat(currentStep()).isEqualTo(AuthRoute.Email.SignUp(AWKWARD_EMAIL))
+
+        restorationTester.emulateSavedInstanceStateRestore()
+        composeTestRule.waitForIdle()
+
+        assertThat(backStackKeys()).containsExactly(
+            AuthRoute.Email.SignIn(),
+            AuthRoute.Email.SignUp(AWKWARD_EMAIL),
+        ).inOrder()
+        assertThat(currentStepEmail()).isEqualTo(AWKWARD_EMAIL)
+        assertThat(renderedEmail()).isEqualTo(AWKWARD_EMAIL)
+    }
+
+    // =============================================================================================
+    // Errors belong to the host
+    // =============================================================================================
+
+    /**
+     * `AuthState.Error` is one event on a shared flow, and the top-level dialog controller
+     * de-duplicates first-wins on it. A hosted step reacting to it as well would race the host —
+     * whose recovery actions are the ones that know what lies outside the email flow — and
+     * composition order would decide which set the user got. A hosted step therefore does
+     * neither: it does not move the flow and it does not raise the dialog.
      */
     @Test
     fun `a hosted step neither navigates nor raises a dialog on an error`() {
@@ -287,12 +368,14 @@ class EmailAuthRouteNavigationTest {
         }
         composeTestRule.waitForIdle()
 
-        assertThat(backStackRoutes()).containsExactly(AuthRoute.Email.SignIn.routePattern)
+        assertThat(backStackTypes()).containsExactly(AuthRoute.Email.SignIn::class)
         assertThat(renderedEmail()).isEqualTo(TYPED_EMAIL)
         composeTestRule.onAllNodesWithText(stringProvider.errorDialogTitle).assertCountEquals(0)
     }
 
+    // =============================================================================================
     // Steps the configuration does not offer
+    // =============================================================================================
 
     @Test
     fun `reauthentication cannot switch to sign-up`() {
@@ -301,7 +384,7 @@ class EmailAuthRouteNavigationTest {
 
         goTo(EmailAuthMode.SignUp)
 
-        assertThat(currentRoute()).isEqualTo(AuthRoute.Email.SignIn.routePattern)
+        assertThat(currentStep()).isInstanceOf(AuthRoute.Email.SignIn::class.java)
     }
 
     @Test
@@ -311,7 +394,7 @@ class EmailAuthRouteNavigationTest {
 
         goTo(EmailAuthMode.EmailLinkSignIn)
 
-        assertThat(currentRoute()).isEqualTo(AuthRoute.Email.SignIn.routePattern)
+        assertThat(currentStep()).isInstanceOf(AuthRoute.Email.SignIn::class.java)
     }
 
     @Test
@@ -321,24 +404,25 @@ class EmailAuthRouteNavigationTest {
 
         goTo(EmailAuthMode.EmailLinkSignIn)
 
-        assertThat(currentRoute()).isEqualTo(AuthRoute.Email.SignIn.routePattern)
+        assertThat(currentStep()).isInstanceOf(AuthRoute.Email.SignIn::class.java)
     }
 
     /**
-     * `AuthSuccessUiContext.onNavigate` takes any [AuthRoute], so a host — or a restored back
-     * stack — can reach a step the configuration switched off. The bounce keeps it unreachable,
-     * and keeps the address.
+     * `AuthSuccessUiContext.onNavigate` takes any [AuthRoute], so a host can hand the graph a step
+     * the configuration switched off; a restored back stack can do the same. The bounce is what
+     * keeps such a step unreachable, and it keeps the address.
      */
     @Test
     fun `the sign-up destination bounces to sign-in when account creation is not offered`() {
         start(configuration = reauthConfiguration())
 
-        navigateDirectlyTo(AuthRoute.Email.SignUp)
+        navigateDirectlyTo(AuthRoute.Email.SignUp())
 
-        assertThat(currentRoute()).isEqualTo(AuthRoute.Email.SignIn.routePattern)
-        assertThat(currentEmailArgument()).isEqualTo(TYPED_EMAIL)
-        // Gone, not left underneath, where back would return to it and bounce again.
-        assertThat(backStackRoutes()).containsExactly(AuthRoute.Email.SignIn.routePattern)
+        assertThat(currentStep()).isInstanceOf(AuthRoute.Email.SignIn::class.java)
+        assertThat(currentStepEmail()).isEqualTo(TYPED_EMAIL)
+        // The bounced step is gone rather than left underneath, where back would return to it and
+        // bounce again, leaving the user unable to go back at all.
+        assertThat(backStackTypes()).containsExactly(AuthRoute.Email.SignIn::class)
     }
 
     /** The same exposure, and now the same guard, for a provider with email-link disabled. */
@@ -346,16 +430,17 @@ class EmailAuthRouteNavigationTest {
     fun `the email-link destination bounces to sign-in when the provider disables it`() {
         start(configuration = emailConfiguration(isEmailLinkSignInEnabled = false))
 
-        navigateDirectlyTo(AuthRoute.Email.EmailLinkSignIn)
+        navigateDirectlyTo(AuthRoute.Email.EmailLinkSignIn())
 
-        assertThat(currentRoute()).isEqualTo(AuthRoute.Email.SignIn.routePattern)
-        assertThat(currentEmailArgument()).isEqualTo(TYPED_EMAIL)
-        assertThat(backStackRoutes()).containsExactly(AuthRoute.Email.SignIn.routePattern)
+        assertThat(currentStep()).isInstanceOf(AuthRoute.Email.SignIn::class.java)
+        assertThat(currentStepEmail()).isEqualTo(TYPED_EMAIL)
+        assertThat(backStackTypes()).containsExactly(AuthRoute.Email.SignIn::class)
     }
 
     /**
-     * The redirect is not instant: against the configured 700 ms cross-fade the bounced step is on
-     * screen for the whole transition, so it must render something.
+     * The redirect is not instant to the eye: against the configured 700 ms cross-fade the step
+     * being left behind is on screen for the whole transition, so rendering nothing there would
+     * show a hole rather than a frame.
      */
     @Test
     fun `a step that is redirecting out of itself still renders something`() {
@@ -368,18 +453,23 @@ class EmailAuthRouteNavigationTest {
         }
         composeTestRule.waitForIdle()
 
-        // No test tag: main-source tags come from the public FirebaseAuthTestTags registry only.
+        // No test tag: main-source tags have to come from the public FirebaseAuthTestTags
+        // registry, and a placeholder nobody addresses does not earn a place in it. The
+        // indeterminate progress semantics are what a user actually sees here.
         composeTestRule
             .onNode(hasProgressBarRangeInfo(ProgressBarRangeInfo.Indeterminate))
             .assertIsDisplayed()
     }
 
+    // =============================================================================================
     // Resets
+    // =============================================================================================
 
     /**
      * [resetBackStackTo] is what every reset in
      * [com.firebase.ui.auth.ui.screens.FirebaseAuthScreen] goes through — success, cancellation
-     * and a genuine idle — and must leave nothing of the flow underneath what it lands on.
+     * and a genuine idle. A reset that quietly did nothing would leave the whole flow sitting
+     * underneath what it navigated to.
      */
     @Test
     fun `a reset clears the flow whatever the back stack holds`() {
@@ -390,7 +480,7 @@ class EmailAuthRouteNavigationTest {
 
         reset(AuthRoute.MethodPicker)
 
-        assertThat(backStackRoutes()).containsExactly(AuthRoute.MethodPicker.routePattern)
+        assertThat(backStackKeys()).containsExactly(AuthRoute.MethodPicker)
     }
 
     /** Repeated resets must not pile up either, whichever destination they land on. */
@@ -400,14 +490,17 @@ class EmailAuthRouteNavigationTest {
 
         repeat(4) {
             reset(AuthRoute.MethodPicker)
-            assertThat(backStackRoutes()).containsExactly(AuthRoute.MethodPicker.routePattern)
+            assertThat(backStackKeys()).containsExactly(AuthRoute.MethodPicker)
 
             reset(AuthRoute.Email)
-            assertThat(backStackRoutes()).containsExactly(AuthRoute.Email.SignIn.routePattern)
+            assertThat(backStackKeys()).containsExactly(AuthRoute.Email.SignIn())
         }
     }
 
-    /** A reset lands on a single entry, leaving nothing inside the flow for system back. */
+    /**
+     * A reset lands on a single entry, so there is nothing left inside the flow for system back
+     * to return to.
+     */
     @Test
     fun `system back after a reset has nothing in the flow to return to`() {
         start()
@@ -416,11 +509,38 @@ class EmailAuthRouteNavigationTest {
 
         back()
 
-        assertThat(currentRoute()).isEqualTo(AuthRoute.Email.SignIn.routePattern)
-        assertThat(backStackRoutes()).containsExactly(AuthRoute.Email.SignIn.routePattern)
+        assertThat(currentStep()).isInstanceOf(AuthRoute.Email.SignIn::class.java)
+        assertThat(backStackKeys()).containsExactly(AuthRoute.Email.SignIn())
     }
 
+    /**
+     * S19/S20: a root back press has to fall through to whatever hosts the graph — the Activity on
+     * the main display, the `ModalBottomSheet` in the reauthentication sheet, where falling through
+     * is what dismisses it.
+     *
+     * `NavDisplay` enables its back handler only while `scene.previousEntries.isNotEmpty()`, so it
+     * swallows nothing at the root — which is why `onBack` only has to be safe for the non-root
+     * case and why the sheet does not need to dismiss from `onBack`. Pinned here because
+     * it is an unwritten property of the navigation library, not of this code: if a future version
+     * enabled the handler at the root, root back would start being swallowed and the sheet would
+     * stop dismissing, silently.
+     */
+    @Test
+    fun `the display leaves root back to its host`() {
+        start()
+        goTo(EmailAuthMode.SignUp)
+
+        assertThat(hasEnabledBackCallbacks()).isTrue()
+
+        back()
+
+        assertThat(backStackKeys()).hasSize(1)
+        assertThat(hasEnabledBackCallbacks()).isFalse()
+    }
+
+    // =============================================================================================
     // Harness
+    // =============================================================================================
 
     private fun emailConfiguration(
         isEmailLinkSignInEnabled: Boolean = true,
@@ -451,8 +571,14 @@ class EmailAuthRouteNavigationTest {
         isReauthenticationMode = true,
     )
 
-    private fun start(configuration: AuthUIConfiguration = emailConfiguration()) {
-        composeTestRule.setContent { EmailFlowHost(configuration) }
+    private fun start(
+        configuration: AuthUIConfiguration = emailConfiguration(),
+        startKey: NavKey = AuthRoute.Email.startKey(),
+        prefillEmail: String? = null,
+    ) {
+        composeTestRule.setContent {
+            EmailFlowHost(configuration, startKey = startKey, prefillEmail = prefillEmail)
+        }
         composeTestRule.waitForIdle()
     }
 
@@ -477,13 +603,13 @@ class EmailAuthRouteNavigationTest {
     /** Enters [step] the way a host's `onNavigate` does — bypassing the screen's own guards. */
     private fun navigateDirectlyTo(step: AuthRoute.Email.Step) {
         composeTestRule.runOnIdle {
-            requireNotNull(navController).navigate(step.withEmail(TYPED_EMAIL))
+            requireNotNull(backStack).add(step.withEmail(TYPED_EMAIL))
         }
         composeTestRule.waitForIdle()
     }
 
     private fun reset(route: AuthRoute) {
-        composeTestRule.runOnIdle { requireNotNull(navController).resetBackStackTo(route) }
+        composeTestRule.runOnIdle { requireNotNull(backStack).resetBackStackTo(route) }
         composeTestRule.waitForIdle()
     }
 
@@ -492,34 +618,41 @@ class EmailAuthRouteNavigationTest {
         composeTestRule.waitForIdle()
     }
 
-    private fun currentRoute(): String? =
-        composeTestRule.runOnIdle { navController?.currentBackStackEntry?.destination?.route }
-
-    private fun currentEmailArgument(): String? = composeTestRule.runOnIdle {
-        navController?.currentBackStackEntry?.arguments?.getString(EMAIL_ARG)
+    private fun hasEnabledBackCallbacks(): Boolean = composeTestRule.runOnIdle {
+        requireNotNull(backDispatcher).hasEnabledCallbacks()
     }
 
-    /**
-     * The composed destinations on the stack, bottom to top, read from the [ComposeNavigator]'s
-     * own back stack. `NavController.currentBackStack` is `@RestrictTo(LIBRARY_GROUP)`.
-     */
-    private fun backStackRoutes(): List<String?> = composeTestRule.runOnIdle {
-        navController?.navigatorProvider?.get(ComposeNavigator::class)
-            ?.backStack?.value
-            ?.map { it.destination.route }
-            .orEmpty()
+    private fun currentStep(): AuthRoute.Email.Step? =
+        composeTestRule.runOnIdle { backStack?.lastOrNull() as? AuthRoute.Email.Step }
+
+    /** The address the top step carries, read straight off the key. */
+    private fun currentStepEmail(): String? = composeTestRule.runOnIdle {
+        (backStack?.lastOrNull() as? AuthRoute.Email.Step)?.email
     }
+
+    /** The keys on the stack, bottom to top — the back stack is itself a public list. */
+    private fun backStackKeys(): List<NavKey> =
+        composeTestRule.runOnIdle { backStack?.toList().orEmpty() }
+
+    /** Types only, for the assertions that must ignore which address a key carries. */
+    private fun backStackTypes(): List<Any> =
+        composeTestRule.runOnIdle { backStack?.map { it::class }.orEmpty() }
 
     private fun renderedEmail(): String? = composeTestRule.runOnIdle { lastState?.email }
 
     private fun renderedMode(): EmailAuthMode? = composeTestRule.runOnIdle { lastState?.mode }
 
     @Composable
-    private fun EmailFlowHost(configuration: AuthUIConfiguration) {
-        val controller = rememberNavController()
+    private fun EmailFlowHost(
+        configuration: AuthUIConfiguration,
+        startKey: NavKey = AuthRoute.Email.startKey(),
+        prefillEmail: String? = null,
+    ) {
+        val stack = rememberNavBackStack(startKey)
         val dispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
         SideEffect {
-            navController = controller
+            backStack = stack
+            backDispatcher = dispatcher
             pressBack = dispatcher?.let { { it.onBackPressed() } }
         }
 
@@ -530,31 +663,43 @@ class EmailAuthRouteNavigationTest {
             LocalAuthUIStringProvider provides configuration.stringProvider,
             LocalTopLevelDialogController provides dialogController,
         ) {
-            NavHost(
-                navController = controller,
-                startDestination = AuthRoute.Email.routePattern,
-                // Transitions would keep two email destinations composed at once.
-                enterTransition = { EnterTransition.None },
-                exitTransition = { ExitTransition.None },
-                popEnterTransition = { EnterTransition.None },
-                popExitTransition = { ExitTransition.None },
-            ) {
-                emailAuthDestinations(
-                    navController = controller,
-                    context = applicationContext,
-                    configuration = configuration,
-                    authUI = authUI,
-                    content = { state -> lastState = state },
-                    onCancel = {},
-                )
-                // Somewhere outside the flow for a reset to land on, standing in for the picker.
-                composable(AuthRoute.MethodPicker.routePattern) { }
-            }
+            NavDisplay(
+                backStack = stack,
+                onBack = { stack.popOrNull() },
+                // Transitions would keep two email destinations composed at once, and the routing
+                // under test has nothing to do with how it animates. That the *configured*
+                // transitions reach a step-to-step move is pinned on the real host instead.
+                transitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+                popTransitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+                predictivePopTransitionSpec = { _ ->
+                    EnterTransition.None togetherWith ExitTransition.None
+                },
+                entryProvider = entryProvider {
+                    emailAuthDestinations(
+                        backStack = stack,
+                        context = applicationContext,
+                        configuration = configuration,
+                        authUI = authUI,
+                        content = { state -> lastState = state },
+                        onCancel = {},
+                        prefillEmail = { prefillEmail },
+                    )
+                    // Somewhere outside the flow for a reset to land on, standing in for the method
+                    // picker the real host resets to when more than one provider is configured.
+                    entry<AuthRoute.MethodPicker> { }
+                },
+            )
             dialogController.CurrentDialog()
         }
     }
 
     private companion object {
         const val TYPED_EMAIL = "user+tag@example.com"
+
+        /** An address the *host* fixed, which a step with no address of its own falls back to. */
+        const val PREFILL_EMAIL = "prefilled@example.com"
+
+        /** Every awkward character class a local part or domain may hold, in one address. */
+        const val AWKWARD_EMAIL = "user name#hash?q=1&more@königsberg.example"
     }
 }

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreenModeSwitchTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreenModeSwitchTest.kt
@@ -47,7 +47,9 @@ import org.robolectric.annotation.Config
  * [EmailAuthScreen] used on its own, with nothing outside it driving the mode — the shape
  * `EmailAuthSlotDemoActivity` and the custom reauthentication content both use.
  *
- * Guards that a mode switch clears only the mode-specific secrets and keeps the typed address.
+ * Switching modes used to blank *every* text field, so a user who typed their address on the
+ * sign-in form and then tapped through to sign-up, password recovery or email-link sign-in had to
+ * type it again. Only the secrets are mode-specific and may be cleared.
  *
  * @suppress Internal test class
  */
@@ -127,7 +129,10 @@ class EmailAuthScreenModeSwitchTest {
         assertThat(state().displayName).isEmpty()
     }
 
-    /** Without a host driving it, the screen owns the mode itself. */
+    /**
+     * Without a host driving it the screen owns the mode itself, which is what keeps standalone
+     * callers working unchanged.
+     */
     @Test
     fun `the unhosted screen drives its own mode from local state`() {
         start()
@@ -142,8 +147,11 @@ class EmailAuthScreenModeSwitchTest {
     }
 
     /**
-     * The screen never moves itself on an error: unhosted, the user stays on the form with
-     * everything they typed, password included.
+     * Signing in with an address that has no account used to hop this screen to sign-up on its
+     * own. That decision now belongs to a host — only a host knows what lies outside the email
+     * flow, and two observers of one shared error event raced each other for the recovery dialog.
+     * Unhosted, the user stays on the form with everything they typed, including the password,
+     * which nothing asked to clear.
      */
     @Test
     fun `an unhosted screen stays put and keeps what was typed when the account is not found`() {
@@ -165,7 +173,7 @@ class EmailAuthScreenModeSwitchTest {
         assertThat(state().password).isEqualTo("hunter2")
     }
 
-    /** The same for an address already taken. */
+    /** The same for an address already taken, which used to hop the other way. */
     @Test
     fun `an unhosted screen stays put when the address is already in use`() {
         start()
@@ -189,8 +197,9 @@ class EmailAuthScreenModeSwitchTest {
     }
 
     /**
-     * `mode` and `onNavigateToMode` are two halves of one contract; either alone leaves every
-     * switch control silently inert, so it is rejected.
+     * `mode` and `onNavigateToMode` are two halves of one contract. Either alone leaves every
+     * switch control silently inert — a fixed mode with nowhere to report a switch to, or a
+     * reported switch that nothing renders — so it is rejected instead of tolerated.
      */
     @Test
     fun `a mode with no way to report a switch is rejected`() {
@@ -198,12 +207,16 @@ class EmailAuthScreenModeSwitchTest {
             startWith(mode = EmailAuthMode.SignUp, onNavigateToMode = null)
         }
 
-        // The message names both halves, so either omission is identifiable.
+        // Both halves are named. A caller who passed one and forgot the other has to be told
+        // which one is missing, and that has to work in either direction.
         assertThat(thrown).hasMessageThat().contains("mode")
         assertThat(thrown).hasMessageThat().contains("onNavigateToMode")
     }
 
-    /** The message is just as usable when it is `mode` that was forgotten. */
+    /**
+     * The direction the message used to point the wrong way: a caller who supplied
+     * `onNavigateToMode` and forgot `mode` was told only about the parameter they *did* pass.
+     */
     @Test
     fun `a switch callback with no mode to render is rejected`() {
         val thrown = assertThrows(IllegalArgumentException::class.java) {
@@ -239,7 +252,9 @@ class EmailAuthScreenModeSwitchTest {
         composeTestRule.waitForIdle()
     }
 
-    // Email-link sign-in configured, so all four modes are actually on offer.
+    // Email-link sign-in configured, so all four modes are actually on offer: a switch to a mode
+    // the provider disables is inert, which is the point of `a provider without email-link
+    // sign-in cannot switch to it` rather than of anything here.
     private fun configuration(): AuthUIConfiguration = authUIConfiguration {
         context = applicationContext
         providers {

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreenReauthEmailLockTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreenReauthEmailLockTest.kt
@@ -58,8 +58,9 @@ import org.robolectric.annotation.Config
  * The reauthentication email lock has to survive an [EmailAuthMode] round-trip.
  *
  * [DefaultEmailAuthContent] dispatches modes with a `when`, so leaving [EmailAuthMode.SignIn]
- * disposes the [SignInUI] composition group and coming back creates a fresh one. A lock inferred
- * from the field's own value would be re-decided on every return.
+ * *disposes* the [SignInUI] composition group and coming back creates a fresh one. Any lock
+ * [SignInUI] inferred from its own (mutable) field value was therefore re-decided on every return —
+ * either dropping the lock, or locking an address the library never prefilled.
  *
  * @suppress Internal test class
  */
@@ -170,8 +171,10 @@ class EmailAuthScreenReauthEmailLockTest {
     }
 
     /**
-     * Unhosted, this screen shows the error but never acts on it, so the dialog explains the
-     * error and renders no action button.
+     * Unhosted, this screen shows the error itself but never acts on it: error recovery belongs to
+     * a host, which alone knows what lies outside the email flow. With nothing to do, an action
+     * button on the dialog could only dismiss it, so it is not rendered — and the dialog keeps
+     * explaining the error, which is the part a standalone caller still needs.
      */
     @Test
     fun `the reauth sub-flow error dialog offers no action button`() {
@@ -200,7 +203,11 @@ class EmailAuthScreenReauthEmailLockTest {
         composeTestRule.onNodeWithTag(FirebaseAuthTestTags.ErrorRecovery.RETRY_BUTTON).assertDoesNotExist()
     }
 
-    /** A mode switch keeps the address, so it can never leave an empty read-only field. */
+    /**
+     * A mode switch must never leave the user on an empty read-only field. It used to clear the
+     * address and put the locked one back; it now keeps the address outright, which reaches the
+     * same place by not breaking it in the first place.
+     */
     @Test
     fun `the locked email survives a mode switch`() {
         var email: String? = null
@@ -285,9 +292,11 @@ class EmailAuthScreenReauthEmailLockTest {
     }
 
     /**
-     * The two out-of-band email routes are not equivalent during reauthentication: a password
-     * reset leaves the sheet up and the request armed, so it stays available, while an email link
-     * reopens the app with nothing armed and stays hidden.
+     * The two out-of-band email routes are not equivalent during reauthentication. A password reset
+     * email leaves the sheet up and the request armed, so it stays available — blocking it stranded
+     * a user who had forgotten their password with no route but dismissal. An email *link* reopens
+     * the app with nothing armed, so completing it reports an interruption instead of finishing the
+     * pending operation, and it stays hidden.
      */
     @Test
     fun `password recovery is offered while reauthenticating but email-link sign-in is not`() {
@@ -295,7 +304,7 @@ class EmailAuthScreenReauthEmailLockTest {
             EmailAuthScreenUnderTest(reauthConfigurationWithEmailLink(), prefill = prefillEmail)
         }
 
-        // The password field proves this is the reauth SignIn screen.
+        // The password field proves this is the reauth SignIn screen, still usable as intended.
         composeTestRule.onNodeWithText(stringProvider.passwordHint).assertExists()
         composeTestRule.onNodeWithText(stringProvider.troubleSigningIn).assertExists()
         composeTestRule.onNodeWithText(stringProvider.signInWithEmailLink, ignoreCase = true)

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentFlowStateRestorationTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentFlowStateRestorationTest.kt
@@ -20,9 +20,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.rememberNavController
+import androidx.compose.animation.togetherWith
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
 import androidx.test.core.app.ApplicationProvider
 import com.firebase.ui.auth.FirebaseAuthUI
 import com.firebase.ui.auth.configuration.MfaConfiguration
@@ -32,6 +35,7 @@ import com.firebase.ui.auth.mfa.MfaEnrollmentContentState
 import com.firebase.ui.auth.mfa.SmsEnrollmentSession
 import com.firebase.ui.auth.mfa.TotpSecret
 import com.firebase.ui.auth.ui.screens.AuthRoute
+import com.firebase.ui.auth.ui.screens.popOrNull
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
@@ -52,17 +56,31 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /**
- * Asserts which [MfaEnrollmentFlowState] fields survive an Activity recreation
- * mid-SMS-verification.
+ * Proves, rather than predicts, what an Activity recreation does to
+ * [MfaEnrollmentFlowState] mid-SMS-verification.
  *
- * Drives the hosted flow to [AuthRoute.MfaEnrollment.VerifyFactor] for SMS with a live session,
- * recreates the Activity via [StateRestorationTester], then checks the restored values for
- * equality with what was set before — not merely for non-null. `smsSession` and `selectedCountry`
- * survive via their hand-written `Saver`s; `totpSecret` and `totpQrCodeUrl` do not, and
- * [MfaEnrollmentTotpRegenerationTest] covers how that loss is recovered.
+ * A prior read-only review of [MfaEnrollmentDestinations.kt] concluded that all eight fields —
+ * [smsSession] and [selectedCountry] included — were lost on recreation, [smsSession] leaving
+ * [MfaEnrollmentContentState.onResendCodeClick] a silent no-op. [smsSession] and
+ * [selectedCountry] now have hand-written `Saver`s
+ * ([com.firebase.ui.auth.mfa.SmsEnrollmentSessionSaver],
+ * [com.firebase.ui.auth.data.CountryDataSaver]) and are `rememberSaveable`, so this test asserts
+ * they now *survive* recreation — restored values checked for equality against what was set
+ * before, not just non-null. [totpSecret] and [totpQrCodeUrl] are unaffected by that fix and stay
+ * lost: `com.google.firebase.auth.TotpSecret`'s only concrete implementation is obfuscated SDK
+ * internal plumbing this library must not reference, so there is no `Saver` to write for it — see
+ * [MfaEnrollmentFlowState] and [MfaEnrollmentTotpRegenerationTest] for how that loss is instead
+ * handled by regenerating the secret rather than surviving recreation.
  *
- * Guards the regression where a lost `smsSession` left
- * [MfaEnrollmentContentState.onResendCodeClick] a silent no-op.
+ * This test drives the hosted flow to [AuthRoute.MfaEnrollment.VerifyFactor] for SMS with a live
+ * session, recreates the Activity via [StateRestorationTester], and asserts the actual
+ * post-recreation [MfaEnrollmentFlowState] — nothing here is asserted from prediction. It stops at
+ * asserting the restored field values rather than also invoking `onResendCodeClick`/`onVerifyClick`
+ * as the pre-fix version of this test did: with a real [SmsEnrollmentSession] now present after
+ * restore, either callback would drive [com.firebase.ui.auth.mfa.SmsEnrollmentHandler] into a real
+ * Firebase network call, which is [MfaEnrollmentRouteNavigationTest]'s and this module's SMS
+ * enrollment tests' concern, not this file's — this file's concern is only whether
+ * [MfaEnrollmentFlowState] itself survives.
  *
  * @suppress Internal test class
  */
@@ -84,7 +102,7 @@ class MfaEnrollmentFlowStateRestorationTest {
 
     private lateinit var authUI: FirebaseAuthUI
 
-    private var navController: NavHostController? = null
+    private var backStack: NavBackStack<NavKey>? = null
     private var flowState: MfaEnrollmentFlowState? = null
     private var lastState: MfaEnrollmentContentState? = null
 
@@ -113,7 +131,7 @@ class MfaEnrollmentFlowStateRestorationTest {
 
     @After
     fun tearDown() {
-        navController = null
+        backStack = null
         flowState = null
         lastState = null
         FirebaseAuthUI.clearInstanceCache()
@@ -139,7 +157,11 @@ class MfaEnrollmentFlowStateRestorationTest {
         }
         composeTestRule.waitForIdle()
 
-        // Stands in for onSendSmsCodeClick, which would make a real SMS network call.
+        // Stands in for onSendSmsCodeClick's own network call, the same way
+        // MfaEnrollmentRouteNavigationTest.pushVerifyFactorDirectly avoids it: populates exactly
+        // what a real send populates on flowState, then pushes VerifyFactor. totpSecret and
+        // totpQrCodeUrl are populated too even though this is an SMS run, so the still-lost
+        // plain-`remember` fields are exercised in the same test as the now-surviving ones.
         val fakeSession = SmsEnrollmentSession(
             verificationId = "verification-id",
             phoneNumber = "+1$TYPED_PHONE_NUMBER",
@@ -159,7 +181,7 @@ class MfaEnrollmentFlowStateRestorationTest {
             state.totpSecret.value = fakeTotpSecret
             state.totpQrCodeUrl.value = FAKE_QR_URL
             state.selectedCountry.value = fakeCountry
-            requireNotNull(navController).navigateToMfaStep(AuthRoute.MfaEnrollment.VerifyFactor)
+            requireNotNull(backStack).navigateToMfaStep(AuthRoute.MfaEnrollment.VerifyFactor)
         }
         composeTestRule.waitForIdle()
         composeTestRule.runOnIdle {
@@ -167,8 +189,9 @@ class MfaEnrollmentFlowStateRestorationTest {
         }
         composeTestRule.waitForIdle()
 
-        // Sanity on the pre-recreation state, so a fixture mistake cannot pass as a loss.
-        assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.VerifyFactor.routePattern)
+        // Sanity on the pre-recreation state, so what follows is provably about recreation's
+        // effect and not a fixture mistake.
+        assertThat(currentKey()).isEqualTo(AuthRoute.MfaEnrollment.VerifyFactor)
         assertThat(requireNotNull(lastState).selectedFactor).isEqualTo(MfaFactor.Sms)
         assertThat(requireNotNull(lastState).phoneNumber).isEqualTo(TYPED_PHONE_NUMBER)
         assertThat(requireNotNull(lastState).verificationCode).isEqualTo(TYPED_VERIFICATION_CODE)
@@ -180,61 +203,71 @@ class MfaEnrollmentFlowStateRestorationTest {
         restorationTester.emulateSavedInstanceStateRestore()
         composeTestRule.waitForIdle()
 
-        // The active route: NavController's own Saver restores the back stack.
-        assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.VerifyFactor.routePattern)
-        // rememberSaveable fields survive.
+        // currentStep / the active destination: survives — rememberNavBackStack serializes the
+        // AuthRoute keys, fields included.
+        assertThat(currentKey()).isEqualTo(AuthRoute.MfaEnrollment.VerifyFactor)
+        // selectedFactor, phoneNumber, verificationCode, resendTimerSeconds: rememberSaveable —
+        // survive.
         assertThat(requireNotNull(lastState).selectedFactor).isEqualTo(MfaFactor.Sms)
         assertThat(requireNotNull(lastState).phoneNumber).isEqualTo(TYPED_PHONE_NUMBER)
         assertThat(requireNotNull(lastState).verificationCode).isEqualTo(TYPED_VERIFICATION_CODE)
         assertThat(requireNotNull(lastState).resendTimer).isEqualTo(0)
-        // smsSession, selectedCountry: restored as the *same* value, not merely a non-null one.
+        // smsSession, selectedCountry: now rememberSaveable via a hand-written Saver — survive,
+        // and survive as the *same* value, not merely a non-null one.
         assertThat(requireNotNull(flowState).smsSession.value).isEqualTo(fakeSession)
         assertThat(requireNotNull(flowState).selectedCountry.value).isEqualTo(fakeCountry)
-        // The control the loss used to leave silently inert.
+        // The control this used to leave silently inert: onResendCodeClick is offered (Sms
+        // survived as the selected factor) and now has a real session to read instead of null —
+        // resending itself is SmsEnrollmentHandler's concern (real Firebase network I/O), not
+        // this file's; the point here is only that flowState no longer hands it null.
         assertThat(requireNotNull(lastState).onResendCodeClick).isNotNull()
 
-        // totpSecret, totpQrCodeUrl: plain remember, so still lost.
+        // totpSecret, totpQrCodeUrl: still plain remember — still lost. Unaffected by this fix;
+        // see MfaEnrollmentTotpRegenerationTest for how that loss is instead handled.
         assertThat(requireNotNull(flowState).totpSecret.value).isNull()
         assertThat(requireNotNull(flowState).totpQrCodeUrl.value).isNull()
     }
 
     @Composable
     private fun MfaFlowHost() {
-        val controller = rememberNavController()
+        val stack = rememberNavBackStack(AuthRoute.MfaEnrollment.SelectFactor)
         val state = rememberMfaEnrollmentFlowState()
         SideEffect {
-            navController = controller
+            backStack = stack
             flowState = state
         }
 
-        NavHost(
-            navController = controller,
-            startDestination = AuthRoute.MfaEnrollment.SelectFactor.routePattern,
-            // Transitions would keep two MFA destinations composed at once.
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None },
-        ) {
-            mfaEnrollmentDestinations(
-                navController = controller,
-                configuration = MfaConfiguration(
-                    allowedFactors = listOf(MfaFactor.Sms, MfaFactor.Totp),
-                    requireEnrollment = false,
-                ),
-                authConfiguration = null,
-                authUI = authUI,
-                flowState = state,
-                content = { contentState -> lastState = contentState },
-                onComplete = {},
-                onSkip = {},
-                onError = {},
-            )
-        }
+        NavDisplay(
+            backStack = stack,
+            onBack = { stack.popOrNull() },
+            // Transitions would keep two MFA destinations composed at once, which has nothing to
+            // do with the state-restoration behavior under test.
+            transitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+            popTransitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+            predictivePopTransitionSpec = { _ ->
+                EnterTransition.None togetherWith ExitTransition.None
+            },
+            entryProvider = entryProvider {
+                mfaEnrollmentDestinations(
+                    backStack = stack,
+                    configuration = MfaConfiguration(
+                        allowedFactors = listOf(MfaFactor.Sms, MfaFactor.Totp),
+                        requireEnrollment = false,
+                    ),
+                    authConfiguration = null,
+                    authUI = authUI,
+                    flowState = state,
+                    content = { contentState -> lastState = contentState },
+                    onComplete = {},
+                    onSkip = {},
+                    onError = {},
+                )
+            },
+        )
     }
 
-    private fun currentRoute(): String? = composeTestRule.runOnIdle {
-        navController?.currentBackStackEntry?.destination?.route
+    private fun currentKey(): NavKey? = composeTestRule.runOnIdle {
+        backStack?.lastOrNull()
     }
 
     private companion object {

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentHostDestinationsTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentHostDestinationsTest.kt
@@ -17,6 +17,7 @@ package com.firebase.ui.auth.ui.screens.mfa
 import android.content.Context
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.togetherWith
 import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -258,10 +259,11 @@ class MfaEnrollmentHostDestinationsTest {
         isCredentialManagerEnabled = false
         // The default fades would keep the destination being left composed alongside its successor.
         transitions = AuthUITransitions(
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None },
+            transitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+            popTransitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+            predictivePopTransitionSpec = {
+                EnterTransition.None togetherWith ExitTransition.None
+            },
         )
     }
 

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentRouteNavigationTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentRouteNavigationTest.kt
@@ -17,22 +17,24 @@ package com.firebase.ui.auth.ui.screens.mfa
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.navigation.NavBackStackEntry
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.ComposeNavigator
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
-import androidx.navigation.get
+import androidx.compose.animation.togetherWith
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
 import androidx.test.core.app.ApplicationProvider
 import com.firebase.ui.auth.FirebaseAuthUI
 import com.firebase.ui.auth.configuration.MfaConfiguration
 import com.firebase.ui.auth.configuration.MfaFactor
 import com.firebase.ui.auth.mfa.MfaEnrollmentContentState
 import com.firebase.ui.auth.ui.screens.AuthRoute
+import com.firebase.ui.auth.ui.screens.popOrNull
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
 import com.google.common.truth.Truth.assertThat
@@ -65,8 +67,10 @@ import org.robolectric.annotation.Config
  * [AuthRoute.MfaEnrollment.ConfigureSms], [AuthRoute.MfaEnrollment.ConfigureTotp] and
  * [AuthRoute.MfaEnrollment.VerifyFactor] — onto real navigation destinations.
  *
- * The unit under test is [mfaEnrollmentDestinations], hosted here in a bare `NavHost` so the back
- * stack can be read directly.
+ * The unit under test is [mfaEnrollmentDestinations], the entry-provider extension
+ * [com.firebase.ui.auth.ui.screens.FirebaseAuthScreen] installs, hosted here in a bare
+ * `NavDisplay` so the back stack can be read directly — the same shape
+ * `com.firebase.ui.auth.ui.screens.email.EmailAuthRouteNavigationTest` uses for the email flow.
  *
  * @suppress Internal test class
  */
@@ -88,10 +92,9 @@ class MfaEnrollmentRouteNavigationTest {
 
     private lateinit var authUI: FirebaseAuthUI
 
-    private var navController: NavHostController? = null
+    private var backStack: NavBackStack<NavKey>? = null
     private var lastState: MfaEnrollmentContentState? = null
     private var pressBack: (() -> Unit)? = null
-    private var reportComplete: (() -> Unit)? = null
 
     @Before
     fun setUp() {
@@ -118,10 +121,9 @@ class MfaEnrollmentRouteNavigationTest {
 
     @After
     fun tearDown() {
-        navController = null
+        backStack = null
         lastState = null
         pressBack = null
-        reportComplete = null
         FirebaseAuthUI.clearInstanceCache()
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
         FirebaseApp.getApps(context).forEach {
@@ -132,11 +134,15 @@ class MfaEnrollmentRouteNavigationTest {
         }
     }
 
-    // A step switch must not dispose what a previous step held
+    // =============================================================================================
+    // The headline bug: a step switch must not dispose what a previous step held
+    // =============================================================================================
 
     /**
-     * Guards the regression where backing out to [AuthRoute.MfaEnrollment.SelectFactor] blanked
-     * the typed phone number.
+     * The ticket's headline bug. `MfaEnrollmentScreen.onBackClick` used to blank the phone number
+     * on the way back to [AuthRoute.MfaEnrollment.SelectFactor] — see the `git show HEAD` version
+     * of `onBackClick`. Hosted, back is real navigation and the flow's data lives in
+     * [MfaEnrollmentFlowState], which the step returned to still holds.
      */
     @Test
     fun `the typed phone number survives a detour through TOTP and back`() {
@@ -145,29 +151,35 @@ class MfaEnrollmentRouteNavigationTest {
         typePhoneNumber(TYPED_PHONE_NUMBER)
 
         back()
-        assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.SelectFactor.routePattern)
+        assertThat(currentKey()).isEqualTo(AuthRoute.MfaEnrollment.SelectFactor)
 
-        // A detour, not an immediate re-selection: local state could survive the latter by luck.
+        // A detour through the other factor and back — not just an immediate re-selection —
+        // is what proves the data lives in the shared flowState rather than surviving by luck in
+        // whatever local state a single recomposition happened to keep around.
         selectFactor(MfaFactor.Totp)
         back()
 
         selectFactor(MfaFactor.Sms)
-        assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureSms.routePattern)
+        assertThat(currentKey()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureSms)
         assertThat(requireNotNull(lastState).phoneNumber).isEqualTo(TYPED_PHONE_NUMBER)
     }
 
-    // System back walks VerifyFactor back to whichever factor was chosen
+    // =============================================================================================
+    // System back walks VerifyFactor back to whichever factor was actually chosen
+    // =============================================================================================
 
     @Test
     fun `back from VerifyFactor returns to ConfigureSms when SMS was chosen`() {
         start()
         selectFactor(MfaFactor.Sms)
+        // Stands in for onSendSmsCodeClick's own navigation, without the real SMS network call
+        // onSendSmsCodeClick would make.
         pushVerifyFactorDirectly()
-        assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.VerifyFactor.routePattern)
+        assertThat(currentKey()).isEqualTo(AuthRoute.MfaEnrollment.VerifyFactor)
 
         back()
 
-        assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureSms.routePattern)
+        assertThat(currentKey()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureSms)
     }
 
     @Test
@@ -176,15 +188,17 @@ class MfaEnrollmentRouteNavigationTest {
             start()
             selectFactor(MfaFactor.Totp)
             continueToVerify()
-            assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.VerifyFactor.routePattern)
+            assertThat(currentKey()).isEqualTo(AuthRoute.MfaEnrollment.VerifyFactor)
 
             back()
 
-            assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureTotp.routePattern)
+            assertThat(currentKey()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureTotp)
         }
     }
 
+    // =============================================================================================
     // The TOTP secret is fetched once, not on every visit to ConfigureTotp
+    // =============================================================================================
 
     @Test
     fun `the TOTP secret is fetched once and survives a back-and-forward through SMS`() {
@@ -192,7 +206,7 @@ class MfaEnrollmentRouteNavigationTest {
             start()
 
             selectFactor(MfaFactor.Totp)
-            assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureTotp.routePattern)
+            assertThat(currentKey()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureTotp)
             assertThat(requireNotNull(lastState).totpSecret).isNotNull()
             assertThat(requireNotNull(lastState).totpQrCodeUrl).isEqualTo(FAKE_QR_URL)
 
@@ -201,7 +215,7 @@ class MfaEnrollmentRouteNavigationTest {
             back()
             selectFactor(MfaFactor.Totp)
 
-            assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureTotp.routePattern)
+            assertThat(currentKey()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureTotp)
             assertThat(requireNotNull(lastState).totpQrCodeUrl).isEqualTo(FAKE_QR_URL)
             totpStatic.verify(
                 { TotpMultiFactorGenerator.generateSecret(mockSession) },
@@ -210,7 +224,9 @@ class MfaEnrollmentRouteNavigationTest {
         }
     }
 
+    // =============================================================================================
     // A single allowed factor resolves its start step at flow entry
+    // =============================================================================================
 
     @Test
     fun `an SMS-only configuration resolves to ConfigureSms`() {
@@ -235,21 +251,25 @@ class MfaEnrollmentRouteNavigationTest {
         val configuration = smsOnlyConfiguration()
         start(configuration, startStep = mfaEnrollmentStartStep(configuration))
 
-        assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureSms.routePattern)
-        assertThat(backStackRoutes())
-            .containsExactly(AuthRoute.MfaEnrollment.ConfigureSms.routePattern)
+        assertThat(currentKey()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureSms)
+        assertThat(backStackKeys())
+            .containsExactly(AuthRoute.MfaEnrollment.ConfigureSms)
     }
 
-    /** The secret must still be pre-fetched when `ConfigureTotp` is the flow's first destination. */
+    /**
+     * The pre-fetch that used to happen in `MfaEnrollmentScreen`'s own `LaunchedEffect(Unit)`
+     * bounce off `SelectFactor` still has to happen when the host resolves straight to
+     * `ConfigureTotp` instead of routing through `SelectFactor` first.
+     */
     @Test
     fun `a TOTP-only flow fetches the secret without ever visiting SelectFactor`() {
         withMockedTotpSecret { totpStatic, mockSession ->
             val configuration = totpOnlyConfiguration()
             start(configuration, startStep = mfaEnrollmentStartStep(configuration))
 
-            assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureTotp.routePattern)
-            assertThat(backStackRoutes())
-                .containsExactly(AuthRoute.MfaEnrollment.ConfigureTotp.routePattern)
+            assertThat(currentKey()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureTotp)
+            assertThat(backStackKeys())
+                .containsExactly(AuthRoute.MfaEnrollment.ConfigureTotp)
             assertThat(requireNotNull(lastState).totpQrCodeUrl).isEqualTo(FAKE_QR_URL)
             totpStatic.verify(
                 { TotpMultiFactorGenerator.generateSecret(mockSession) },
@@ -258,172 +278,22 @@ class MfaEnrollmentRouteNavigationTest {
         }
     }
 
-    // Completing or skipping leaves the flow, from whichever step it happened on
-
-    @Test
-    fun `a successful enrolment three steps deep leaves the flow`() {
-        startOutsideFlow()
-        val hostEntry = hostEntry()
-        selectFactor(MfaFactor.Sms)
-        pushVerifyFactorDirectly()
-        assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.VerifyFactor.routePattern)
-
-        completeEnrollment()
-
-        assertThat(currentRoute()).isEqualTo(HOST_ROUTE)
-        assertThat(backStackRoutes()).containsExactly(HOST_ROUTE)
-        assertThat(hostEntry()).isSameInstanceAs(hostEntry)
-    }
-
-    @Test
-    fun `a skip from a pushed step leaves the flow`() {
-        startOutsideFlow()
-        val hostEntry = hostEntry()
-        selectFactor(MfaFactor.Sms)
-        assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureSms.routePattern)
-
-        skipEnrollment()
-
-        assertThat(currentRoute()).isEqualTo(HOST_ROUTE)
-        assertThat(backStackRoutes()).containsExactly(HOST_ROUTE)
-        assertThat(hostEntry()).isSameInstanceAs(hostEntry)
-    }
-
-    /** The start step is `ConfigureSms`, so an exit pinned to `SelectFactor` would pop nothing. */
-    @Test
-    fun `a successful enrolment leaves an SMS-only flow that never visited SelectFactor`() {
-        startOutsideFlow(smsOnlyConfiguration())
-        val hostEntry = hostEntry()
-        assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureSms.routePattern)
-        pushVerifyFactorDirectly()
-
-        completeEnrollment()
-
-        assertThat(currentRoute()).isEqualTo(HOST_ROUTE)
-        assertThat(hostEntry()).isSameInstanceAs(hostEntry)
-    }
-
-    /**
-     * A host can enter at any step through `AuthSuccessUiContext.onNavigate`, which never pushes
-     * the resolved start step — so an exit that pops up to that start step finds nothing.
-     */
-    @Test
-    fun `a successful enrolment leaves a flow entered at a step that is not its start step`() {
-        startOutsideFlow(enterAtStartStep = false)
-        val hostEntry = hostEntry()
-        navigateDirectlyTo(AuthRoute.MfaEnrollment.ConfigureSms)
-        pushVerifyFactorDirectly()
-        assertThat(backStackRoutes())
-            .doesNotContain(AuthRoute.MfaEnrollment.SelectFactor.routePattern)
-
-        completeEnrollment()
-
-        assertThat(currentRoute()).isEqualTo(HOST_ROUTE)
-        assertThat(backStackRoutes()).containsExactly(HOST_ROUTE)
-        assertThat(hostEntry()).isSameInstanceAs(hostEntry)
-    }
-
-    /**
-     * The "Manage MFA" control is an undebounced `Button` and entry is a bare `navigate`, so two
-     * taps in one frame stack the start step twice. An exit popping only the topmost occurrence
-     * would land on the duplicate.
-     */
-    @Test
-    fun `a successful enrolment leaves a flow whose start step was entered twice`() {
-        startOutsideFlow()
-        val hostEntry = hostEntry()
-        enterFlow(twoFactorConfiguration())
-        selectFactor(MfaFactor.Sms)
-        assertThat(backStackRoutes()).containsExactly(
-            HOST_ROUTE,
-            AuthRoute.MfaEnrollment.SelectFactor.routePattern,
-            AuthRoute.MfaEnrollment.SelectFactor.routePattern,
-            AuthRoute.MfaEnrollment.ConfigureSms.routePattern,
-        ).inOrder()
-
-        completeEnrollment()
-
-        assertThat(currentRoute()).isEqualTo(HOST_ROUTE)
-        assertThat(backStackRoutes()).containsExactly(HOST_ROUTE)
-        assertThat(hostEntry()).isSameInstanceAs(hostEntry)
-    }
-
-    /**
-     * `onNavigate` accepts any step, so an SMS-only configuration — whose start step is
-     * `ConfigureSms` — can still be entered at `SelectFactor`. An exit inclusive of the resolved
-     * start step would strand the user on the picker it stacked underneath.
-     */
-    @Test
-    fun `a successful enrolment leaves an SMS-only flow entered at SelectFactor`() {
-        startOutsideFlow(smsOnlyConfiguration(), enterAtStartStep = false)
-        val hostEntry = hostEntry()
-        navigateDirectlyTo(AuthRoute.MfaEnrollment.SelectFactor)
-        selectFactor(MfaFactor.Sms)
-        pushVerifyFactorDirectly()
-
-        completeEnrollment()
-
-        assertThat(currentRoute()).isEqualTo(HOST_ROUTE)
-        assertThat(backStackRoutes()).containsExactly(HOST_ROUTE)
-        assertThat(hostEntry()).isSameInstanceAs(hostEntry)
-    }
-
-    /**
-     * `onVerifyClick` reports completion from an unguarded coroutine, so a second exit is
-     * reachable. It must not rebuild the host entry the caller's own state is scoped to.
-     */
-    @Test
-    fun `a second exit after the flow has been left changes nothing`() {
-        startOutsideFlow()
-        val hostEntry = hostEntry()
-        selectFactor(MfaFactor.Sms)
-        completeEnrollment()
-
-        completeEnrollment()
-
-        assertThat(currentRoute()).isEqualTo(HOST_ROUTE)
-        assertThat(backStackRoutes()).containsExactly(HOST_ROUTE)
-        assertThat(hostEntry()).isSameInstanceAs(hostEntry)
-    }
-
-    /**
-     * A step reached with no signed-in user cannot render, and neither can the step underneath
-     * it. Popping one at a time would walk the flow out a step per frame; leaving does it in one.
-     */
-    @Test
-    fun `a step reached with no signed-in user leaves the whole flow`() {
-        startOutsideFlow()
-        val hostEntry = hostEntry()
-        selectFactor(MfaFactor.Sms)
-        pushVerifyFactorDirectly()
-        `when`(mockAuth.currentUser).thenReturn(null)
-
-        navigateDirectlyTo(AuthRoute.MfaEnrollment.ConfigureTotp)
-
-        assertThat(currentRoute()).isEqualTo(HOST_ROUTE)
-        assertThat(backStackRoutes()).containsExactly(HOST_ROUTE)
-        assertThat(hostEntry()).isSameInstanceAs(hostEntry)
-    }
-
-    /** Nothing to pop back to: the fallback has to put something on the emptied stack. */
-    @Test
-    fun `an exit from a flow that is the whole back stack resets to Success`() {
-        start()
-        selectFactor(MfaFactor.Sms)
-        assertThat(backStackRoutes()).doesNotContain(HOST_ROUTE)
-
-        completeEnrollment()
-
-        assertThat(currentRoute()).isEqualTo(AuthRoute.Success.routePattern)
-        assertThat(backStackRoutes()).containsExactly(AuthRoute.Success.routePattern)
-    }
-
+    // =============================================================================================
     // Every public AuthRoute.MfaEnrollment value is a registered destination
+    // =============================================================================================
 
     /**
-     * Wrapped in [withMockedTotpSecret]: the loop walks `ConfigureTotp` before `VerifyFactor`, so
-     * without a live secret the TOTP-loss recovery would bounce `VerifyFactor` back — correct
-     * behavior, but it would hide whether that step is reachable at all.
+     * Wrapped in [withMockedTotpSecret]: by the time this loop reaches
+     * [AuthRoute.MfaEnrollment.VerifyFactor], the [AuthRoute.MfaEnrollment.ConfigureTotp] step
+     * visited just before it (steps are declared and walked in that order) has already set
+     * `selectedFactor` to TOTP. Without a mocked secret, that fetch fails and leaves `totpSecret`
+     * null — which `MfaEnrollmentScreen`'s TOTP-loss recovery (added alongside
+     * [com.firebase.ui.auth.ui.screens.mfa.MfaEnrollmentTotpRegenerationTest]) now correctly reads
+     * as "landed on VerifyFactor with no live secret" and bounces back to `ConfigureTotp` for,
+     * exactly as it should for a genuine loss. That is a real product behavior this test must
+     * account for, not something to route around: mocking the secret is what makes "every step is
+     * directly reachable" true again, the same way [withMockedTotpSecret] already lets the other
+     * TOTP-path tests in this class reach `VerifyFactor` at all.
      */
     @Test
     fun `every declared MFA enrolment step is reachable directly`() {
@@ -432,12 +302,138 @@ class MfaEnrollmentRouteNavigationTest {
 
             AuthRoute.MfaEnrollment.steps.forEach { step ->
                 navigateDirectlyTo(step)
-                assertThat(currentRoute()).isEqualTo(step.routePattern)
+                assertThat(currentKey()).isEqualTo(step)
             }
         }
     }
 
+    // =============================================================================================
+    // Leaving the flow drops every entry it pushed, from any depth
+    // =============================================================================================
+
+    /**
+     * The headline defect: every move between steps is a push, so a single pop from three deep
+     * strands the user on the step before rather than leaving.
+     */
+    @Test
+    fun `leaving from the deepest step drops every entry the flow pushed`() {
+        val stack = stackOf(
+            AuthRoute.MethodPicker,
+            AuthRoute.Success,
+            AuthRoute.MfaEnrollment.SelectFactor,
+            AuthRoute.MfaEnrollment.ConfigureSms,
+            AuthRoute.MfaEnrollment.VerifyFactor,
+        )
+
+        stack.exitMfaEnrollment()
+
+        assertThat(stack.toList())
+            .containsExactly(AuthRoute.MethodPicker, AuthRoute.Success)
+            .inOrder()
+    }
+
+    /**
+     * Entered, left, entered again: the flow's entries need not be one unbroken run at the top, and
+     * a pop loop that stops at the first non-step leaves the earlier ones stranded underneath.
+     * Truncating to the lowest step is what makes the exit independent of how the stack got there.
+     */
+    @Test
+    fun `leaving drops the flow's entries wherever they sit on the stack`() {
+        val stack = stackOf(
+            AuthRoute.Success,
+            AuthRoute.MfaEnrollment.SelectFactor,
+            AuthRoute.MfaChallenge,
+            AuthRoute.MfaEnrollment.ConfigureSms,
+        )
+
+        stack.exitMfaEnrollment()
+
+        assertThat(stack.toList()).containsExactly(AuthRoute.Success)
+    }
+
+    /**
+     * A single-factor configuration resolves its start step to a `Configure…` step, so the flow's
+     * lowest entry is not [AuthRoute.MfaEnrollment.SelectFactor] — see [mfaEnrollmentStartStep].
+     */
+    @Test
+    fun `leaving works when the flow never started on SelectFactor`() {
+        val stack = stackOf(
+            AuthRoute.Success,
+            AuthRoute.MfaEnrollment.ConfigureSms,
+            AuthRoute.MfaEnrollment.VerifyFactor,
+        )
+
+        stack.exitMfaEnrollment()
+
+        assertThat(stack.toList()).containsExactly(AuthRoute.Success)
+    }
+
+    /**
+     * `onComplete` and `onSkip` are both reachable more than once — a second tap in the same frame,
+     * or a completion racing a skip — and the second call must not eat the destination the first
+     * one returned to.
+     */
+    @Test
+    fun `leaving a flow already left changes nothing`() {
+        val stack = stackOf(AuthRoute.MethodPicker, AuthRoute.Success)
+
+        stack.exitMfaEnrollment()
+        stack.exitMfaEnrollment()
+
+        assertThat(stack.toList())
+            .containsExactly(AuthRoute.MethodPicker, AuthRoute.Success)
+            .inOrder()
+    }
+
+    /**
+     * Nothing under the flow to return to: truncating would empty the stack, and `NavDisplay`
+     * throws `IllegalArgumentException: NavDisplay backstack cannot be empty` from recomposition
+     * rather than from the call that emptied it. Same convention as `resetBackStackTo`, which this
+     * delegates to, so the size is checked at every snapshot write rather than only at the end.
+     */
+    @Test
+    fun `leaving never empties the stack, even momentarily`() {
+        val stack = stackOf(
+            AuthRoute.MfaEnrollment.SelectFactor,
+            AuthRoute.MfaEnrollment.ConfigureSms,
+        )
+        val sizes = mutableListOf<Int>()
+
+        Snapshot.observe(writeObserver = { sizes += stack.size }) { stack.exitMfaEnrollment() }
+
+        assertThat(sizes).isNotEmpty()
+        assertThat(sizes.min()).isAtLeast(1)
+        assertThat(stack.toList()).containsExactly(AuthRoute.Success)
+    }
+
+    /**
+     * The second, worse instance of the same defect. A step whose user has gone signs itself out of
+     * the flow from composition; popping one entry there hands the step below the same null user,
+     * which pops again, so the flow eats the stack one recomposition at a time until nothing is
+     * left to pop and the user is stranded on a step that renders nothing. Leaving in one write
+     * cannot cascade.
+     */
+    @Test
+    fun `a step with no signed-in user leaves the flow rather than draining the stack`() {
+        `when`(mockAuth.currentUser).thenReturn(null)
+
+        composeTestRule.setContent {
+            SignedOutFlowHost(
+                AuthRoute.MfaEnrollment.SelectFactor,
+                AuthRoute.MfaEnrollment.ConfigureSms,
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        assertThat(backStackKeys()).containsExactly(AuthRoute.Success)
+    }
+
+    // =============================================================================================
     // Harness
+    // =============================================================================================
+
+    private fun stackOf(vararg keys: NavKey): NavBackStack<NavKey> =
+        NavBackStack<NavKey>().apply { addAll(keys) }
 
     private fun twoFactorConfiguration() = MfaConfiguration(
         allowedFactors = listOf(MfaFactor.Sms, MfaFactor.Totp),
@@ -456,8 +452,9 @@ class MfaEnrollmentRouteNavigationTest {
 
     /**
      * Stubs [mockMultiFactor]'s session and [TotpMultiFactorGenerator.generateSecret] to complete
-     * synchronously with a fake secret, for the duration of [block]. Every action and assertion
-     * depending on the stub must run inside [block].
+     * synchronously with a fake secret, for the duration of [block]. A `MockedStatic` is scoped to
+     * `use { }`, so every action and assertion that depends on the stub — starting the flow,
+     * driving it, reading [lastState] — has to run inside [block].
      */
     private fun withMockedTotpSecret(
         block: (
@@ -490,60 +487,6 @@ class MfaEnrollmentRouteNavigationTest {
         composeTestRule.waitForIdle()
     }
 
-    /**
-     * Hosts the flow the way a real host does: [HOST_ROUTE] underneath it. Needed to tell leaving
-     * the flow apart both from landing on one of its steps and from the [AuthRoute.Success]
-     * fallback, which is a separate destination here.
-     *
-     * @param enterAtStartStep false to stay on [HOST_ROUTE], for a caller entering the flow at a
-     * step of its own choosing.
-     */
-    private fun startOutsideFlow(
-        configuration: MfaConfiguration = twoFactorConfiguration(),
-        enterAtStartStep: Boolean = true,
-    ) {
-        composeTestRule.setContent {
-            MfaFlowHost(
-                configuration = configuration,
-                startStep = AuthRoute.MfaEnrollment.SelectFactor,
-                startOutsideFlow = true,
-            )
-        }
-        composeTestRule.waitForIdle()
-        if (enterAtStartStep) enterFlow(configuration)
-    }
-
-    /** Enters the flow the way both of `FirebaseAuthScreen`'s entry points do. */
-    private fun enterFlow(configuration: MfaConfiguration) {
-        composeTestRule.runOnIdle {
-            requireNotNull(navController).navigate(mfaEnrollmentStartStep(configuration).route)
-        }
-        composeTestRule.waitForIdle()
-    }
-
-    /**
-     * The live [HOST_ROUTE] entry, or null once it is gone. Compared by reference: a pop leaves
-     * the same instance, a reset builds a new one and destroys whatever was scoped to the old.
-     */
-    private fun hostEntry(): NavBackStackEntry? = composeTestRule.runOnIdle {
-        navController?.navigatorProvider?.get(ComposeNavigator::class)
-            ?.backStack?.value
-            ?.firstOrNull { it.destination.route == HOST_ROUTE }
-    }
-
-    /** Invokes the host's `onComplete`, as the screen does on a successful enrolment. */
-    private fun completeEnrollment() {
-        composeTestRule.runOnIdle { requireNotNull(reportComplete).invoke() }
-        composeTestRule.waitForIdle()
-    }
-
-    private fun skipEnrollment() {
-        composeTestRule.runOnIdle {
-            requireNotNull(requireNotNull(lastState).onSkipClick).invoke()
-        }
-        composeTestRule.waitForIdle()
-    }
-
     private fun selectFactor(factor: MfaFactor) {
         composeTestRule.runOnIdle { requireNotNull(lastState).onFactorSelected(factor) }
         composeTestRule.waitForIdle()
@@ -559,18 +502,18 @@ class MfaEnrollmentRouteNavigationTest {
         composeTestRule.waitForIdle()
     }
 
-    /** Enters [AuthRoute.MfaEnrollment.VerifyFactor] as `onSendSmsCodeClick` does, minus the
+    /** Enters [AuthRoute.MfaEnrollment.VerifyFactor] the way `onSendSmsCodeClick` does, minus the
      * real SMS network call. */
     private fun pushVerifyFactorDirectly() {
         composeTestRule.runOnIdle {
-            requireNotNull(navController).navigateToMfaStep(AuthRoute.MfaEnrollment.VerifyFactor)
+            requireNotNull(backStack).navigateToMfaStep(AuthRoute.MfaEnrollment.VerifyFactor)
         }
         composeTestRule.waitForIdle()
     }
 
     /** Enters [step] the way a host's `onNavigate` does — bypassing the screen's own guards. */
     private fun navigateDirectlyTo(step: AuthRoute.MfaEnrollment.Step) {
-        composeTestRule.runOnIdle { requireNotNull(navController).navigate(step.route) }
+        composeTestRule.runOnIdle { requireNotNull(backStack).add(step) }
         composeTestRule.waitForIdle()
     }
 
@@ -579,70 +522,84 @@ class MfaEnrollmentRouteNavigationTest {
         composeTestRule.waitForIdle()
     }
 
-    private fun currentRoute(): String? =
-        composeTestRule.runOnIdle { navController?.currentBackStackEntry?.destination?.route }
+    private fun currentKey(): NavKey? =
+        composeTestRule.runOnIdle { backStack?.lastOrNull() }
 
-    /**
-     * The composed destinations on the stack, bottom to top. Reads the `ComposeNavigator`'s own
-     * back stack; `NavController.currentBackStack` is `@RestrictTo`.
-     */
-    private fun backStackRoutes(): List<String?> = composeTestRule.runOnIdle {
-        navController?.navigatorProvider?.get(ComposeNavigator::class)
-            ?.backStack?.value
-            ?.map { it.destination.route }
-            .orEmpty()
-    }
+    /** The keys on the stack, bottom to top. */
+    private fun backStackKeys(): List<NavKey> =
+        composeTestRule.runOnIdle { backStack?.toList().orEmpty() }
 
     @Composable
-    private fun MfaFlowHost(
-        configuration: MfaConfiguration,
-        startStep: AuthRoute.MfaEnrollment.Step,
-        startOutsideFlow: Boolean = false,
-    ) {
-        val controller = rememberNavController()
+    private fun MfaFlowHost(configuration: MfaConfiguration, startStep: AuthRoute.MfaEnrollment.Step) {
+        val stack = rememberNavBackStack(startStep)
         val dispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
         val flowState = rememberMfaEnrollmentFlowState()
-        val exit: () -> Unit = { controller.exitMfaEnrollment() }
         SideEffect {
-            navController = controller
+            backStack = stack
             pressBack = dispatcher?.let { { it.onBackPressed() } }
-            reportComplete = exit
         }
 
-        NavHost(
-            navController = controller,
-            startDestination =
-                if (startOutsideFlow) HOST_ROUTE else startStep.routePattern,
-            // Transitions would keep two MFA destinations composed at once.
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None },
-        ) {
-            composable(HOST_ROUTE) {}
-            composable(AuthRoute.Success.routePattern) {}
-            mfaEnrollmentDestinations(
-                navController = controller,
-                configuration = configuration,
-                authConfiguration = null,
-                authUI = authUI,
-                flowState = flowState,
-                content = { state -> lastState = state },
-                onComplete = exit,
-                onSkip = exit,
-                onError = {},
-            )
-        }
+        NavDisplay(
+            backStack = stack,
+            onBack = { stack.popOrNull() },
+            // Transitions would keep two MFA destinations composed at once, which has nothing to
+            // do with the routing under test.
+            transitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+            popTransitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+            predictivePopTransitionSpec = { _ ->
+                EnterTransition.None togetherWith ExitTransition.None
+            },
+            entryProvider = entryProvider {
+                mfaEnrollmentDestinations(
+                    backStack = stack,
+                    configuration = configuration,
+                    authConfiguration = null,
+                    authUI = authUI,
+                    flowState = flowState,
+                    content = { state -> lastState = state },
+                    onComplete = {},
+                    onSkip = {},
+                    onError = {},
+                )
+            },
+        )
+    }
+
+    /**
+     * The same graph as [MfaFlowHost], started on [initialSteps] and with an
+     * [AuthRoute.Success] entry registered so the exit's stack-would-be-empty fallback resolves.
+     */
+    @Composable
+    private fun SignedOutFlowHost(vararg initialSteps: AuthRoute.MfaEnrollment.Step) {
+        val stack = rememberNavBackStack(*initialSteps)
+        SideEffect { backStack = stack }
+
+        NavDisplay(
+            backStack = stack,
+            onBack = { stack.popOrNull() },
+            transitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+            popTransitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+            predictivePopTransitionSpec = { _ ->
+                EnterTransition.None togetherWith ExitTransition.None
+            },
+            entryProvider = entryProvider {
+                entry<AuthRoute.Success> { Text(text = "left-the-flow") }
+                mfaEnrollmentDestinations(
+                    backStack = stack,
+                    configuration = twoFactorConfiguration(),
+                    authConfiguration = null,
+                    authUI = authUI,
+                    flowState = rememberMfaEnrollmentFlowState(),
+                    content = { state -> lastState = state },
+                    onComplete = {},
+                    onSkip = {},
+                    onError = {},
+                )
+            },
+        )
     }
 
     private companion object {
-        /**
-         * Stands in for whatever the host had on the stack before the flow was entered.
-         * Deliberately not [AuthRoute.Success]: that is the exit's fallback target, and the two
-         * outcomes have to be distinguishable.
-         */
-        const val HOST_ROUTE = "host_outside_flow"
-
         const val TYPED_PHONE_NUMBER = "5551234567"
         const val FAKE_SHARED_SECRET = "JBSWY3DPEHPK3PXP"
         const val FAKE_QR_URL = "otpauth://totp/test-issuer:user%40example.com?secret=JBSWY3DPEHPK3PXP"

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentTotpRegenerationTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentTotpRegenerationTest.kt
@@ -20,15 +20,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.rememberNavController
+import androidx.compose.animation.togetherWith
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
 import androidx.test.core.app.ApplicationProvider
 import com.firebase.ui.auth.FirebaseAuthUI
 import com.firebase.ui.auth.configuration.MfaConfiguration
 import com.firebase.ui.auth.configuration.MfaFactor
 import com.firebase.ui.auth.mfa.MfaEnrollmentContentState
 import com.firebase.ui.auth.ui.screens.AuthRoute
+import com.firebase.ui.auth.ui.screens.popOrNull
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.TaskCompletionSource
 import com.google.android.gms.tasks.Tasks
@@ -57,17 +61,18 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /**
- * Covers the recovery from `totpSecret`/`totpQrCodeUrl` being lost to Activity recreation — the
- * loss [MfaEnrollmentFlowStateRestorationTest] establishes.
+ * Proves the other half of the TOTP-loss fix [MfaEnrollmentFlowStateRestorationTest] documents:
+ * `totpSecret`/`totpQrCodeUrl` are genuinely lost to Activity recreation (there is no `Saver` to
+ * write for `com.google.firebase.auth.TotpSecret` without reaching into obfuscated SDK internals —
+ * see [MfaEnrollmentFlowState]), and that loss must not become a dead end — `onVerifyClick`
+ * throwing `"No TOTP secret available"` with nowhere to go.
  *
  * Drives the hosted flow to [AuthRoute.MfaEnrollment.VerifyFactor] for TOTP with a live secret,
- * recreates the Activity via [StateRestorationTester], and asserts the executed recovery:
+ * recreates the Activity via [StateRestorationTester], and asserts the actual, executed recovery:
  * [TotpMultiFactorGenerator.generateSecret] is called again, the user lands back on
  * [AuthRoute.MfaEnrollment.ConfigureTotp] with a *new* secret and QR code rather than the stale
- * one, and [MfaEnrollmentContentState.error] explains why.
- *
- * Guards the regression where that loss dead-ended in `onVerifyClick` throwing
- * `"No TOTP secret available"` with nowhere to go.
+ * one, and [MfaEnrollmentContentState.error] explains why — nothing here is asserted from
+ * prediction.
  *
  * @suppress Internal test class
  */
@@ -89,7 +94,7 @@ class MfaEnrollmentTotpRegenerationTest {
 
     private lateinit var authUI: FirebaseAuthUI
 
-    private var navController: NavHostController? = null
+    private var backStack: NavBackStack<NavKey>? = null
     private var flowState: MfaEnrollmentFlowState? = null
     private var lastState: MfaEnrollmentContentState? = null
 
@@ -118,7 +123,7 @@ class MfaEnrollmentTotpRegenerationTest {
 
     @After
     fun tearDown() {
-        navController = null
+        backStack = null
         flowState = null
         lastState = null
         FirebaseAuthUI.clearInstanceCache()
@@ -142,7 +147,13 @@ class MfaEnrollmentTotpRegenerationTest {
         `when`(secondSecret.sharedSecretKey).thenReturn(SECOND_SHARED_SECRET)
         `when`(secondSecret.generateQrCodeUrl(any(), any())).thenReturn(SECOND_QR_URL)
 
-        // Held pending: a completed Task would resolve in the same idle pass as the recomposition.
+        // The second generateSecret call — the regeneration this test is actually about — is
+        // held pending rather than completing immediately, specifically so there is a real,
+        // observable moment where recreation has already dropped totpSecret but the fetch that
+        // replaces it has not yet resolved. Without that, an already-completed Task (as Firebase
+        // Tasks used elsewhere in this suite are) resolves within the same idle pass that runs
+        // the recomposition, and "totpSecret.value is null post-recreation" would only ever be
+        // inferred, not actually observed.
         val secondSecretSource = TaskCompletionSource<FirebaseTotpSecret>()
 
         mockStatic(TotpMultiFactorGenerator::class.java).use { totpStatic ->
@@ -159,8 +170,9 @@ class MfaEnrollmentTotpRegenerationTest {
             composeTestRule.runOnIdle { requireNotNull(lastState).onFactorSelected(MfaFactor.Totp) }
             composeTestRule.waitForIdle()
 
-            // Sanity on the pre-recreation state, so a fixture mistake cannot pass as a loss.
-            assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureTotp.routePattern)
+            // Sanity: the original secret was actually fetched and is what ConfigureTotp shows,
+            // so what follows is provably about recreation's effect and not a fixture mistake.
+            assertThat(currentKey()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureTotp)
             assertThat(requireNotNull(lastState).totpQrCodeUrl).isEqualTo(FIRST_QR_URL)
             totpStatic.verify(
                 { TotpMultiFactorGenerator.generateSecret(mockSession) },
@@ -169,14 +181,20 @@ class MfaEnrollmentTotpRegenerationTest {
 
             composeTestRule.runOnIdle { requireNotNull(lastState).onContinueToVerifyClick() }
             composeTestRule.waitForIdle()
-            assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.VerifyFactor.routePattern)
+            assertThat(currentKey()).isEqualTo(AuthRoute.MfaEnrollment.VerifyFactor)
 
             restorationTester.emulateSavedInstanceStateRestore()
             composeTestRule.waitForIdle()
 
-            // Observed before the pending fetch resolves: VerifyFactor has already popped back.
+            // The loss itself, actually observed rather than inferred: unchanged by this fix,
+            // totpSecret is a plain `remember` and is genuinely null right after restore, exactly
+            // as MfaEnrollmentFlowStateRestorationTest proves for the SMS-side fields that *don't*
+            // survive either. VerifyFactor's own LaunchedEffect(currentStep) has already reacted
+            // to that null by queuing the expired-secret message and popping back to
+            // ConfigureTotp — real navigation, so it lands there before the still-pending
+            // regeneration fetch resolves.
             assertThat(requireNotNull(flowState).totpSecret.value).isNull()
-            assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureTotp.routePattern)
+            assertThat(currentKey()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureTotp)
             assertThat(requireNotNull(lastState).isLoading).isTrue()
 
             // (a) generateSecret was called again — exactly once more, not on every recomposition.
@@ -185,6 +203,7 @@ class MfaEnrollmentTotpRegenerationTest {
                 times(2),
             )
 
+            // Let the regeneration actually resolve.
             secondSecretSource.setResult(secondSecret)
             composeTestRule.waitForIdle()
 
@@ -198,11 +217,28 @@ class MfaEnrollmentTotpRegenerationTest {
     }
 
     /**
-     * The single-allowed-factor variant of the test above: [AuthRoute.MfaEnrollment.ConfigureTotp]
-     * **is** the `NavHost`'s `startDestination`, with no entry beneath it.
+     * The single-allowed-factor variant of the test above. A TOTP-only [MfaConfiguration]
+     * resolves its start step straight to [AuthRoute.MfaEnrollment.ConfigureTotp] —
+     * [mfaEnrollmentStartStep] — so this flow never visits [AuthRoute.MfaEnrollment.SelectFactor]
+     * at all: `ConfigureTotp` **is** the back stack's only initial entry, with nothing beneath it.
      *
-     * With nothing below it, a `popBackStack()` that overshoots or that leaves `VerifyFactor` in
-     * place shows up as a wrong route or a non-root stack, which [isAtBackStackRoot] catches.
+     * That makes the recovery's `onNavigateBack()` step worth checking on its own: with a
+     * `SelectFactor` entry in the stack (the two-factor case above), landing back on
+     * `ConfigureTotp` is unsurprising — it is simply the next entry down. Here there is nothing
+     * below `ConfigureTotp` to reason about, so a real defect (e.g. `popBackStack()` overshooting,
+     * or leaving `VerifyFactor` in place) would show up as either a wrong route or a stack that
+     * still has something beneath the current entry. [isAtBackStackRoot] asserts there is nothing
+     * beneath it, on top of the same recovery sequence
+     * [MfaEnrollmentTotpRegenerationTest] already proves for the two-factor case.
+     *
+     * This is also the harshest back-stack site in the flow. The pop comes from an effect on a
+     * precondition failure, on the first frame after restore, on a stack whose
+     * only entry is the one being popped from — and `NavDisplay` throws
+     * `IllegalArgumentException: NavDisplay backstack cannot be empty` from *recomposition* rather
+     * than from the mutation, so an unguarded `removeLastOrNull()` here would surface as a crash
+     * naming neither this file nor `MfaEnrollmentScreen`. Hence the explicit
+     * [backStackKeys] assertion below: the stack must still hold exactly `ConfigureTotp`, not
+     * merely report it as its top.
      */
     @Test
     fun `losing the TOTP secret to recreation regenerates it and bounces back to ConfigureTotp when TOTP is the only allowed factor`() {
@@ -215,7 +251,9 @@ class MfaEnrollmentTotpRegenerationTest {
         `when`(secondSecret.sharedSecretKey).thenReturn(SECOND_SHARED_SECRET)
         `when`(secondSecret.generateQrCodeUrl(any(), any())).thenReturn(SECOND_QR_URL)
 
-        // Held pending, as in the two-factor test, so the null totpSecret is observed.
+        // Same rationale as the two-factor test: the regeneration fetch is held pending so
+        // "totpSecret.value is null post-recreation" is actually observed, not inferred from an
+        // already-resolved Task.
         val secondSecretSource = TaskCompletionSource<FirebaseTotpSecret>()
 
         mockStatic(TotpMultiFactorGenerator::class.java).use { totpStatic ->
@@ -230,8 +268,9 @@ class MfaEnrollmentTotpRegenerationTest {
             }
             composeTestRule.waitForIdle()
 
-            // Sanity: landed directly on ConfigureTotp, at the back-stack root, with a live secret.
-            assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureTotp.routePattern)
+            // Sanity: the flow landed directly on ConfigureTotp with a live secret — no
+            // SelectFactor visit needed, and it is genuinely the back-stack root.
+            assertThat(currentKey()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureTotp)
             assertThat(isAtBackStackRoot()).isTrue()
             assertThat(requireNotNull(lastState).totpQrCodeUrl).isEqualTo(FIRST_QR_URL)
             totpStatic.verify(
@@ -241,15 +280,23 @@ class MfaEnrollmentTotpRegenerationTest {
 
             composeTestRule.runOnIdle { requireNotNull(lastState).onContinueToVerifyClick() }
             composeTestRule.waitForIdle()
-            assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.VerifyFactor.routePattern)
+            assertThat(currentKey()).isEqualTo(AuthRoute.MfaEnrollment.VerifyFactor)
 
             restorationTester.emulateSavedInstanceStateRestore()
             composeTestRule.waitForIdle()
 
-            // With no SelectFactor entry, back-to-ConfigureTotp and back-to-root are one claim.
+            // The loss, actually observed: totpSecret is null right after restore, exactly as the
+            // two-factor case. VerifyFactor's LaunchedEffect(currentStep) has already reacted by
+            // queuing the expired-secret message and popping back — and with no SelectFactor entry
+            // in this stack, "back to ConfigureTotp" and "back to the stack root" are the same
+            // assertion, which isAtBackStackRoot makes explicit rather than assumed.
             assertThat(requireNotNull(flowState).totpSecret.value).isNull()
-            assertThat(currentRoute()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureTotp.routePattern)
+            assertThat(currentKey()).isEqualTo(AuthRoute.MfaEnrollment.ConfigureTotp)
             assertThat(isAtBackStackRoot()).isTrue()
+            // Exactly one entry, and it is ConfigureTotp: the guarded pop declined to mutate a
+            // single-entry stack rather than emptying it.
+            assertThat(backStackKeys())
+                .containsExactly(AuthRoute.MfaEnrollment.ConfigureTotp)
             assertThat(requireNotNull(lastState).isLoading).isTrue()
 
             // (a) generateSecret was called again — exactly once more, not on every recomposition.
@@ -258,6 +305,7 @@ class MfaEnrollmentTotpRegenerationTest {
                 times(2),
             )
 
+            // Let the regeneration actually resolve.
             secondSecretSource.setResult(secondSecret)
             composeTestRule.waitForIdle()
 
@@ -270,51 +318,123 @@ class MfaEnrollmentTotpRegenerationTest {
         }
     }
 
+    /**
+     * The same recovery, but with [AuthRoute.MfaEnrollment.VerifyFactor] as the back stack's
+     * **only** entry — the shape a host produces by entering that step directly through the public
+     * `AuthSuccessUiContext.onNavigate`, and the shape a restored back stack can produce on its
+     * own.
+     *
+     * This is the one place in the flow where the TOTP-loss redirect has nothing to pop to, and it
+     * is only reachable through a real Activity recreation: `totpSecret` is deliberately a plain
+     * `remember` (see [MfaEnrollmentFlowState]), while `selectedFactor` is `rememberSaveable`, so
+     * "TOTP was chosen but the secret is gone" cannot be constructed without one. Popping the last
+     * entry makes `NavDisplay` throw `IllegalArgumentException: NavDisplay backstack cannot be
+     * empty` — and throw it from *recomposition*, naming neither this file nor
+     * `MfaEnrollmentScreen`.
+     *
+     * With nothing underneath, the redirect stays put: the user is left on `VerifyFactor` with the
+     * regenerated secret rather than bounced.
+     */
+    @Test
+    fun `the TOTP-loss redirect does not empty a back stack whose only entry is VerifyFactor`() {
+        val mockSession = mock(MultiFactorSession::class.java)
+        val firstSecret = mock(FirebaseTotpSecret::class.java)
+        val secondSecret = mock(FirebaseTotpSecret::class.java)
+        `when`(mockMultiFactor.session).thenReturn(Tasks.forResult(mockSession))
+        `when`(firstSecret.sharedSecretKey).thenReturn(FIRST_SHARED_SECRET)
+        `when`(firstSecret.generateQrCodeUrl(any(), any())).thenReturn(FIRST_QR_URL)
+        `when`(secondSecret.sharedSecretKey).thenReturn(SECOND_SHARED_SECRET)
+        `when`(secondSecret.generateQrCodeUrl(any(), any())).thenReturn(SECOND_QR_URL)
+
+        mockStatic(TotpMultiFactorGenerator::class.java).use { totpStatic ->
+            totpStatic.`when`<Task<FirebaseTotpSecret>> {
+                TotpMultiFactorGenerator.generateSecret(mockSession)
+            }.thenReturn(Tasks.forResult(firstSecret), Tasks.forResult(secondSecret))
+
+            val restorationTester = StateRestorationTester(composeTestRule)
+            restorationTester.setContent {
+                MfaFlowHost(totpOnlyConfiguration(), AuthRoute.MfaEnrollment.VerifyFactor)
+            }
+            composeTestRule.waitForIdle()
+
+            // The pre-recreation state a real flow would have left behind: TOTP chosen, a live
+            // secret in hand, sitting on VerifyFactor with nothing beneath it. selectedFactor is
+            // rememberSaveable and survives the restore; totpSecret is not and does not.
+            composeTestRule.runOnIdle {
+                val state = requireNotNull(flowState)
+                state.selectedFactor.value = MfaFactor.Totp
+                state.totpSecret.value =
+                    com.firebase.ui.auth.mfa.TotpSecret.from(firstSecret)
+                state.totpQrCodeUrl.value = FIRST_QR_URL
+            }
+            composeTestRule.waitForIdle()
+            assertThat(backStackKeys())
+                .containsExactly(AuthRoute.MfaEnrollment.VerifyFactor)
+
+            restorationTester.emulateSavedInstanceStateRestore()
+            composeTestRule.waitForIdle()
+
+            // The redirect fired (selectedFactor survived as Totp, the secret did not) and found
+            // nothing to pop to. The stack still holds exactly one entry, and it is still
+            // VerifyFactor — not an empty list, and not a crash from NavDisplay.
+            assertThat(backStackKeys())
+                .containsExactly(AuthRoute.MfaEnrollment.VerifyFactor)
+            assertThat(currentKey()).isEqualTo(AuthRoute.MfaEnrollment.VerifyFactor)
+        }
+    }
+
     @Composable
     private fun MfaFlowHost(
         configuration: MfaConfiguration,
         startStep: AuthRoute.MfaEnrollment.Step,
     ) {
-        val controller = rememberNavController()
+        val stack = rememberNavBackStack(startStep)
         val state = rememberMfaEnrollmentFlowState()
         SideEffect {
-            navController = controller
+            backStack = stack
             flowState = state
         }
 
-        NavHost(
-            navController = controller,
-            startDestination = startStep.routePattern,
-            // Transitions would keep two MFA destinations composed at once.
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None },
-        ) {
-            mfaEnrollmentDestinations(
-                navController = controller,
-                configuration = configuration,
-                authConfiguration = null,
-                authUI = authUI,
-                flowState = state,
-                content = { contentState -> lastState = contentState },
-                onComplete = {},
-                onSkip = {},
-                onError = {},
-            )
-        }
+        NavDisplay(
+            backStack = stack,
+            onBack = { stack.popOrNull() },
+            // Transitions would keep two MFA destinations composed at once, which has nothing to
+            // do with the state-restoration behavior under test.
+            transitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+            popTransitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+            predictivePopTransitionSpec = { _ ->
+                EnterTransition.None togetherWith ExitTransition.None
+            },
+            entryProvider = entryProvider {
+                mfaEnrollmentDestinations(
+                    backStack = stack,
+                    configuration = configuration,
+                    authConfiguration = null,
+                    authUI = authUI,
+                    flowState = state,
+                    content = { contentState -> lastState = contentState },
+                    onComplete = {},
+                    onSkip = {},
+                    onError = {},
+                )
+            },
+        )
     }
 
-    private fun currentRoute(): String? = composeTestRule.runOnIdle {
-        navController?.currentBackStackEntry?.destination?.route
+    private fun currentKey(): NavKey? = composeTestRule.runOnIdle {
+        backStack?.lastOrNull()
     }
+
+    /** The keys on the stack, bottom to top. */
+    private fun backStackKeys(): List<NavKey> =
+        composeTestRule.runOnIdle { backStack?.toList().orEmpty() }
 
     /**
      * Whether the current back-stack entry has nothing beneath it — true only when it is the
-     * `NavHost`'s `startDestination` itself, with no earlier entry to pop to.
+     * back stack's only entry, with no earlier entry to pop to.
      */
     private fun isAtBackStackRoot(): Boolean = composeTestRule.runOnIdle {
-        navController?.previousBackStackEntry == null
+        backStack?.size == 1
     }
 
     private fun twoFactorConfiguration() = MfaConfiguration(

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/reauth/ReauthPresentationStateSaverTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/reauth/ReauthPresentationStateSaverTest.kt
@@ -20,11 +20,12 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 /**
- * The reauthentication marker is all that survives Activity recreation for a request whose retry
- * callback is process-local, so what it round-trips has to be exact.
+ * The reauthentication marker is the only thing that survives Activity recreation for a request
+ * whose retry callback is process-local, so what it round-trips has to be exact.
  *
- * [AuthRoute.route] is not an identity: a flow entry point shares its start step's route string.
- * These tests pin that the saver uses explicit ids instead, and pin the collision itself.
+ * The saver maps each presentable sub-route to an explicit id rather than to anything derived from
+ * the type, so restoring a marker cannot depend on the order candidates are tested in. These tests
+ * pin that mapping.
  *
  * @suppress Internal test class
  */
@@ -43,7 +44,10 @@ class ReauthPresentationStateSaverTest {
         )
     }
 
-    /** Every sub-route the presentation can be restored into comes back as itself. */
+    /**
+     * Every sub-route the presentation can be restored into. Written out per value rather than
+     * looped, because the point is that each one comes back as *itself*.
+     */
     @Test
     fun `each presentable sub-route round-trips as itself`() {
         listOf(AuthRoute.Email, AuthRoute.Phone).forEach { subRoute ->
@@ -62,24 +66,29 @@ class ReauthPresentationStateSaverTest {
     }
 
     /**
-     * The collision the ids exist to survive: a flow and its start step report the same [route],
-     * so a saver keyed on that string cannot tell the two apart.
+     * A flow and its start step are distinct values, and only the flow — the presentable sub-route
+     * — carries an id, so a step can never be restored in place of the flow it belongs to.
+     *
+     * The explicit ids are independent of class names, so renaming a destination cannot change
+     * what an already-saved marker restores to.
      */
     @Test
-    fun `a flow and its start step share a route string but not an id`() {
-        assertThat(AuthRoute.Email.route).isEqualTo(AuthRoute.Email.SignIn.route)
-        assertThat(AuthRoute.Phone.route).isEqualTo(AuthRoute.Phone.EnterPhoneNumber.route)
+    fun `a flow and its start step are distinct, and only the flow has an id`() {
+        assertThat(AuthRoute.Email as Any).isNotEqualTo(AuthRoute.Email.SignIn() as Any)
+        assertThat(AuthRoute.Phone as Any).isNotEqualTo(AuthRoute.Phone.EnterPhoneNumber as Any)
 
         assertThat(AuthRoute.Email.reauthSubRouteId())
             .isNotEqualTo(AuthRoute.Phone.reauthSubRouteId())
-        // A step is not a presentable sub-route at all, so it has no id.
-        assertThat(AuthRoute.Email.SignIn.reauthSubRouteId()).isNull()
+        // The step is not a presentable sub-route at all, so it has no id and cannot be mistaken
+        // for its flow on the way back in.
+        assertThat(AuthRoute.Email.SignIn().reauthSubRouteId()).isNull()
         assertThat(AuthRoute.Phone.EnterPhoneNumber.reauthSubRouteId()).isNull()
     }
 
     /**
-     * The MFA challenge is not restorable: its resolver lives only in the process-local
-     * `AuthState`, so saving it would restore a challenge screen with nothing to challenge.
+     * The MFA challenge is deliberately not restorable: its resolver lives only in the
+     * process-local `AuthState`, so the sub-route is derived from that state on the way back in.
+     * Saving it would restore a challenge screen with nothing to challenge.
      */
     @Test
     fun `the mfa challenge sub-route is not restored`() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,13 @@ facebook = "18.3.0"
 
 compose-bom = "2026.06.01"
 activity-compose = "1.13.0"
-navigation-compose = "2.9.8"
+navigation3 = "1.1.7"
+# Pinned to the kotlinx-serialization-core that navigation3-runtime 1.1.7 declares in both its api
+# and runtime variants, and which consumers therefore resolve transitively. The only use of this
+# entry is auth's test-only `-json`; a higher one there would drag a higher core onto the test
+# classpath (Gradle resolves the highest), leaving the @Serializable round-trip test exercising the
+# key codegen at a version no consumer runs. Raise this only together with `navigation3`.
+kotlinx-serialization = "1.7.3"
 coroutines = "1.11.0"
 zxing = "3.5.4"
 
@@ -86,7 +92,9 @@ compose-foundation = { module = "androidx.compose.foundation:foundation" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 compose-activity = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
-compose-navigation = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-compose" }
+androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3" }
+androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 
 # Firebase (BOM-managed, no version except BOM itself)
@@ -132,5 +140,6 @@ android-library = { id = "com.android.library", version.ref = "android-gradle-pl
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish-plugin" }


### PR DESCRIPTION
The auth module now navigates with Jetpack Navigation 3. Destinations are typed `NavKey`s in a `NavBackStack` list rather than string routes in a `NavHost`, so the address a step carries is a field on the key instead of a URI query argument, and the back stack is a plain list the library can inspect without reflection.

Navigation 2 is removed outright — `api(libs.compose.navigation)` is gone, replaced by `api` on `navigation3-runtime` and `navigation3-ui`.

- `AuthRoute.kt`: extracted from `FirebaseAuthScreen`, now a `@Serializable sealed interface` split into `Destination` (a real `NavKey`) and `FlowEntry` (names a flow, resolves to its start step). Also holds `resetBackStackTo`, `pushUnique` and `popOrNull`.
- `AuthUITransitions`: three `ContentTransform` specs receiving `Scene<NavKey>`, replacing four `EnterTransition`/`ExitTransition` lambdas. `Scene<NavKey>.authRoute()` is public so a consumer can still vary the animation per destination.
- `NavDisplay` throws on an empty back stack, so every pop goes through `popOrNull`.

## ⚠️ Breaking Changes

- `AuthRoute` is a `@Serializable sealed interface`; `route` and `routePattern` are gone. Email steps carry their address, so `AuthRoute.Email.SignUp` is now `AuthRoute.Email.SignUp()`. `Email`/`Phone`/`MfaEnrollment` are `FlowEntry`, not destinations.
- `AuthRoute.Email.Step.withEmail` returns a `Step`, not a `String`.
- `AuthUITransitions` takes `transitionSpec`/`popTransitionSpec`/`predictivePopTransitionSpec` instead of the four Navigation 2 lambdas.
- Consumers get `navigation3-*` transitively instead of `navigation-compose`.

## Usage

```kotlin
AuthUITransitions(
    transitionSpec = { fadeIn() togetherWith fadeOut() },
    popTransitionSpec = { fadeIn() togetherWith fadeOut() },
)
```

---
Maintainer note: Fixes internal CPRN-403