### PR TITLE
fix(auth): don't strand phone-only users on email verification after reload

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthUI.kt
@@ -535,6 +535,24 @@ class FirebaseAuthUI private constructor(
         }
     }
 
+    /**
+     * Re-reads the signed-in user from the server and republishes the resulting auth state.
+     * No-op when nobody is signed in.
+     */
+    internal suspend fun reloadUser() {
+        val user = auth.currentUser ?: return
+        user.reload().await()
+        user.getIdToken(true).await()
+        // Signing out (or switching account) mid-reload must win: publishing here would pin the
+        // combine in authStateFlow() to a Success for a user who is already gone.
+        if (auth.currentUser?.uid != user.uid) return
+        updateAuthState(handleAuthUserState(user, result = null, isNewUser = false))
+    }
+
+    /**
+     * Single source of truth for whether a signed-in user still owes email verification.
+     * Callers must not re-derive it: only password users with an email can satisfy that screen.
+     */
     private fun handleAuthUserState(user: FirebaseUser, result: AuthResult?, isNewUser: Boolean): AuthState {
         return if (!user.isEmailVerified &&
             user.email != null &&

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
@@ -120,8 +120,8 @@ import com.google.firebase.auth.AuthCredential
 import com.google.firebase.auth.EmailAuthProvider
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.MultiFactorResolver
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
 
 /**
  * High-level authentication screen that wires together provider selection, individual provider
@@ -456,28 +456,21 @@ fun FirebaseAuthScreen(
                             onReloadUser = {
                                 coroutineScope.launch {
                                     try {
-                                        authUI.getCurrentUser()?.let {
-                                            it.reload().await()
-                                            it.getIdToken(true).await()
-                                            if (it.isEmailVerified) {
-                                                authUI.updateAuthState(
-                                                    AuthState.Success(
-                                                        result = null,
-                                                        user = it,
-                                                        isNewUser = false
-                                                    )
-                                                )
-                                            } else {
-                                                authUI.updateAuthState(
-                                                    AuthState.RequiresEmailVerification(
-                                                        user = it,
-                                                        email = it.email ?: ""
-                                                    )
-                                                )
-                                            }
-                                        }
+                                        authUI.reloadUser()
+                                    } catch (e: CancellationException) {
+                                        throw e
                                     } catch (e: Exception) {
-                                        Log.e("FirebaseAuthScreen", "Failed to refresh user", e)
+                                        // Signing out mid-reload fails the token refresh. That is
+                                        // the sign-out landing, not a refresh the user can retry.
+                                        if (authUI.getCurrentUser() == null) {
+                                            Log.d(
+                                                "FirebaseAuthScreen",
+                                                "Reload abandoned, user signed out",
+                                                e
+                                            )
+                                        } else {
+                                            Log.e("FirebaseAuthScreen", "Failed to refresh user", e)
+                                        }
                                     }
                                 }
                             },

--- a/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthUIAuthStateTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/FirebaseAuthUIAuthStateTest.kt
@@ -20,11 +20,13 @@ import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
 import android.content.Context
 import com.google.android.gms.tasks.TaskCompletionSource
+import com.google.android.gms.tasks.Tasks
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseAuth.AuthStateListener
 import com.google.firebase.auth.FirebaseAuthRecentLoginRequiredException
 import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.GetTokenResult
 import com.google.firebase.auth.MultiFactorResolver
 import com.google.firebase.auth.UserInfo
 import kotlinx.coroutines.test.runTest
@@ -317,6 +319,119 @@ class FirebaseAuthUIAuthStateTest {
         // Verify that the listener was added and then removed
         verify(mockFirebaseAuth).addAuthStateListener(listenerCaptor.capture())
         verify(mockFirebaseAuth).removeAuthStateListener(listenerCaptor.value)
+    }
+
+    // =============================================================================================
+    // reloadUser() Tests
+    // =============================================================================================
+
+    /** Completed reload/token tasks, so `reloadUser()` runs straight through. */
+    private fun stubReloadTasks() {
+        `when`(mockFirebaseUser.reload()).thenReturn(Tasks.forResult<Void>(null))
+        `when`(mockFirebaseUser.getIdToken(true))
+            .thenReturn(Tasks.forResult(mock(GetTokenResult::class.java)))
+    }
+
+    /**
+     * Pins the flow to a verification state a phone-only user cannot satisfy. authStateFlow()
+     * prefers any non-Idle internal state, so these tests fail unless reloadUser() republishes.
+     */
+    private fun pinToEmailVerification() {
+        authUI.updateAuthState(
+            AuthState.RequiresEmailVerification(user = mockFirebaseUser, email = "")
+        )
+    }
+
+    @Test
+    fun `reloadUser() republishes Success for phone-only users`() = runTest {
+        // Given a phone-only user stranded on email verification
+        val mockProviderData = mock(UserInfo::class.java)
+        `when`(mockProviderData.providerId).thenReturn("phone")
+
+        `when`(mockFirebaseAuth.currentUser).thenReturn(mockFirebaseUser)
+        `when`(mockFirebaseUser.uid).thenReturn("test-uid")
+        `when`(mockFirebaseUser.isEmailVerified).thenReturn(false)
+        `when`(mockFirebaseUser.email).thenReturn(null)
+        `when`(mockFirebaseUser.providerData).thenReturn(listOf(mockProviderData))
+        stubReloadTasks()
+        pinToEmailVerification()
+
+        // When reloading the user
+        authUI.reloadUser()
+
+        // Then the stranding state is replaced with Success
+        assertThat(authUI.authStateFlow().first()).isInstanceOf(AuthState.Success::class.java)
+    }
+
+    @Test
+    fun `reloadUser() republishes Success for federated users with an unverified email`() = runTest {
+        // Given a Google user whose email Firebase reports as unverified
+        val mockProviderData = mock(UserInfo::class.java)
+        `when`(mockProviderData.providerId).thenReturn("google.com")
+
+        `when`(mockFirebaseAuth.currentUser).thenReturn(mockFirebaseUser)
+        `when`(mockFirebaseUser.uid).thenReturn("test-uid")
+        `when`(mockFirebaseUser.isEmailVerified).thenReturn(false)
+        `when`(mockFirebaseUser.email).thenReturn("test@example.com")
+        `when`(mockFirebaseUser.providerData).thenReturn(listOf(mockProviderData))
+        stubReloadTasks()
+        pinToEmailVerification()
+
+        // When reloading the user
+        authUI.reloadUser()
+
+        // Then it is Success - there is no password credential to verify
+        assertThat(authUI.authStateFlow().first()).isInstanceOf(AuthState.Success::class.java)
+    }
+
+    @Test
+    fun `reloadUser() keeps RequiresEmailVerification for an unverified password user`() = runTest {
+        // Given an unverified password user holding a phone credential too
+        val mockPhoneProvider = mock(UserInfo::class.java)
+        `when`(mockPhoneProvider.providerId).thenReturn("phone")
+        val mockPasswordProvider = mock(UserInfo::class.java)
+        `when`(mockPasswordProvider.providerId).thenReturn("password")
+
+        `when`(mockFirebaseAuth.currentUser).thenReturn(mockFirebaseUser)
+        `when`(mockFirebaseUser.uid).thenReturn("test-uid")
+        `when`(mockFirebaseUser.isEmailVerified).thenReturn(false)
+        `when`(mockFirebaseUser.email).thenReturn("test@example.com")
+        `when`(mockFirebaseUser.providerData)
+            .thenReturn(listOf(mockPhoneProvider, mockPasswordProvider))
+        stubReloadTasks()
+        pinToEmailVerification()
+
+        // When reloading the user
+        authUI.reloadUser()
+
+        // Then verification is still required, and the blank email is replaced with the real one
+        val state = authUI.authStateFlow().first()
+        assertThat(state).isInstanceOf(AuthState.RequiresEmailVerification::class.java)
+        assertThat((state as AuthState.RequiresEmailVerification).email)
+            .isEqualTo("test@example.com")
+    }
+
+    @Test
+    fun `reloadUser() publishes nothing when the user signs out mid-reload`() = runTest {
+        // Given a user who signs out while their reload is in flight. Driving the sign-out from
+        // reload() itself keeps the ordering deterministic instead of dispatcher-dependent.
+        var signedIn = true
+        `when`(mockFirebaseAuth.currentUser).thenAnswer { if (signedIn) mockFirebaseUser else null }
+        `when`(mockFirebaseUser.reload()).thenAnswer {
+            signedIn = false
+            Tasks.forResult<Void>(null)
+        }
+        `when`(mockFirebaseUser.getIdToken(true))
+            .thenReturn(Tasks.forResult(mock(GetTokenResult::class.java)))
+        `when`(mockFirebaseUser.uid).thenReturn("test-uid")
+        `when`(mockFirebaseUser.isEmailVerified).thenReturn(true)
+        `when`(mockFirebaseUser.providerData).thenReturn(emptyList())
+
+        // When the reload finishes after the user is gone
+        authUI.reloadUser()
+
+        // Then no Success is published for the departed user
+        assertThat(authUI.authStateFlow().first()).isEqualTo(AuthState.Idle)
     }
 
     // =============================================================================================


### PR DESCRIPTION
`onReloadUser` on `AuthSuccessUiContext` re-derived "does this user need email verification?" from `isEmailVerified` alone, dropping the `email != null` and `password`-provider checks `FirebaseAuthUI` already applied. A phone-only user is unverified and has no email, so any `authenticatedContent` slot calling `uiContext.onReloadUser()` published `RequiresEmailVerification(email = "")` — and because `authStateFlow()` prefers any non-Idle internal state, it stuck there with signing out the only exit. Latent in the stock UI, which wires the callback only to its own verify-email screen.

Deriving auth state isn't the screen's job, so the reload moves to `FirebaseAuthUI.reloadUser()` and reuses the existing `handleAuthUserState` rule rather than duplicating it. It also revalidates the current user after its two suspension points: signing out mid-reload previously published `Success` for the departed user, made permanent by that same precedence. The screen keeps only the error logging, and now rethrows `CancellationException` instead of logging it as a refresh failure.

Tests go in `FirebaseAuthUIAuthStateTest` — phone-only, federated, unverified password, and sign-out mid-reload. Verified by mutation rather than assumed: reinstating the old derivation reds the first two, and dropping the revalidation reds the last.

---
Maintainer note: Fixes internal CPRN-407
