### PR TITLE
feat(auth)!: require the multi-step auth screens to be given navigation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,9 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose")
     id("com.google.gms.google-services")
     id("kotlin-kapt")
+    // The slot demos host the auth screens on their own Navigation 3 back stacks, and a
+    // rememberNavBackStack key has to be @Serializable to survive process death.
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {

--- a/app/src/main/java/com/firebaseui/android/demo/auth/EmailAuthSlotDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/EmailAuthSlotDemoActivity.kt
@@ -39,6 +39,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.FirebaseAuthUI
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
@@ -51,6 +56,33 @@ import com.firebase.ui.auth.ui.screens.email.EmailAuthContentState
 import com.firebase.ui.auth.ui.screens.email.EmailAuthMode
 import com.firebase.ui.auth.ui.screens.email.EmailAuthScreen
 import com.google.firebase.auth.AuthResult
+import kotlinx.serialization.Serializable
+
+/**
+ * One email mode, as this demo's own back-stack key.
+ *
+ * The library's navigation keys are its own business — a caller hosting [EmailAuthScreen] outside
+ * `FirebaseAuthScreen` brings its own, built from the public [EmailAuthMode] and the address the
+ * screen hands back. Distinct keys are distinct entries, so every mode composes fresh and system
+ * back pops one mode at a time.
+ */
+@Serializable
+private data class EmailModeKey(val mode: EmailAuthMode, val email: String = "") : NavKey
+
+/**
+ * Moves to [mode], carrying the address so a switch keeps what the user typed.
+ *
+ * Adds before trimming, so no single write empties the stack: a mode already on the stack is
+ * replaced by the fresh key rather than revisited with a stale address; one that is not is pushed,
+ * leaving the mode below reachable by back.
+ */
+private fun NavBackStack<NavKey>.goToEmailMode(mode: EmailAuthMode, email: String) {
+    val existing = indexOfFirst { it is EmailModeKey && it.mode == mode }
+    add(EmailModeKey(mode, email))
+    if (existing >= 0) {
+        while (size > existing + 1) removeAt(existing)
+    }
+}
 
 class EmailAuthSlotDemoActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -133,6 +165,12 @@ fun EmailAuthDemo(
         }
     }
 
+    // Every mode is a real destination on this demo's own stack, so system back steps between modes
+    // instead of leaving the flow. Allocated above the branch: a rememberSaveable must not sit
+    // behind one, or signing out and back in restores it against a composition that no longer
+    // matches.
+    val backStack = rememberNavBackStack(EmailModeKey(EmailAuthMode.SignIn))
+
     if (currentUser != null) {
         Column(
             modifier = Modifier
@@ -160,22 +198,42 @@ fun EmailAuthDemo(
         }
     } else {
         CompositionLocalProvider(LocalAuthUIStringProvider provides configuration.stringProvider) {
-            EmailAuthScreen(
-                context = context,
-                configuration = configuration,
-                authUI = authUI,
-                onSuccess = { result: AuthResult ->
-                    Log.d("EmailAuthSlotDemo", "Auth success: ${result.user?.uid}")
+            NavDisplay(
+                backStack = backStack,
+                // Guarded like the library's popOrNull: NavDisplay throws on an empty
+                // stack, and throws from recomposition, so the first mode must not pop.
+                onBack = { if (backStack.size > 1) backStack.removeLastOrNull() },
+                entryProvider = entryProvider {
+                    entry<EmailModeKey> { key ->
+                        EmailAuthScreen(
+                            context = context,
+                            configuration = configuration,
+                            authUI = authUI,
+                            prefillEmail = key.email.ifEmpty { null },
+                            mode = key.mode,
+                            onNavigateToMode = { mode, email ->
+                                backStack.goToEmailMode(mode, email)
+                            },
+                            onSuccess = { result: AuthResult ->
+                                Log.d("EmailAuthSlotDemo", "Auth success: ${result.user?.uid}")
+                            },
+                            onError = { exception: AuthException ->
+                                Log.e("EmailAuthSlotDemo", "Auth error", exception)
+                            },
+                            onCancel = {
+                                // Below the start mode there is nothing left to pop back to.
+                                if (backStack.size > 1) {
+                                    backStack.removeLastOrNull()
+                                } else {
+                                    Log.d("EmailAuthSlotDemo", "Auth cancelled")
+                                }
+                            }
+                        ) { state: EmailAuthContentState ->
+                            CustomEmailAuthUI(state)
+                        }
+                    }
                 },
-                onError = { exception: AuthException ->
-                    Log.e("EmailAuthSlotDemo", "Auth error", exception)
-                },
-                onCancel = {
-                    Log.d("EmailAuthSlotDemo", "Auth cancelled")
-                }
-            ) { state: EmailAuthContentState ->
-                CustomEmailAuthUI(state)
-            }
+            )
         }
     }
 }

--- a/app/src/main/java/com/firebaseui/android/demo/auth/PhoneAuthSlotDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/PhoneAuthSlotDemoActivity.kt
@@ -38,6 +38,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.FirebaseAuthUI
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
@@ -47,7 +52,32 @@ import com.firebase.ui.auth.configuration.string_provider.LocalAuthUIStringProvi
 import com.firebase.ui.auth.ui.screens.phone.PhoneAuthContentState
 import com.firebase.ui.auth.ui.screens.phone.PhoneAuthScreen
 import com.firebase.ui.auth.ui.screens.phone.PhoneAuthStep
+import com.firebase.ui.auth.ui.screens.phone.rememberPhoneAuthFlowState
 import com.google.firebase.auth.AuthResult
+import kotlinx.serialization.Serializable
+
+/**
+ * One phone step, as this demo's own back-stack key.
+ *
+ * A caller hosting [PhoneAuthScreen] outside `FirebaseAuthScreen` brings its own keys, built from
+ * the public [PhoneAuthStep]. The data a step switch must not dispose lives in the flow state,
+ * which is remembered above the display so it outlives the entries.
+ */
+@Serializable
+private data class PhoneStepKey(val step: PhoneAuthStep) : NavKey
+
+/**
+ * Moves to [step], ignoring a move to the step already on top.
+ *
+ * The guard is the point: the screen asks to go to code entry for every verification id it has not
+ * navigated for, and a resend mints a new one — so without this, resending stacks a second code
+ * entry under the first and back returns to an identical screen instead of to number entry.
+ */
+private fun NavBackStack<NavKey>.goToPhoneStep(step: PhoneAuthStep) {
+    val key = PhoneStepKey(step)
+    if (lastOrNull() == key) return
+    add(key)
+}
 
 class PhoneAuthSlotDemoActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -110,6 +140,13 @@ fun PhoneAuthDemo(
         }
     }
 
+    // Each step is a real destination, so system back returns to the number entry rather than
+    // leaving the flow. The flow state sits above the display: a step switch must not dispose the
+    // verification it holds. Both are allocated above the branch, because a rememberSaveable must
+    // not sit behind one.
+    val backStack = rememberNavBackStack(PhoneStepKey(PhoneAuthStep.EnterPhoneNumber))
+    val flowState = rememberPhoneAuthFlowState(configuration)
+
     if (currentUser != null) {
         Column(
             modifier = Modifier
@@ -137,22 +174,41 @@ fun PhoneAuthDemo(
         }
     } else {
         CompositionLocalProvider(LocalAuthUIStringProvider provides configuration.stringProvider) {
-            PhoneAuthScreen(
-                context = context,
-                configuration = configuration,
-                authUI = authUI,
-                onSuccess = { result: AuthResult ->
-                    Log.d("PhoneAuthSlotDemo", "Auth success: ${result.user?.uid}")
+            NavDisplay(
+                backStack = backStack,
+                // Guarded like the library's popOrNull: NavDisplay throws on an empty
+                // stack, and throws from recomposition, so the first step must not pop.
+                onBack = { if (backStack.size > 1) backStack.removeLastOrNull() },
+                entryProvider = entryProvider {
+                    entry<PhoneStepKey> { key ->
+                        PhoneAuthScreen(
+                            context = context,
+                            configuration = configuration,
+                            authUI = authUI,
+                            step = key.step,
+                            onNavigateToStep = { backStack.goToPhoneStep(it) },
+                            onNavigateBack = { backStack.removeLastOrNull() },
+                            flowState = flowState,
+                            onSuccess = { result: AuthResult ->
+                                Log.d("PhoneAuthSlotDemo", "Auth success: ${result.user?.uid}")
+                            },
+                            onError = { exception: AuthException ->
+                                Log.e("PhoneAuthSlotDemo", "Auth error", exception)
+                            },
+                            onCancel = {
+                                // Below the first step there is nothing left to pop back to.
+                                if (backStack.size > 1) {
+                                    backStack.removeLastOrNull()
+                                } else {
+                                    Log.d("PhoneAuthSlotDemo", "Auth cancelled")
+                                }
+                            }
+                        ) { state: PhoneAuthContentState ->
+                            CustomPhoneAuthUI(state)
+                        }
+                    }
                 },
-                onError = { exception: AuthException ->
-                    Log.e("PhoneAuthSlotDemo", "Auth error", exception)
-                },
-                onCancel = {
-                    Log.d("PhoneAuthSlotDemo", "Auth cancelled")
-                }
-            ) { state: PhoneAuthContentState ->
-                CustomPhoneAuthUI(state)
-            }
+            )
         }
     }
 }

--- a/auth/README.md
+++ b/auth/README.md
@@ -1097,39 +1097,83 @@ val configuration = authUIConfiguration {
 
 Prompt users to enroll in MFA after sign-in:
 
+Every enrollment step is its own navigation destination, so the host owns the step and navigates
+between them. Keep the flow state above the `NavDisplay` — a step switch must not dispose what a
+previous step collected.
+
 ```kotlin
+@Serializable
+data class MfaStepKey(val step: MfaEnrollmentStep) : NavKey
+
 @Composable
 fun MfaEnrollmentFlow() {
-    val currentUser = FirebaseAuth.getInstance().currentUser
+    val auth = FirebaseAuth.getInstance()
+    val currentUser = auth.currentUser
 
     if (currentUser != null) {
         val mfaConfig = MfaConfiguration(
             allowedFactors = listOf(MfaFactor.Sms, MfaFactor.Totp)
         )
+        val backStack = rememberNavBackStack(MfaStepKey(MfaEnrollmentStep.SelectFactor))
+        val flowState = rememberMfaEnrollmentFlowState()
 
-        MfaEnrollmentScreen(
-            user = currentUser,
-            configuration = mfaConfig,
-            onEnrollmentComplete = {
-                Toast.makeText(context, "MFA enrolled successfully!", Toast.LENGTH_SHORT).show()
-                navigateToHome()
+        NavDisplay(
+            backStack = backStack,
+            // NavDisplay throws on an empty back stack, and throws from recomposition, so the
+            // first step must not pop.
+            onBack = { if (backStack.size > 1) backStack.removeLastOrNull() },
+            entryProvider = entryProvider {
+                entry<MfaStepKey> { key ->
+                    MfaEnrollmentScreen(
+                        user = currentUser,
+                        auth = auth,
+                        configuration = mfaConfig,
+                        onComplete = {
+                            Toast.makeText(context, "MFA enrolled!", Toast.LENGTH_SHORT).show()
+                            navigateToHome()
+                        },
+                        onSkip = { navigateToHome() },
+                        step = key.step,
+                        // A step already on top must not be pushed twice.
+                        onNavigateToStep = {
+                            val target = MfaStepKey(it)
+                            if (backStack.lastOrNull() != target) backStack.add(target)
+                        },
+                        onNavigateBack = {
+                            if (backStack.size > 1) backStack.removeLastOrNull()
+                        },
+                        flowState = flowState,
+                    )
+                }
             },
-            onSkip = {
-                navigateToHome()
-            }
         )
     }
 }
 ```
+
+A back-stack key must be `@Serializable` to survive process death, so add the
+`org.jetbrains.kotlin.plugin.serialization` plugin to the module hosting this screen. If you would
+rather not own any of the navigation, use `FirebaseAuthScreen` and its `mfaEnrollmentContent` slot,
+which owns it for you.
 
 Or with custom UI:
 
 ```kotlin
 MfaEnrollmentScreen(
     user = currentUser,
+    auth = auth,
     configuration = mfaConfig,
-    onEnrollmentComplete = { /* ... */ },
-    onSkip = { /* ... */ }
+    onComplete = { /* ... */ },
+    onSkip = { /* ... */ },
+    // Hosted exactly as above — the step and its two navigation callbacks, plus the flow state
+    // remembered above the NavDisplay.
+    step = key.step,
+    onNavigateToStep = {
+        val target = MfaStepKey(it)
+        if (backStack.lastOrNull() != target) backStack.add(target)
+    },
+    onNavigateBack = { if (backStack.size > 1) backStack.removeLastOrNull() },
+    flowState = flowState,
 ) { state ->
     when (state.step) {
         MfaEnrollmentStep.SelectFactor -> {

--- a/auth/src/main/java/com/firebase/ui/auth/mfa/MfaEnrollmentContentState.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/mfa/MfaEnrollmentContentState.kt
@@ -28,7 +28,20 @@ import com.google.firebase.auth.MultiFactorInfo
  * Use a `when` expression on [step] to determine which UI to render:
  *
  * ```kotlin
- * MfaEnrollmentScreen(user, config, onComplete, onSkip) { state ->
+ * MfaEnrollmentScreen(
+ *     user = user,
+ *     auth = auth,
+ *     configuration = config,
+ *     onComplete = onComplete,
+ *     onSkip = onSkip,
+ *     // The host owns the step: every one of them is its own navigation destination. Both writes
+ *     // are guarded — a step already on top must not be pushed twice, and the first step must not
+ *     // be popped, because NavDisplay throws on an empty back stack from recomposition.
+ *     step = step,
+ *     onNavigateToStep = { if (backStack.lastOrNull() != it) backStack.add(it) },
+ *     onNavigateBack = { if (backStack.size > 1) backStack.removeLastOrNull() },
+ *     flowState = flowState,
+ * ) { state ->
  *     when (state.step) {
  *         MfaEnrollmentStep.SelectFactor -> {
  *             // Render factor selection UI using state.availableFactors

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
@@ -41,7 +41,6 @@ import com.firebase.ui.auth.credentialmanager.PasswordCredentialCancelledExcepti
 import com.firebase.ui.auth.credentialmanager.PasswordCredentialException
 import com.firebase.ui.auth.credentialmanager.PasswordCredentialHandler
 import com.firebase.ui.auth.credentialmanager.PasswordCredentialNotFoundException
-import com.firebase.ui.auth.ui.components.LocalTopLevelDialogController
 import com.google.firebase.auth.AuthCredential
 import com.google.firebase.auth.AuthResult
 import kotlinx.coroutines.launch
@@ -57,12 +56,11 @@ enum class EmailAuthMode {
  * A class passed to the content slot, containing all the necessary information to render custom
  * UIs for sign-in, sign-up, and password reset flows.
  *
- * Switching modes keeps whatever address the user has typed; only the password, its confirmation
- * and the display name are cleared.
+ * Switching modes navigates, so each mode composes fresh; only the address the user typed travels
+ * with the switch.
  *
  * @param mode An enum representing the current UI mode. Use a when expression on this to render
- * the correct screen. Inside [com.firebase.ui.auth.ui.screens.FirebaseAuthScreen] every mode is its
- * own navigation destination and this mirrors the active one.
+ * the correct screen. Every mode is its own navigation destination and this mirrors the active one.
  * @param isLoading true when an asynchronous operation (like signing in or sending an email)
  * is in progress.
  * @param error An optional error message to display to the user.
@@ -130,19 +128,21 @@ class EmailAuthContentState(
  * including sign-in, sign-up, and password reset. It exposes the state for the current mode to
  * a custom UI via a trailing lambda (slot), allowing for complete visual customization.
  *
- * The mode can be driven from the outside — [com.firebase.ui.auth.ui.screens.FirebaseAuthScreen]
- * gives every mode its own navigation destination and passes [mode] and [onNavigateToMode] — or
- * left to this composable, which then keeps the mode in local state.
+ * The mode is always driven from the outside: a host gives every mode its own navigation
+ * destination and passes [mode] and [onNavigateToMode]. Callers that do not want to own that are
+ * served by [com.firebase.ui.auth.ui.screens.FirebaseAuthScreen], which owns it for them.
  *
  * This composable never changes mode on its own in response to an error. Signing in with an
  * address that has no account leaves the user on the sign-in form rather than moving them to
  * sign-up; acting on an error is the host's job alone.
  *
- * @param mode The mode to render. When null this composable owns the mode itself, starting at
- * [EmailAuthMode.EmailLinkSignIn] for a cross-device email link and [EmailAuthMode.SignIn]
- * otherwise. Goes together with [onNavigateToMode]: passing either without the other is rejected.
- * @param onNavigateToMode Invoked instead of changing local state when the user switches mode,
- * with the address currently typed so the host can carry it over. Goes together with [mode].
+ * @param mode The mode to render. A flow entered for a cross-device email link starts at
+ * [EmailAuthMode.EmailLinkSignIn]; every other entry starts at [EmailAuthMode.SignIn]. Give each
+ * mode its own navigation destination: a host that instead re-renders this screen in place carries
+ * the password, display name and "link sent" latches into the mode it switches to, and leaves
+ * system back with nothing to pop.
+ * @param onNavigateToMode Invoked when the user switches mode, with the address currently typed so
+ * the host can carry it over. Never called for a mode the configuration does not offer.
  * @param onEmailTyped Invoked with the address as the user edits it, so a host driving [mode] has
  * the live value once this step is disposed. Fires per keystroke, so a host must keep what it
  * hears out of anything read during composition.
@@ -158,8 +158,8 @@ fun EmailAuthScreen(
     onError: (AuthException) -> Unit,
     onCancel: () -> Unit,
     prefillEmail: String? = null,
-    mode: EmailAuthMode? = null,
-    onNavigateToMode: ((mode: EmailAuthMode, email: String) -> Unit)? = null,
+    mode: EmailAuthMode,
+    onNavigateToMode: (mode: EmailAuthMode, email: String) -> Unit,
     onEmailTyped: (String) -> Unit = {},
     /**
      * Where a consumed one-off notification leaves the flow. Null retracts to [AuthState.Idle];
@@ -169,24 +169,10 @@ fun EmailAuthScreen(
     onNotificationConsumed: (() -> Unit)? = null,
     content: @Composable ((EmailAuthContentState) -> Unit)? = null,
 ) {
-    require((mode == null) == (onNavigateToMode == null)) {
-        "EmailAuthScreen's mode and onNavigateToMode go together: pass both to drive the mode " +
-                "from outside, or neither to let the screen own it. Got mode=$mode and " +
-                "onNavigateToMode=${if (onNavigateToMode == null) "null" else "a callback"}."
-    }
     val provider = configuration.providers.filterIsInstance<AuthProvider.Email>().first()
     val stringProvider = LocalAuthUIStringProvider.current
-    val dialogController = LocalTopLevelDialogController.current
     val coroutineScope = rememberCoroutineScope()
 
-    val initialMode = if (emailLinkFromDifferentDevice != null && provider.isEmailLinkSignInEnabled) {
-        EmailAuthMode.EmailLinkSignIn
-    } else {
-        EmailAuthMode.SignIn
-    }
-    // Allocated unconditionally: a rememberSaveable must not sit behind a branch on a parameter.
-    val localMode = rememberSaveable { mutableStateOf(initialMode) }
-    val currentMode = mode ?: localMode.value
     val displayNameValue = rememberSaveable { mutableStateOf("") }
     val emailTextValue = rememberSaveable { mutableStateOf(prefillEmail ?: "") }
     val passwordTextValue = rememberSaveable { mutableStateOf("") }
@@ -198,15 +184,6 @@ fun EmailAuthScreen(
 
     val isSignUpOffered = configuration.isEmailSignUpOffered()
     val isEmailLinkSignInOffered = configuration.isEmailLinkSignInOffered()
-
-    // Cleared on a mode change; the address the user typed is deliberately not among them.
-    val secretTextValues = remember {
-        listOf(
-            displayNameValue,
-            passwordTextValue,
-            confirmPasswordTextValue
-        )
-    }
 
     val authFlowScope = rememberAuthFlowScope(authUI, configuration)
     // Under a reauthentication request this is that request's phase, not the host's state.
@@ -227,27 +204,15 @@ fun EmailAuthScreen(
     val retrievedCredential = remember { mutableStateOf<Pair<String, String>?>(null) }
 
     /**
-     * The single way this screen changes mode, so every guard lives in one place. Hosted, it asks
-     * the host to navigate and hands over the typed address; unhosted, it swaps local state and
-     * clears the mode-specific fields itself.
+     * The single way this screen changes mode, so every guard lives in one place: it asks the host
+     * to navigate and hands over the typed address.
      *
      * Only ever called for a switch the user asked for; error recovery is the host's.
      */
     fun goToMode(target: EmailAuthMode) {
         if (target == EmailAuthMode.SignUp && !isSignUpOffered) return
         if (target == EmailAuthMode.EmailLinkSignIn && !isEmailLinkSignInOffered) return
-        if (onNavigateToMode != null) {
-            onNavigateToMode(target, emailTextValue.value)
-            return
-        }
-        // Unhosted, the same composition renders the target, so stale "link sent" latches must go.
-        when (target) {
-            EmailAuthMode.ResetPassword -> resetLinkSentLocal = false
-            EmailAuthMode.SignIn, EmailAuthMode.EmailLinkSignIn -> emailSignInLinkSentLocal = false
-            EmailAuthMode.SignUp -> Unit
-        }
-        secretTextValues.forEach { it.value = "" }
-        localMode.value = target
+        onNavigateToMode(target, emailTextValue.value)
     }
 
     LaunchedEffect(authState) {
@@ -261,16 +226,8 @@ fun EmailAuthScreen(
 
             is AuthState.Error -> {
                 val exception = AuthException.from(state.exception, stringProvider)
+                // The host shows this with its own recovery actions; this screen only reports it.
                 onError(exception)
-                // Hosted, the host already shows this error with its own recovery actions.
-                if (onNavigateToMode == null) {
-                    dialogController?.showErrorDialog(
-                        exception = exception,
-                        errorState = state,
-                        onRetry = null,
-                        onRecover = null,
-                    )
-                }
                 // Consumed so the error doesn't leak into a freshly created screen.
                 authFlowScope.emit(AuthState.Idle)
             }
@@ -295,7 +252,7 @@ fun EmailAuthScreen(
     }
 
     val state = EmailAuthContentState(
-        mode = currentMode,
+        mode = mode,
         displayName = displayNameValue.value,
         email = emailTextValue.value,
         isEmailLocked = isEmailLocked,

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.LocalContext
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.configuration.MfaConfiguration
@@ -48,12 +47,10 @@ import kotlinx.coroutines.launch
  * 2. **ConfigureSms** or **ConfigureTotp** - User sets up their chosen factor
  * 3. **VerifyFactor** - User verifies with a code
  *
- * The step can be driven from the outside —
- * [com.firebase.ui.auth.ui.screens.mfa.mfaEnrollmentDestinations] gives every step its own
- * navigation destination and passes [step], [onNavigateToStep] and [onNavigateBack] — or left to
- * this composable, which then keeps the step in local state. Hosting it is preferred: each step
- * gets a real back-stack entry and the configured screen transitions, and a step switch does not
- * dispose what a previous step held, because that lives in [flowState].
+ * The step is always driven from the outside: a host gives every step its own navigation
+ * destination and passes [step], [onNavigateToStep] and [onNavigateBack], so each step gets a real
+ * back-stack entry and the configured screen transitions, and a step switch does not dispose what a
+ * previous step held, because that lives in [flowState].
  *
  * @param user The currently authenticated [FirebaseUser] to enroll in MFA
  * @param auth The [FirebaseAuth] instance
@@ -61,19 +58,18 @@ import kotlinx.coroutines.launch
  * @param onComplete Callback invoked when enrollment completes successfully
  * @param onSkip Callback invoked when user skips enrollment (only if not required)
  * @param onError Callback invoked when an error occurs during enrollment
- * @param step The step to render. When null this composable owns the step itself, starting at
- * [MfaEnrollmentStep.SelectFactor] — or straight at the single allowed factor's configuration step
- * when [MfaConfiguration.allowedFactors] holds only one. Goes together with [onNavigateToStep],
- * [onNavigateBack] and [flowState]: passing any of the four without the rest throws.
- * @param onNavigateToStep Invoked instead of changing local state when the flow moves forward —
- * selecting a factor, or continuing from a configured one to verification. Always a push. Goes
- * together with [step].
- * @param onNavigateBack Invoked instead of changing local state when the user backs out of a
- * step. Hosted, this is `NavController.popBackStack()`, which returns to whichever of
- * [MfaEnrollmentStep.ConfigureSms] or [MfaEnrollmentStep.ConfigureTotp] was actually pushed before
- * [MfaEnrollmentStep.VerifyFactor]. Goes together with [step].
+ * @param step The step to render. A flow starts at [MfaEnrollmentStep.SelectFactor], or straight at
+ * the single allowed factor's configuration step when [MfaConfiguration.allowedFactors] holds only
+ * one. Give each step its own navigation destination: a host that instead re-renders this screen
+ * in place leaves system back with nothing to pop.
+ * @param onNavigateToStep Invoked when the flow moves forward — selecting a factor, or continuing
+ * from a configured one to verification. Always a push.
+ * @param onNavigateBack Invoked when the user backs out of a step — a pop, which returns to
+ * whichever of [MfaEnrollmentStep.ConfigureSms] or [MfaEnrollmentStep.ConfigureTotp] was actually
+ * pushed before [MfaEnrollmentStep.VerifyFactor].
  * @param flowState The data a step switch must not dispose — see
- * [com.firebase.ui.auth.ui.screens.mfa.MfaEnrollmentFlowState]. Goes together with [step].
+ * [com.firebase.ui.auth.ui.screens.mfa.MfaEnrollmentFlowState]. Build one with
+ * [com.firebase.ui.auth.ui.screens.mfa.rememberMfaEnrollmentFlowState].
  * @param content A composable lambda that receives [MfaEnrollmentContentState] to render custom UI
  *
  * @since 10.0.0
@@ -87,25 +83,12 @@ fun MfaEnrollmentScreen(
     onComplete: () -> Unit,
     onSkip: () -> Unit = {},
     onError: (Exception) -> Unit = {},
-    step: MfaEnrollmentStep? = null,
-    onNavigateToStep: ((MfaEnrollmentStep) -> Unit)? = null,
-    onNavigateBack: (() -> Unit)? = null,
-    flowState: MfaEnrollmentFlowState? = null,
+    step: MfaEnrollmentStep,
+    onNavigateToStep: (MfaEnrollmentStep) -> Unit,
+    onNavigateBack: () -> Unit,
+    flowState: MfaEnrollmentFlowState,
     content: @Composable ((MfaEnrollmentContentState) -> Unit)? = null,
 ) {
-    require(
-        (step == null) == (onNavigateToStep == null) &&
-            (onNavigateToStep == null) == (onNavigateBack == null) &&
-            (onNavigateBack == null) == (flowState == null)
-    ) {
-        "MfaEnrollmentScreen's step, onNavigateToStep, onNavigateBack and flowState go " +
-            "together: pass all four to drive the step from outside, or none to let the " +
-            "screen own it. Got step=$step, onNavigateToStep=" +
-            "${if (onNavigateToStep == null) "null" else "a callback"}, onNavigateBack=" +
-            "${if (onNavigateBack == null) "null" else "a callback"}, flowState=" +
-            "${if (flowState == null) "null" else "provided"}."
-    }
-
     val activity = requireNotNull(LocalActivity.current) {
         "MfaEnrollmentScreen must be used within an Activity context for SMS verification"
     }
@@ -149,29 +132,24 @@ internal fun MfaEnrollmentScreenInternal(
     onComplete: () -> Unit,
     onSkip: () -> Unit = {},
     onError: (Exception) -> Unit = {},
-    step: MfaEnrollmentStep? = null,
-    onNavigateToStep: ((MfaEnrollmentStep) -> Unit)? = null,
-    onNavigateBack: (() -> Unit)? = null,
-    flowState: MfaEnrollmentFlowState? = null,
+    step: MfaEnrollmentStep,
+    onNavigateToStep: (MfaEnrollmentStep) -> Unit,
+    onNavigateBack: () -> Unit,
+    flowState: MfaEnrollmentFlowState,
     content: @Composable ((MfaEnrollmentContentState) -> Unit)? = null
 ) {
     val coroutineScope = rememberCoroutineScope()
     val applicationContext = LocalContext.current.applicationContext
 
-    // Read only when this composable owns the step.
-    val localStep = rememberSaveable { mutableStateOf(MfaEnrollmentStep.SelectFactor) }
-    val currentStep = step ?: localStep.value
-
-    val effectiveFlowState = flowState ?: rememberMfaEnrollmentFlowState()
-    val selectedFactor = effectiveFlowState.selectedFactor
-    val phoneNumber = effectiveFlowState.phoneNumber
-    val verificationCode = effectiveFlowState.verificationCode
-    val resendTimerSeconds = effectiveFlowState.resendTimerSeconds
-    val smsSession = effectiveFlowState.smsSession
-    val totpSecret = effectiveFlowState.totpSecret
-    val totpQrCodeUrl = effectiveFlowState.totpQrCodeUrl
-    val selectedCountry = effectiveFlowState.selectedCountry
-    val totpSecretExpiredMessage = effectiveFlowState.totpSecretExpiredMessage
+    val selectedFactor = flowState.selectedFactor
+    val phoneNumber = flowState.phoneNumber
+    val verificationCode = flowState.verificationCode
+    val resendTimerSeconds = flowState.resendTimerSeconds
+    val smsSession = flowState.smsSession
+    val totpSecret = flowState.totpSecret
+    val totpQrCodeUrl = flowState.totpQrCodeUrl
+    val selectedCountry = flowState.selectedCountry
+    val totpSecretExpiredMessage = flowState.totpSecretExpiredMessage
 
     // Transient per-step UI state: never part of flowState, so a step switch resets it.
     val isLoading = remember { mutableStateOf(false) }
@@ -201,21 +179,9 @@ internal fun MfaEnrollmentScreenInternal(
         }
     }
 
-    // Un-hosted only: hosted, mfaEnrollmentStartStep already resolved the single-factor start.
-    if (step == null) {
-        LaunchedEffect(Unit) {
-            if (configuration.allowedFactors.size == 1) {
-                localStep.value = when (configuration.allowedFactors.first()) {
-                    MfaFactor.Sms -> MfaEnrollmentStep.ConfigureSms
-                    MfaFactor.Totp -> MfaEnrollmentStep.ConfigureTotp
-                }
-            }
-        }
-    }
-
     // The null-secret guard fetches once per entry, so a back-and-forward must not re-fetch.
-    LaunchedEffect(currentStep) {
-        when (currentStep) {
+    LaunchedEffect(step) {
+        when (step) {
             MfaEnrollmentStep.ConfigureSms -> selectedFactor.value = MfaFactor.Sms
             MfaEnrollmentStep.ConfigureTotp -> {
                 selectedFactor.value = MfaFactor.Totp
@@ -245,11 +211,7 @@ internal fun MfaEnrollmentScreenInternal(
                 // A null secret here means Activity recreation dropped it: recover on ConfigureTotp.
                 if (selectedFactor.value == MfaFactor.Totp && totpSecret.value == null) {
                     totpSecretExpiredMessage.value = TOTP_SECRET_EXPIRED_MESSAGE
-                    if (onNavigateBack != null) {
-                        onNavigateBack()
-                    } else {
-                        localStep.value = MfaEnrollmentStep.ConfigureTotp
-                    }
+                    onNavigateBack()
                 }
             }
             MfaEnrollmentStep.SelectFactor -> Unit
@@ -257,49 +219,20 @@ internal fun MfaEnrollmentScreenInternal(
     }
 
     /**
-     * Moves the flow forward one step: hosted, asks the host to navigate; un-hosted, swaps local
-     * state. Forward moves only — a backward move goes through `onBackClick`.
+     * Moves the flow forward one step, by asking the host to navigate. Forward moves only — a
+     * backward move goes through `onBackClick`.
      */
     fun goToStep(target: MfaEnrollmentStep) {
-        if (onNavigateToStep != null) {
-            onNavigateToStep(target)
-        } else {
-            localStep.value = target
-        }
+        onNavigateToStep(target)
     }
 
     val state = MfaEnrollmentContentState(
-        step = currentStep,
+        step = step,
         isLoading = isLoading.value,
         error = error.value,
         exception = lastException.value,
-        onBackClick = {
-            if (onNavigateBack != null) {
-                // Hosted, flowState is deliberately not cleared: a step still on the stack keeps it.
-                onNavigateBack()
-            } else {
-                when (currentStep) {
-                    MfaEnrollmentStep.SelectFactor -> {}
-                    MfaEnrollmentStep.ConfigureSms, MfaEnrollmentStep.ConfigureTotp -> {
-                        localStep.value = MfaEnrollmentStep.SelectFactor
-                        selectedFactor.value = null
-                        phoneNumber.value = ""
-                        totpSecret.value = null
-                        totpQrCodeUrl.value = null
-                    }
-                    MfaEnrollmentStep.VerifyFactor -> {
-                        verificationCode.value = ""
-                        localStep.value = when (selectedFactor.value) {
-                            MfaFactor.Sms -> MfaEnrollmentStep.ConfigureSms
-                            MfaFactor.Totp -> MfaEnrollmentStep.ConfigureTotp
-                            null -> MfaEnrollmentStep.SelectFactor
-                        }
-                    }
-                }
-                error.value = null
-                lastException.value = null
-            }
-        },
+        // flowState is deliberately not cleared: a step still on the stack keeps it.
+        onBackClick = onNavigateBack,
         availableFactors = configuration.allowedFactors,
         enrolledFactors = enrolledFactors.value,
         onFactorSelected = { factor ->

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthDestinations.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthDestinations.kt
@@ -31,6 +31,7 @@ import com.firebase.ui.auth.FirebaseAuthUI
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
 import com.firebase.ui.auth.data.CountryData
+import com.firebase.ui.auth.data.CountryDataSaver
 import com.firebase.ui.auth.ui.screens.AuthRoute
 import com.firebase.ui.auth.ui.screens.authRouteMetadata
 import com.firebase.ui.auth.ui.screens.phoneStep
@@ -51,9 +52,10 @@ import kotlinx.coroutines.Job
  * through [phoneAuthDestinations], this is what a step reads and writes instead of its own local
  * state.
  *
- * [phoneNumber], [verificationCode], [verificationId], [forceResendingToken] and
- * [resendTimerSeconds] are backed by [rememberSaveable] and survive Activity recreation.
- * [selectedCountry] is not, matching what the un-hosted screen always did.
+ * [phoneNumber], [verificationCode], [selectedCountry], [verificationId], [forceResendingToken]
+ * and [resendTimerSeconds] are backed by [rememberSaveable] and survive Activity recreation.
+ * [selectedCountry] has to: the number it prefixes is restored, so a country re-resolved from the
+ * configuration instead would submit the typed number under a dial code the user never chose.
  *
  * @since 10.0.0
  */
@@ -95,7 +97,7 @@ fun rememberPhoneAuthFlowState(configuration: AuthUIConfiguration): PhoneAuthFlo
     val provider = configuration.providers.filterIsInstance<AuthProvider.Phone>().firstOrNull()
     val phoneNumber = rememberSaveable { mutableStateOf(provider?.defaultNumber ?: "") }
     val verificationCode = rememberSaveable { mutableStateOf("") }
-    val selectedCountry = remember {
+    val selectedCountry = rememberSaveable(stateSaver = CountryDataSaver) {
         mutableStateOf(
             provider?.defaultCountryCode?.let { code -> CountryUtils.findByCountryCode(code) }
                 ?: CountryUtils.getDefaultCountry()

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
@@ -122,16 +121,15 @@ class PhoneAuthContentState(
  * @param onCancel Callback invoked when the user cancels the authentication flow.
  * @param modifier Applied once to the [Box] hosting the rendered content; it propagates minimum
  * constraints so it doesn't change how content is measured.
- * @param step The step to render. When null this composable owns the step itself, starting at
- * [PhoneAuthStep.EnterPhoneNumber]. Goes together with [onNavigateToStep], [onNavigateBack] and
- * [flowState]: passing any of the four without the rest throws.
- * @param onNavigateToStep Invoked instead of changing local state when a sent code moves the flow
- * on to [PhoneAuthStep.EnterVerificationCode]. Always a push. Goes together with [step].
- * @param onNavigateBack Invoked instead of changing local state when the user asks to change the
- * number they entered. Hosted, this is a pop back to [PhoneAuthStep.EnterPhoneNumber]. Goes
- * together with [step].
- * @param flowState The data a step switch must not dispose — see [PhoneAuthFlowState]. Goes
- * together with [step].
+ * @param step The step to render. A flow starts at [PhoneAuthStep.EnterPhoneNumber]. Give each
+ * step its own navigation destination: a host that instead re-renders this screen in place
+ * leaves system back with nothing to pop.
+ * @param onNavigateToStep Invoked when a sent code moves the flow on to
+ * [PhoneAuthStep.EnterVerificationCode]. Always a push.
+ * @param onNavigateBack Invoked when the user asks to change the number they entered — a pop back
+ * to [PhoneAuthStep.EnterPhoneNumber].
+ * @param flowState The data a step switch must not dispose — see [PhoneAuthFlowState]. Build one
+ * with [rememberPhoneAuthFlowState].
  * @param content A composable lambda that receives [PhoneAuthContentState] to render the UI for
  * each step. If null, the default UI for the current step is rendered.
  */
@@ -144,10 +142,10 @@ fun PhoneAuthScreen(
     onError: (AuthException) -> Unit,
     onCancel: () -> Unit,
     modifier: Modifier = Modifier,
-    step: PhoneAuthStep? = null,
-    onNavigateToStep: ((PhoneAuthStep) -> Unit)? = null,
-    onNavigateBack: (() -> Unit)? = null,
-    flowState: PhoneAuthFlowState? = null,
+    step: PhoneAuthStep,
+    onNavigateToStep: (PhoneAuthStep) -> Unit,
+    onNavigateBack: () -> Unit,
+    flowState: PhoneAuthFlowState,
     /**
      * Where a consumed one-off notification leaves the flow. Null retracts to [AuthState.Idle];
      * reauthentication passes its own, returning the request to provider selection.
@@ -160,52 +158,24 @@ fun PhoneAuthScreen(
     onAttemptStarted: (() -> Unit)? = null,
     content: @Composable ((PhoneAuthContentState) -> Unit)? = null,
 ) {
-    require(
-        (step == null) == (onNavigateToStep == null) &&
-            (onNavigateToStep == null) == (onNavigateBack == null) &&
-            (onNavigateBack == null) == (flowState == null)
-    ) {
-        "PhoneAuthScreen's step, onNavigateToStep, onNavigateBack and flowState go together: " +
-            "pass all four to drive the step from outside, or none to let the screen own it. " +
-            "Got step=$step, onNavigateToStep=" +
-            "${if (onNavigateToStep == null) "null" else "a callback"}, onNavigateBack=" +
-            "${if (onNavigateBack == null) "null" else "a callback"}, flowState=" +
-            "${if (flowState == null) "null" else "provided"}."
-    }
-
     val activity = LocalActivity.current
     val provider = configuration.providers.filterIsInstance<AuthProvider.Phone>().first()
     val stringProvider = LocalAuthUIStringProvider.current
     val dialogController = LocalTopLevelDialogController.current
     val coroutineScope = rememberCoroutineScope()
 
-    // Read only when this composable owns the step.
-    val localStep = rememberSaveable { mutableStateOf(PhoneAuthStep.EnterPhoneNumber) }
-    val currentStep = step ?: localStep.value
-    val navigateToStep: (PhoneAuthStep) -> Unit = { target ->
-        if (onNavigateToStep != null) onNavigateToStep(target) else localStep.value = target
-    }
-    val navigateBack: () -> Unit = {
-        if (onNavigateBack != null) {
-            onNavigateBack()
-        } else {
-            localStep.value = PhoneAuthStep.EnterPhoneNumber
-        }
-    }
-
-    val effectiveFlowState = flowState ?: rememberPhoneAuthFlowState(configuration)
-    val phoneNumberValue = effectiveFlowState.phoneNumber
-    val verificationCodeValue = effectiveFlowState.verificationCode
-    val selectedCountry = effectiveFlowState.selectedCountry
-    val verificationId = effectiveFlowState.verificationId
-    val forceResendingToken = effectiveFlowState.forceResendingToken
-    val resendTimerSeconds = effectiveFlowState.resendTimerSeconds
-    val pendingVerificationPhoneNumber = effectiveFlowState.pendingVerificationPhoneNumber
-    val verificationStartTime = effectiveFlowState.verificationStartTime
-    val verificationJob = effectiveFlowState.verificationJob
-    val verificationScope = effectiveFlowState.verificationScope
-    val navigatedVerificationId = effectiveFlowState.navigatedVerificationId
-    val consumedAutoCredential = effectiveFlowState.consumedAutoCredential
+    val phoneNumberValue = flowState.phoneNumber
+    val verificationCodeValue = flowState.verificationCode
+    val selectedCountry = flowState.selectedCountry
+    val verificationId = flowState.verificationId
+    val forceResendingToken = flowState.forceResendingToken
+    val resendTimerSeconds = flowState.resendTimerSeconds
+    val pendingVerificationPhoneNumber = flowState.pendingVerificationPhoneNumber
+    val verificationStartTime = flowState.verificationStartTime
+    val verificationJob = flowState.verificationJob
+    val verificationScope = flowState.verificationScope
+    val navigatedVerificationId = flowState.navigatedVerificationId
+    val consumedAutoCredential = flowState.consumedAutoCredential
 
     val fullPhoneNumber = remember(selectedCountry.value, phoneNumberValue.value) {
         CountryUtils.formatPhoneNumber(selectedCountry.value.dialCode, phoneNumberValue.value)
@@ -293,7 +263,7 @@ fun PhoneAuthScreen(
                 // so the move it already made must not repeat.
                 if (navigatedVerificationId.value != id) {
                     navigatedVerificationId.value = id
-                    navigateToStep(PhoneAuthStep.EnterVerificationCode)
+                    onNavigateToStep(PhoneAuthStep.EnterVerificationCode)
                 }
                 resendTimerSeconds.intValue = provider.timeout.toInt() // Start 60-second countdown
             }
@@ -397,7 +367,7 @@ fun PhoneAuthScreen(
     }
 
     val state = PhoneAuthContentState(
-        step = currentStep,
+        step = step,
         isLoading = isLoading,
         error = errorMessage,
         phoneNumber = phoneNumberValue.value,
@@ -513,7 +483,7 @@ fun PhoneAuthScreen(
             onNotificationConsumed?.invoke() ?: authFlowScope.emit(AuthState.Idle)
             verificationJob.value = null
             isSubmittingCode.value = false
-            navigateBack()
+            onNavigateBack()
             verificationCodeValue.value = ""
             verificationId.value = null
             forceResendingToken.value = null

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/MfaEnrollmentScreenTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/MfaEnrollmentScreenTest.kt
@@ -14,9 +14,16 @@
 
 package com.firebase.ui.auth.ui.screens
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.firebase.ui.auth.configuration.MfaConfiguration
@@ -30,6 +37,7 @@ import com.firebase.ui.auth.mfa.TotpEnrollmentHandler
 import com.firebase.ui.auth.mfa.TotpSecret
 import com.firebase.ui.auth.ui.screens.mfa.MfaEnrollmentScreen
 import com.firebase.ui.auth.ui.screens.mfa.MfaEnrollmentScreenInternal
+import com.firebase.ui.auth.ui.screens.mfa.rememberMfaEnrollmentFlowState
 import com.firebase.ui.auth.ui.screens.mfa.TOTP_SECRET_EXPIRED_MESSAGE
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
@@ -128,44 +136,13 @@ class MfaEnrollmentScreenTest {
         )
 
         composeTestRule.setContent {
-            MfaEnrollmentScreen(
-                user = mockUser,
-                auth = mockAuth,
-                configuration = configuration,
-                onComplete = {},
-                onSkip = {}
-            ) { state ->
-                capturedState = state
-            }
+            MfaEnrollmentUnderTest(configuration) { state -> capturedState = state }
         }
 
         composeTestRule.waitForIdle()
         assertEquals(MfaEnrollmentStep.SelectFactor, capturedState.step)
         assertEquals(2, capturedState.availableFactors.size)
         assertNotNull(capturedState.onSkipClick)
-    }
-
-    @Test
-    fun `screen skips SelectFactor with single SMS factor`() {
-        val configuration = MfaConfiguration(
-            allowedFactors = listOf(MfaFactor.Sms),
-            requireEnrollment = false
-        )
-
-        composeTestRule.setContent {
-            MfaEnrollmentScreen(
-                user = mockUser,
-                auth = mockAuth,
-                configuration = configuration,
-                onComplete = {},
-                onSkip = {}
-            ) { state ->
-                capturedState = state
-            }
-        }
-
-        composeTestRule.waitForIdle()
-        assertEquals(MfaEnrollmentStep.ConfigureSms, capturedState.step)
     }
 
     @Test
@@ -176,15 +153,7 @@ class MfaEnrollmentScreenTest {
         )
 
         composeTestRule.setContent {
-            MfaEnrollmentScreen(
-                user = mockUser,
-                auth = mockAuth,
-                configuration = configuration,
-                onComplete = {},
-                onSkip = {}
-            ) { state ->
-                capturedState = state
-            }
+            MfaEnrollmentUnderTest(configuration) { state -> capturedState = state }
         }
 
         composeTestRule.waitForIdle()
@@ -201,14 +170,7 @@ class MfaEnrollmentScreenTest {
         var currentState by mutableStateOf<MfaEnrollmentContentState?>(null)
 
         composeTestRule.setContent {
-            MfaEnrollmentScreen(
-                user = mockUser,
-                auth = mockAuth,
-                configuration = configuration,
-                onComplete = {}
-            ) { state ->
-                currentState = state
-            }
+            MfaEnrollmentUnderTest(configuration) { state -> currentState = state }
         }
 
         composeTestRule.waitForIdle()
@@ -231,12 +193,7 @@ class MfaEnrollmentScreenTest {
         var currentState by mutableStateOf<MfaEnrollmentContentState?>(null)
 
         composeTestRule.setContent {
-            MfaEnrollmentScreen(
-                user = mockUser,
-                auth = mockAuth,
-                configuration = configuration,
-                onComplete = {}
-            ) { state ->
+            MfaEnrollmentUnderTest(configuration, MfaEnrollmentStep.ConfigureSms) { state ->
                 currentState = state
             }
         }
@@ -261,21 +218,9 @@ class MfaEnrollmentScreenTest {
         var currentState by mutableStateOf<MfaEnrollmentContentState?>(null)
 
         composeTestRule.setContent {
-            MfaEnrollmentScreen(
-                user = mockUser,
-                auth = mockAuth,
-                configuration = configuration,
-                onComplete = {}
-            ) { state ->
+            MfaEnrollmentUnderTest(configuration, MfaEnrollmentStep.VerifyFactor) { state ->
                 currentState = state
             }
-        }
-
-        composeTestRule.waitForIdle()
-
-        // Navigate to verify step manually by updating state
-        composeTestRule.runOnUiThread {
-            currentState?.onPhoneNumberChange?.invoke("1234567890")
         }
 
         composeTestRule.waitForIdle()
@@ -297,14 +242,7 @@ class MfaEnrollmentScreenTest {
         var currentState by mutableStateOf<MfaEnrollmentContentState?>(null)
 
         composeTestRule.setContent {
-            MfaEnrollmentScreen(
-                user = mockUser,
-                auth = mockAuth,
-                configuration = configuration,
-                onComplete = {}
-            ) { state ->
-                currentState = state
-            }
+            MfaEnrollmentUnderTest(configuration) { state -> currentState = state }
         }
 
         composeTestRule.waitForIdle()
@@ -333,12 +271,7 @@ class MfaEnrollmentScreenTest {
         var currentState by mutableStateOf<MfaEnrollmentContentState?>(null)
 
         composeTestRule.setContent {
-            MfaEnrollmentScreen(
-                user = mockUser,
-                auth = mockAuth,
-                configuration = configuration,
-                onComplete = {}
-            ) { state ->
+            MfaEnrollmentUnderTest(configuration, MfaEnrollmentStep.ConfigureSms) { state ->
                 currentState = state
             }
         }
@@ -365,14 +298,7 @@ class MfaEnrollmentScreenTest {
         )
 
         composeTestRule.setContent {
-            MfaEnrollmentScreen(
-                user = mockUser,
-                auth = mockAuth,
-                configuration = configuration,
-                onComplete = {}
-            ) { state ->
-                capturedState = state
-            }
+            MfaEnrollmentUnderTest(configuration) { state -> capturedState = state }
         }
 
         composeTestRule.waitForIdle()
@@ -386,12 +312,7 @@ class MfaEnrollmentScreenTest {
         )
 
         composeTestRule.setContent {
-            MfaEnrollmentScreen(
-                user = mockUser,
-                auth = mockAuth,
-                configuration = configuration,
-                onComplete = {}
-            ) { state ->
+            MfaEnrollmentUnderTest(configuration, MfaEnrollmentStep.ConfigureSms) { state ->
                 capturedState = state
             }
         }
@@ -440,9 +361,10 @@ class MfaEnrollmentScreenTest {
     @Test
     fun `successful TOTP enrollment refreshes the enrolled factors from the user`() {
         val enrolledFactor = mock<MultiFactorInfo>()
-        // First read is the initial state; the second is the post-enrollment refresh.
-        `when`(mockMultiFactor.enrolledFactors)
-            .thenReturn(emptyList(), listOf(enrolledFactor))
+        // Stubbed by what the user actually has rather than by read count: each step reads the
+        // enrolled factors for itself, so how many reads the walk to VerifyFactor takes is not
+        // this test's business.
+        `when`(mockMultiFactor.enrolledFactors).thenReturn(emptyList())
 
         val state = driveTotpFlowToVerifyStep(
             configuration = MfaConfiguration(allowedFactors = listOf(MfaFactor.Totp)),
@@ -450,6 +372,9 @@ class MfaEnrollmentScreenTest {
         )
 
         assertEquals(emptyList<MultiFactorInfo>(), state()?.enrolledFactors)
+
+        // Enrolment is what puts the factor on the user; the refresh after it must pick that up.
+        `when`(mockMultiFactor.enrolledFactors).thenReturn(listOf(enrolledFactor))
 
         composeTestRule.runOnUiThread {
             state()?.onVerifyClick?.invoke()
@@ -504,14 +429,11 @@ class MfaEnrollmentScreenTest {
         // Two allowed factors, so nothing is auto-selected until the TOTP factor is picked.
         val restorationTester = StateRestorationTester(composeTestRule)
         restorationTester.setContent {
-            MfaEnrollmentScreenInternal(
-                user = mockUser,
-                auth = mockAuth,
+            MfaEnrollmentInternalUnderTest(
                 configuration = configuration,
-                smsHandler = mockSmsHandler,
-                totpHandler = mockTotpHandler,
+                startStep = MfaEnrollmentStep.SelectFactor,
                 onComplete = { completeCount++ },
-                onError = { errors.add(it) }
+                onError = { errors.add(it) },
             ) { state ->
                 currentState = state
             }
@@ -604,14 +526,11 @@ class MfaEnrollmentScreenTest {
         var currentState by mutableStateOf<MfaEnrollmentContentState?>(null)
 
         composeTestRule.setContent {
-            MfaEnrollmentScreenInternal(
-                user = mockUser,
-                auth = mockAuth,
+            MfaEnrollmentInternalUnderTest(
                 configuration = configuration,
-                smsHandler = mockSmsHandler,
-                totpHandler = mockTotpHandler,
+                startStep = MfaEnrollmentStep.ConfigureSms,
                 onComplete = {},
-                onError = { errors.add(it) }
+                onError = { errors.add(it) },
             ) { state ->
                 currentState = state
             }
@@ -680,14 +599,11 @@ class MfaEnrollmentScreenTest {
         var currentState by mutableStateOf<MfaEnrollmentContentState?>(null)
 
         composeTestRule.setContent {
-            MfaEnrollmentScreenInternal(
-                user = mockUser,
-                auth = mockAuth,
+            MfaEnrollmentInternalUnderTest(
                 configuration = configuration,
-                smsHandler = mockSmsHandler,
-                totpHandler = mockTotpHandler,
+                startStep = MfaEnrollmentStep.ConfigureSms,
                 onComplete = { completeCount++ },
-                onError = { errors.add(it) }
+                onError = { errors.add(it) },
             ) { state ->
                 currentState = state
             }
@@ -727,14 +643,11 @@ class MfaEnrollmentScreenTest {
         var currentState by mutableStateOf<MfaEnrollmentContentState?>(null)
 
         composeTestRule.setContent {
-            MfaEnrollmentScreenInternal(
-                user = mockUser,
-                auth = mockAuth,
+            MfaEnrollmentInternalUnderTest(
                 configuration = configuration,
-                smsHandler = mockSmsHandler,
-                totpHandler = mockTotpHandler,
+                startStep = MfaEnrollmentStep.ConfigureSms,
                 onComplete = { completeCount++ },
-                onError = { errors.add(it) }
+                onError = { errors.add(it) },
             ) { state ->
                 currentState = state
             }
@@ -880,14 +793,11 @@ class MfaEnrollmentScreenTest {
         var currentState by mutableStateOf<MfaEnrollmentContentState?>(null)
 
         composeTestRule.setContent {
-            MfaEnrollmentScreenInternal(
-                user = mockUser,
-                auth = mockAuth,
+            MfaEnrollmentInternalUnderTest(
                 configuration = MfaConfiguration(allowedFactors = listOf(MfaFactor.Sms)),
-                smsHandler = mockSmsHandler,
-                totpHandler = mockTotpHandler,
+                startStep = MfaEnrollmentStep.ConfigureSms,
                 onComplete = onComplete,
-                onError = onError
+                onError = onError,
             ) { state ->
                 currentState = state
             }
@@ -934,14 +844,11 @@ class MfaEnrollmentScreenTest {
         var currentState by mutableStateOf<MfaEnrollmentContentState?>(null)
 
         composeTestRule.setContent {
-            MfaEnrollmentScreenInternal(
-                user = mockUser,
-                auth = mockAuth,
+            MfaEnrollmentInternalUnderTest(
                 configuration = configuration,
-                smsHandler = mockSmsHandler,
-                totpHandler = mockTotpHandler,
+                startStep = MfaEnrollmentStep.ConfigureTotp,
                 onComplete = onComplete,
-                onError = onError
+                onError = onError,
             ) { state ->
                 currentState = state
             }
@@ -968,7 +875,81 @@ class MfaEnrollmentScreenTest {
         return { currentState }
     }
 
+    /**
+     * Hosts [MfaEnrollmentScreen] the way a navigation host does, since the screen no longer owns
+     * its step: a saveable stack, so it survives recreation the way a back stack does, and a [key]
+     * on the top of it, so every step composes fresh instead of inheriting what the last one held.
+     */
+    @Composable
+    private fun MfaEnrollmentUnderTest(
+        configuration: MfaConfiguration,
+        startStep: MfaEnrollmentStep = MfaEnrollmentStep.SelectFactor,
+        onComplete: () -> Unit = {},
+        onSkip: () -> Unit = {},
+        onError: (Exception) -> Unit = {},
+        content: @Composable (MfaEnrollmentContentState) -> Unit,
+    ) {
+        val stack = rememberSaveable(saver = STEP_STACK_SAVER) { mutableStateListOf(startStep) }
+        val flowState = rememberMfaEnrollmentFlowState()
+        // NOTE: `key` re-creates state on a switch; a real NavDisplay pop would restore it.
+        key(stack.last()) {
+            MfaEnrollmentScreen(
+                user = mockUser,
+                auth = mockAuth,
+                configuration = configuration,
+                onComplete = onComplete,
+                onSkip = onSkip,
+                onError = onError,
+                step = stack.last(),
+                onNavigateToStep = { stack.add(it) },
+                onNavigateBack = { if (stack.size > 1) stack.removeAt(stack.lastIndex) },
+                flowState = flowState,
+                content = content,
+            )
+        }
+    }
+
+    /** [MfaEnrollmentUnderTest] against the handler-injection seam, for the enrolment tests. */
+    @Composable
+    private fun MfaEnrollmentInternalUnderTest(
+        configuration: MfaConfiguration,
+        startStep: MfaEnrollmentStep = MfaEnrollmentStep.SelectFactor,
+        onComplete: () -> Unit = {},
+        onSkip: () -> Unit = {},
+        onError: (Exception) -> Unit = {},
+        content: @Composable (MfaEnrollmentContentState) -> Unit,
+    ) {
+        val stack = rememberSaveable(saver = STEP_STACK_SAVER) { mutableStateListOf(startStep) }
+        val flowState = rememberMfaEnrollmentFlowState()
+        // NOTE: `key` re-creates state on a switch; a real NavDisplay pop would restore it.
+        key(stack.last()) {
+            MfaEnrollmentScreenInternal(
+                user = mockUser,
+                auth = mockAuth,
+                configuration = configuration,
+                smsHandler = mockSmsHandler,
+                totpHandler = mockTotpHandler,
+                onComplete = onComplete,
+                onSkip = onSkip,
+                onError = onError,
+                step = stack.last(),
+                onNavigateToStep = { stack.add(it) },
+                onNavigateBack = { if (stack.size > 1) stack.removeAt(stack.lastIndex) },
+                flowState = flowState,
+                content = content,
+            )
+        }
+    }
+
     private companion object {
+        /** The host's stack is what survives process death; the flow state's secret is not. */
+        val STEP_STACK_SAVER = listSaver<SnapshotStateList<MfaEnrollmentStep>, Int>(
+            save = { stack -> stack.map { it.ordinal } },
+            restore = { saved ->
+                saved.map { MfaEnrollmentStep.entries[it] }.toMutableStateList()
+            },
+        )
+
         const val VERIFICATION_CODE = "123456"
         const val TOTP_DISPLAY_NAME = "Authenticator App"
         const val SMS_DISPLAY_NAME = "SMS"

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreenModeSwitchTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreenModeSwitchTest.kt
@@ -17,6 +17,11 @@ package com.firebase.ui.auth.ui.screens.email
 import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.core.app.ApplicationProvider
 import com.firebase.ui.auth.AuthException
@@ -33,23 +38,20 @@ import com.google.firebase.FirebaseOptions
 import com.google.firebase.auth.ActionCodeSettings
 import com.google.firebase.auth.FirebaseAuth
 import org.junit.After
-import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /**
- * [EmailAuthScreen] used on its own, with nothing outside it driving the mode — the shape
- * `EmailAuthSlotDemoActivity` and the custom reauthentication content both use.
+ * How [EmailAuthScreen] reports a mode switch to whoever hosts it.
  *
- * Switching modes used to blank *every* text field, so a user who typed their address on the
- * sign-in form and then tapped through to sign-up, password recovery or email-link sign-in had to
- * type it again. Only the secrets are mode-specific and may be cleared.
+ * The screen renders the mode it is given and never changes it, so what is testable here is the
+ * report: which mode a switch control names, and that the address the user typed goes with it, so
+ * a host can carry it to the destination it navigates to.
  *
  * @suppress Internal test class
  */
@@ -64,6 +66,7 @@ class EmailAuthScreenModeSwitchTest {
     private lateinit var authUI: FirebaseAuthUI
 
     private var lastState: EmailAuthContentState? = null
+    private val reported = mutableListOf<Pair<EmailAuthMode, String>>()
 
     @Before
     fun setUp() {
@@ -84,6 +87,7 @@ class EmailAuthScreenModeSwitchTest {
     @After
     fun tearDown() {
         lastState = null
+        reported.clear()
         FirebaseAuthUI.clearInstanceCache()
         FirebaseApp.getApps(applicationContext).forEach {
             try {
@@ -93,68 +97,50 @@ class EmailAuthScreenModeSwitchTest {
         }
     }
 
+    /**
+     * The address is the one field a switch must not lose: a user who typed it on the sign-in form
+     * and tapped through to sign-up should not have to type it again. It travels as the second
+     * argument, because the destination is a different composition that holds nothing of this one.
+     */
     @Test
-    fun `the typed address survives every mode switch`() {
+    fun `a switch carries the address typed so far`() {
         start()
         type { it.onEmailChange(TYPED_EMAIL) }
 
-        listOf(
+        goTo(EmailAuthMode.SignUp)
+
+        assertThat(reported).containsExactly(EmailAuthMode.SignUp to TYPED_EMAIL)
+    }
+
+    /** Every switch control names its own mode, and reports rather than renders it. */
+    @Test
+    fun `every switch control reports the mode it names`() {
+        start()
+
+        goTo(EmailAuthMode.SignUp)
+        goTo(EmailAuthMode.ResetPassword)
+        goTo(EmailAuthMode.EmailLinkSignIn)
+        goTo(EmailAuthMode.SignIn)
+
+        assertThat(reported.map { it.first }).containsExactly(
             EmailAuthMode.SignUp,
-            EmailAuthMode.SignIn,
             EmailAuthMode.ResetPassword,
             EmailAuthMode.EmailLinkSignIn,
             EmailAuthMode.SignIn,
-        ).forEach { target ->
-            goTo(target)
-
-            assertThat(state().mode).isEqualTo(target)
-            assertThat(state().email).isEqualTo(TYPED_EMAIL)
-        }
-    }
-
-    @Test
-    fun `switching modes still clears the password, its confirmation and the display name`() {
-        start()
-        type {
-            it.onEmailChange(TYPED_EMAIL)
-            it.onPasswordChange("hunter2")
-            it.onConfirmPasswordChange("hunter2")
-            it.onDisplayNameChange("Ada")
-        }
-
-        goTo(EmailAuthMode.SignUp)
-
-        assertThat(state().password).isEmpty()
-        assertThat(state().confirmPassword).isEmpty()
-        assertThat(state().displayName).isEmpty()
-    }
-
-    /**
-     * Without a host driving it the screen owns the mode itself, which is what keeps standalone
-     * callers working unchanged.
-     */
-    @Test
-    fun `the unhosted screen drives its own mode from local state`() {
-        start()
-
-        assertThat(state().mode).isEqualTo(EmailAuthMode.SignIn)
-
-        goTo(EmailAuthMode.ResetPassword)
-        assertThat(state().mode).isEqualTo(EmailAuthMode.ResetPassword)
-
-        goTo(EmailAuthMode.SignIn)
+        ).inOrder()
+        // Reporting a switch is not rendering one: the mode on screen is still the one passed in.
         assertThat(state().mode).isEqualTo(EmailAuthMode.SignIn)
     }
 
     /**
      * Signing in with an address that has no account used to hop this screen to sign-up on its
-     * own. That decision now belongs to a host — only a host knows what lies outside the email
-     * flow, and two observers of one shared error event raced each other for the recovery dialog.
-     * Unhosted, the user stays on the form with everything they typed, including the password,
-     * which nothing asked to clear.
+     * own. That decision belongs to a host — only a host knows what lies outside the email flow,
+     * and two observers of one shared error event raced each other for the recovery dialog. The
+     * user stays on the form with everything they typed, including the password, which nothing
+     * asked to clear.
      */
     @Test
-    fun `an unhosted screen stays put and keeps what was typed when the account is not found`() {
+    fun `no switch is reported when the account is not found`() {
         start()
         type {
             it.onEmailChange(TYPED_EMAIL)
@@ -168,6 +154,7 @@ class EmailAuthScreenModeSwitchTest {
         }
         composeTestRule.waitForIdle()
 
+        assertThat(reported).isEmpty()
         assertThat(state().mode).isEqualTo(EmailAuthMode.SignIn)
         assertThat(state().email).isEqualTo(TYPED_EMAIL)
         assertThat(state().password).isEqualTo("hunter2")
@@ -175,9 +162,8 @@ class EmailAuthScreenModeSwitchTest {
 
     /** The same for an address already taken, which used to hop the other way. */
     @Test
-    fun `an unhosted screen stays put when the address is already in use`() {
-        start()
-        goTo(EmailAuthMode.SignUp)
+    fun `no switch is reported when the address is already in use`() {
+        start(EmailAuthMode.SignUp)
         type { it.onEmailChange(TYPED_EMAIL) }
 
         composeTestRule.runOnIdle {
@@ -192,61 +178,70 @@ class EmailAuthScreenModeSwitchTest {
         }
         composeTestRule.waitForIdle()
 
+        assertThat(reported).isEmpty()
         assertThat(state().mode).isEqualTo(EmailAuthMode.SignUp)
         assertThat(state().email).isEqualTo(TYPED_EMAIL)
     }
 
     /**
-     * `mode` and `onNavigateToMode` are two halves of one contract. Either alone leaves every
-     * switch control silently inert — a fixed mode with nowhere to report a switch to, or a
-     * reported switch that nothing renders — so it is rejected instead of tolerated.
+     * The shape this screen cannot defend itself against, pinned so the hazard is visible: a host
+     * that satisfies [EmailAuthScreen]'s `mode` and `onNavigateToMode` out of plain state, without
+     * giving the target mode a composition of its own.
+     *
+     * Compose sees one call site and keeps the composition, so every `rememberSaveable` the screen
+     * holds survives the switch — including the password typed on the sign-in form, which then
+     * greets the user pre-filled on sign-up.
      */
     @Test
-    fun `a mode with no way to report a switch is rejected`() {
-        val thrown = assertThrows(IllegalArgumentException::class.java) {
-            startWith(mode = EmailAuthMode.SignUp, onNavigateToMode = null)
-        }
+    fun `flipping the mode parameter within one composition carries the password over`() {
+        startFlippingAParameter(fresh = false)
 
-        // Both halves are named. A caller who passed one and forgot the other has to be told
-        // which one is missing, and that has to work in either direction.
-        assertThat(thrown).hasMessageThat().contains("mode")
-        assertThat(thrown).hasMessageThat().contains("onNavigateToMode")
+        type { it.onPasswordChange("hunter2") }
+        goTo(EmailAuthMode.SignUp)
+
+        assertThat(state().mode).isEqualTo(EmailAuthMode.SignUp)
+        assertThat(state().password).isEqualTo("hunter2")
     }
 
     /**
-     * The direction the message used to point the wrong way: a caller who supplied
-     * `onNavigateToMode` and forgot `mode` was told only about the parameter they *did* pass.
+     * The same host, one line different: the target mode gets its own composition. That is all real
+     * navigation does here, and it is the whole of the difference — nothing in the screen changes.
      */
     @Test
-    fun `a switch callback with no mode to render is rejected`() {
-        val thrown = assertThrows(IllegalArgumentException::class.java) {
-            startWith(mode = null, onNavigateToMode = { _, _ -> })
-        }
+    fun `giving the target mode its own composition leaves the password behind`() {
+        startFlippingAParameter(fresh = true)
 
-        assertThat(thrown).hasMessageThat().contains("mode")
-        assertThat(thrown).hasMessageThat().contains("onNavigateToMode")
+        type { it.onPasswordChange("hunter2") }
+        goTo(EmailAuthMode.SignUp)
+
+        assertThat(state().mode).isEqualTo(EmailAuthMode.SignUp)
+        assertThat(state().password).isEmpty()
     }
 
-    private fun startWith(
-        mode: EmailAuthMode?,
-        onNavigateToMode: ((EmailAuthMode, String) -> Unit)?,
-    ) {
+    /**
+     * A host driving the mode from plain state. [fresh] is the only variable under test: whether
+     * the target mode is composed anew, the way a navigation destination is.
+     */
+    private fun startFlippingAParameter(fresh: Boolean) {
         composeTestRule.setContent {
+            var mode by remember { mutableStateOf(EmailAuthMode.SignIn) }
             CompositionLocalProvider(
-                LocalAuthUIStringProvider provides
-                        DefaultAuthUIStringProvider(applicationContext)
+                LocalAuthUIStringProvider provides DefaultAuthUIStringProvider(applicationContext)
             ) {
-                EmailAuthScreen(
-                    context = applicationContext,
-                    configuration = configuration(),
-                    authUI = authUI,
-                    onSuccess = {},
-                    onError = {},
-                    onCancel = {},
-                    mode = mode,
-                    onNavigateToMode = onNavigateToMode,
-                    content = { },
-                )
+                // NOTE: `key` re-creates state on a switch; a real NavDisplay pop would restore it.
+                key(if (fresh) mode else Unit) {
+                    EmailAuthScreen(
+                        context = applicationContext,
+                        configuration = configuration(),
+                        authUI = authUI,
+                        onSuccess = {},
+                        onError = {},
+                        onCancel = {},
+                        mode = mode,
+                        onNavigateToMode = { target, _ -> mode = target },
+                        content = { state -> lastState = state },
+                    )
+                }
             }
         }
         composeTestRule.waitForIdle()
@@ -273,8 +268,8 @@ class EmailAuthScreenModeSwitchTest {
         isCredentialManagerEnabled = false
     }
 
-    private fun start() {
-        composeTestRule.setContent { EmailScreenUnderTest(configuration()) }
+    private fun start(mode: EmailAuthMode = EmailAuthMode.SignIn) {
+        composeTestRule.setContent { EmailScreenUnderTest(configuration(), mode) }
         composeTestRule.waitForIdle()
     }
 
@@ -300,7 +295,10 @@ class EmailAuthScreenModeSwitchTest {
     }
 
     @Composable
-    private fun EmailScreenUnderTest(configuration: AuthUIConfiguration) {
+    private fun EmailScreenUnderTest(
+        configuration: AuthUIConfiguration,
+        mode: EmailAuthMode,
+    ) {
         CompositionLocalProvider(
             LocalAuthUIStringProvider provides DefaultAuthUIStringProvider(applicationContext)
         ) {
@@ -311,6 +309,9 @@ class EmailAuthScreenModeSwitchTest {
                 onSuccess = {},
                 onError = {},
                 onCancel = {},
+                mode = mode,
+                // A host navigates here; recording is enough to assert what it would be told.
+                onNavigateToMode = { target, email -> reported += target to email },
                 content = { state -> lastState = state },
             )
         }

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreenReauthEmailLockTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreenReauthEmailLockTest.kt
@@ -16,6 +16,11 @@ package com.firebase.ui.auth.ui.screens.email
 
 import android.content.Context
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
@@ -24,8 +29,6 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
-import com.firebase.ui.auth.AuthException
-import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.FirebaseAuthUI
 import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.configuration.authUIConfiguration
@@ -34,9 +37,6 @@ import com.firebase.ui.auth.configuration.string_provider.AuthUIStringProvider
 import com.firebase.ui.auth.configuration.string_provider.DefaultAuthUIStringProvider
 import com.firebase.ui.auth.configuration.string_provider.LocalAuthUIStringProvider
 import androidx.compose.runtime.CompositionLocalProvider
-import com.firebase.ui.auth.ui.FirebaseAuthTestTags
-import com.firebase.ui.auth.ui.components.LocalTopLevelDialogController
-import com.firebase.ui.auth.ui.components.rememberTopLevelDialogController
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.ActionCodeSettings
@@ -152,55 +152,40 @@ class EmailAuthScreenReauthEmailLockTest {
         return authUI.createReauthFlow(configuration).configuration
     }
 
+    /**
+     * Hosts the screen the way production does: a mode switch navigates, so [key] gives the target
+     * mode its own composition, seeded with the address the switch carried — which is what a host
+     * puts on the destination's key.
+     */
     @Composable
     private fun EmailAuthScreenUnderTest(
         configuration: AuthUIConfiguration,
         prefill: String?,
+        startMode: EmailAuthMode = EmailAuthMode.SignIn,
+        content: (@Composable (EmailAuthContentState) -> Unit)? = null,
     ) {
+        var mode by remember { mutableStateOf(startMode) }
+        var email by remember { mutableStateOf(prefill) }
         CompositionLocalProvider(LocalAuthUIStringProvider provides stringProvider) {
-            EmailAuthScreen(
-                context = applicationContext,
-                configuration = configuration,
-                authUI = authUI,
-                prefillEmail = prefill,
-                onSuccess = {},
-                onError = {},
-                onCancel = {},
-            )
-        }
-    }
-
-    /**
-     * Unhosted, this screen shows the error itself but never acts on it: error recovery belongs to
-     * a host, which alone knows what lies outside the email flow. With nothing to do, an action
-     * button on the dialog could only dismiss it, so it is not rendered — and the dialog keeps
-     * explaining the error, which is the part a standalone caller still needs.
-     */
-    @Test
-    fun `the reauth sub-flow error dialog offers no action button`() {
-        composeTestRule.setContent {
-            CompositionLocalProvider(LocalAuthUIStringProvider provides stringProvider) {
-                val controller = rememberTopLevelDialogController(
-                    stringProvider = stringProvider,
-                    authState = { AuthState.Idle },
+            // NOTE: `key` re-creates state on a switch; a real NavDisplay pop would restore it.
+            key(mode) {
+                EmailAuthScreen(
+                    context = applicationContext,
+                    configuration = configuration,
+                    authUI = authUI,
+                    prefillEmail = email,
+                    mode = mode,
+                    onNavigateToMode = { target, typed ->
+                        email = typed.ifEmpty { null }
+                        mode = target
+                    },
+                    onSuccess = {},
+                    onError = {},
+                    onCancel = {},
+                    content = content,
                 )
-                CompositionLocalProvider(LocalTopLevelDialogController provides controller) {
-                    EmailAuthScreenUnderTest(reauthConfiguration(), prefillEmail)
-                    controller.CurrentDialog()
-                }
             }
         }
-        composeTestRule.waitForIdle()
-
-        composeTestRule.runOnIdle {
-            authUI.updateAuthState(
-                AuthState.Error(AuthException.UserNotFoundException(message = "nope"))
-            )
-        }
-        composeTestRule.waitForIdle()
-
-        composeTestRule.onNodeWithText(stringProvider.dismissAction).assertExists()
-        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.ErrorRecovery.RETRY_BUTTON).assertDoesNotExist()
     }
 
     /**
@@ -212,29 +197,18 @@ class EmailAuthScreenReauthEmailLockTest {
     fun `the locked email survives a mode switch`() {
         var email: String? = null
         var isEmailLocked: Boolean? = null
-        var goToSignIn: (() -> Unit)? = null
+        var goToResetPassword: (() -> Unit)? = null
 
         composeTestRule.setContent {
-            CompositionLocalProvider(LocalAuthUIStringProvider provides stringProvider) {
-                EmailAuthScreen(
-                    context = applicationContext,
-                    configuration = reauthConfiguration(),
-                    authUI = authUI,
-                    prefillEmail = prefillEmail,
-                    onSuccess = {},
-                    onError = {},
-                    onCancel = {},
-                    content = { state ->
-                        email = state.email
-                        isEmailLocked = state.isEmailLocked
-                        goToSignIn = state.onGoToSignIn
-                    },
-                )
+            EmailAuthScreenUnderTest(reauthConfiguration(), prefillEmail) { state ->
+                email = state.email
+                isEmailLocked = state.isEmailLocked
+                goToResetPassword = state.onGoToResetPassword
             }
         }
         composeTestRule.waitForIdle()
 
-        composeTestRule.runOnIdle { requireNotNull(goToSignIn).invoke() }
+        composeTestRule.runOnIdle { requireNotNull(goToResetPassword).invoke() }
         composeTestRule.waitForIdle()
 
         assertThat(email).isEqualTo(prefillEmail)
@@ -322,21 +296,10 @@ class EmailAuthScreenReauthEmailLockTest {
         var goToEmailLinkSignIn: (() -> Unit)? = null
 
         composeTestRule.setContent {
-            CompositionLocalProvider(LocalAuthUIStringProvider provides stringProvider) {
-                EmailAuthScreen(
-                    context = applicationContext,
-                    configuration = reauthConfigurationWithEmailLink(),
-                    authUI = authUI,
-                    prefillEmail = prefillEmail,
-                    onSuccess = {},
-                    onError = {},
-                    onCancel = {},
-                    content = { state ->
-                        observed.add(state.mode)
-                        goToResetPassword = state.onGoToResetPassword
-                        goToEmailLinkSignIn = state.onGoToEmailLinkSignIn
-                    },
-                )
+            EmailAuthScreenUnderTest(reauthConfigurationWithEmailLink(), prefillEmail) { state ->
+                observed.add(state.mode)
+                goToResetPassword = state.onGoToResetPassword
+                goToEmailLinkSignIn = state.onGoToEmailLinkSignIn
             }
         }
         composeTestRule.waitForIdle()
@@ -408,31 +371,20 @@ class EmailAuthScreenReauthEmailLockTest {
     @Test
     fun `isEmailLocked is reported to a custom content slot and is stable across modes`() {
         val observed = mutableListOf<Pair<EmailAuthMode, Boolean>>()
-        var goToSignIn: (() -> Unit)? = null
+        var goToResetPassword: (() -> Unit)? = null
 
         composeTestRule.setContent {
-            CompositionLocalProvider(LocalAuthUIStringProvider provides stringProvider) {
-                EmailAuthScreen(
-                    context = applicationContext,
-                    configuration = reauthConfiguration(),
-                    authUI = authUI,
-                    prefillEmail = prefillEmail,
-                    onSuccess = {},
-                    onError = {},
-                    onCancel = {},
-                    content = { state ->
-                        observed.add(state.mode to state.isEmailLocked)
-                        goToSignIn = state.onGoToSignIn
-                    },
-                )
+            EmailAuthScreenUnderTest(reauthConfiguration(), prefillEmail) { state ->
+                observed.add(state.mode to state.isEmailLocked)
+                goToResetPassword = state.onGoToResetPassword
             }
         }
         composeTestRule.waitForIdle()
 
-        composeTestRule.runOnIdle { requireNotNull(goToSignIn).invoke() }
+        composeTestRule.runOnIdle { requireNotNull(goToResetPassword).invoke() }
         composeTestRule.waitForIdle()
 
-        assertThat(observed.map { it.first }.last()).isEqualTo(EmailAuthMode.SignIn)
+        assertThat(observed.map { it.first }.last()).isEqualTo(EmailAuthMode.ResetPassword)
         assertThat(observed.map { it.second }.toSet()).containsExactly(true)
     }
 
@@ -443,20 +395,9 @@ class EmailAuthScreenReauthEmailLockTest {
         var onEmailChange: ((String) -> Unit)? = null
 
         composeTestRule.setContent {
-            CompositionLocalProvider(LocalAuthUIStringProvider provides stringProvider) {
-                EmailAuthScreen(
-                    context = applicationContext,
-                    configuration = reauthConfiguration(),
-                    authUI = authUI,
-                    prefillEmail = prefillEmail,
-                    onSuccess = {},
-                    onError = {},
-                    onCancel = {},
-                    content = { state ->
-                        email = state.email
-                        onEmailChange = state.onEmailChange
-                    },
-                )
+            EmailAuthScreenUnderTest(reauthConfiguration(), prefillEmail) { state ->
+                email = state.email
+                onEmailChange = state.onEmailChange
             }
         }
         composeTestRule.waitForIdle()

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthFlowStateRestorationTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthFlowStateRestorationTest.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens.phone
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.test.junit4.StateRestorationTester
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.core.app.ApplicationProvider
+import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.configuration.AuthUIConfiguration
+import com.firebase.ui.auth.configuration.authUIConfiguration
+import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.util.CountryUtils
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.auth.FirebaseAuth
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * What an Activity recreation does to the country a user picked.
+ *
+ * The number is `rememberSaveable` and comes back; the country used to be a plain `remember` and
+ * did not, so it was re-resolved from the configuration. That pairing is the bug: the dial code is
+ * what prefixes the restored number, so a user who picked one country and rotated had their number
+ * submitted under a dial code they never chose. The country is now saved by
+ * [com.firebase.ui.auth.data.CountryDataSaver], the same saver the MFA flow state uses — see
+ * [com.firebase.ui.auth.ui.screens.mfa.MfaEnrollmentFlowStateRestorationTest] for the equivalent
+ * there.
+ *
+ * @suppress Internal test class
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class PhoneAuthFlowStateRestorationTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var applicationContext: android.content.Context
+    private lateinit var authUI: FirebaseAuthUI
+
+    private var flowState: PhoneAuthFlowState? = null
+
+    @Before
+    fun setUp() {
+        FirebaseAuthUI.clearInstanceCache()
+        applicationContext = ApplicationProvider.getApplicationContext()
+        FirebaseApp.getApps(applicationContext).forEach { it.delete() }
+        val app = FirebaseApp.initializeApp(
+            applicationContext,
+            FirebaseOptions.Builder()
+                .setApiKey("fake-api-key")
+                .setApplicationId("fake-app-id")
+                .setProjectId("fake-project-id")
+                .build()
+        )
+        authUI = FirebaseAuthUI.create(app, mock(FirebaseAuth::class.java))
+    }
+
+    @After
+    fun tearDown() {
+        flowState = null
+        FirebaseAuthUI.clearInstanceCache()
+        FirebaseApp.getApps(applicationContext).forEach {
+            try {
+                it.delete()
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    /**
+     * The country is picked away from the configured default on purpose: re-resolving from the
+     * configuration would restore the default and still look like a pass if the test had started
+     * there.
+     */
+    @Test
+    fun `the picked country survives recreation alongside the number it prefixes`() {
+        val picked = requireNotNull(CountryUtils.findByCountryCode("DE")) { "DE missing" }
+
+        val restorationTester = StateRestorationTester(composeTestRule)
+        restorationTester.setContent { Host(configuration(defaultCountryCode = "US")) }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            val state = requireNotNull(flowState)
+            state.selectedCountry.value = picked
+            state.phoneNumber.value = TYPED_NUMBER
+        }
+        composeTestRule.waitForIdle()
+
+        // Sanity before recreation, so what follows is about recreation and not the fixture.
+        assertThat(requireNotNull(flowState).selectedCountry.value).isEqualTo(picked)
+
+        restorationTester.emulateSavedInstanceStateRestore()
+        composeTestRule.waitForIdle()
+
+        assertThat(requireNotNull(flowState).phoneNumber.value).isEqualTo(TYPED_NUMBER)
+        // The assertion the plain `remember` failed: not merely non-null, but the same country,
+        // so the dial code still matches the number above.
+        assertThat(requireNotNull(flowState).selectedCountry.value).isEqualTo(picked)
+        assertThat(requireNotNull(flowState).selectedCountry.value.dialCode)
+            .isEqualTo(picked.dialCode)
+    }
+
+    /** A country never picked still falls back to the configured default on a fresh flow. */
+    @Test
+    fun `an untouched country still comes from the configuration`() {
+        val configured = requireNotNull(CountryUtils.findByCountryCode("GB")) { "GB missing" }
+
+        composeTestRule.setContent { Host(configuration(defaultCountryCode = "GB")) }
+        composeTestRule.waitForIdle()
+
+        assertThat(requireNotNull(flowState).selectedCountry.value).isEqualTo(configured)
+    }
+
+    @Composable
+    private fun Host(configuration: AuthUIConfiguration) {
+        val state = rememberPhoneAuthFlowState(configuration)
+        SideEffect { flowState = state }
+    }
+
+    private fun configuration(defaultCountryCode: String): AuthUIConfiguration =
+        authUIConfiguration {
+            context = applicationContext
+            providers {
+                provider(
+                    AuthProvider.Phone(
+                        defaultNumber = null,
+                        defaultCountryCode = defaultCountryCode,
+                        allowedCountries = null,
+                    )
+                )
+            }
+        }
+
+    private companion object {
+        const val TYPED_NUMBER = "15123456789"
+    }
+}

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthRouteNavigationTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthRouteNavigationTest.kt
@@ -52,7 +52,6 @@ import com.google.firebase.auth.PhoneAuthOptions
 import com.google.firebase.auth.PhoneAuthProvider
 import com.google.firebase.auth.PhoneAuthProvider.OnVerificationStateChangedCallbacks
 import org.junit.After
-import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -503,35 +502,6 @@ class PhoneAuthRouteNavigationTest {
             AuthRoute.Phone.EnterPhoneNumber,
             AuthRoute.Phone.EnterVerificationCode,
         ).inOrder()
-    }
-
-    // =============================================================================================
-    // The hosted parameters are all-or-none
-    // =============================================================================================
-
-    /**
-     * The un-hosted screen owning its own step is public API, so the four hosted parameters have to
-     * arrive together or the screen would drive a step nothing is listening to.
-     */
-    @Test
-    fun `passing a step without the rest of the hosted parameters throws`() {
-        val thrown = assertThrows(IllegalArgumentException::class.java) {
-            composeTestRule.setContent {
-                PhoneAuthScreen(
-                    context = applicationContext,
-                    configuration = phoneConfiguration(timeout = 0L),
-                    authUI = authUI,
-                    onSuccess = {},
-                    onError = {},
-                    onCancel = {},
-                    step = PhoneAuthStep.EnterVerificationCode,
-                    content = {},
-                )
-            }
-            composeTestRule.waitForIdle()
-        }
-
-        assertThat(thrown).hasMessageThat().contains("go together")
     }
 
     // =============================================================================================

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreenModifierTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreenModifierTest.kt
@@ -110,6 +110,10 @@ class PhoneAuthScreenModifierTest {
                     onError = { },
                     onCancel = { },
                     modifier = modifier,
+                    step = PhoneAuthStep.EnterPhoneNumber,
+                    onNavigateToStep = { },
+                    onNavigateBack = { },
+                    flowState = rememberPhoneAuthFlowState(configuration),
                     content = content,
                 )
             }

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreenVerificationLifecycleTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreenVerificationLifecycleTest.kt
@@ -18,6 +18,9 @@ import com.firebase.ui.auth.ui.screens.reauth.ReauthFlowState
 import androidx.compose.runtime.mutableStateOf
 import android.content.Context
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ApplicationProvider
@@ -176,14 +179,29 @@ class PhoneAuthScreenVerificationLifecycleTest {
                 LocalAuthUIStringProvider provides configuration.stringProvider,
                 LocalTopLevelDialogController provides controller.takeIf { withDialogs },
             ) {
-                PhoneAuthScreen(
-                    context = context,
-                    configuration = configuration,
-                    authUI = authUI,
-                    onSuccess = {},
-                    onError = { reportedErrors += it },
-                    onCancel = {},
-                ) { state -> capturedState = state }
+                // Hosted the way production is: a stack of steps, and a `key` on its top, so a
+                // step switch composes fresh rather than inheriting what the last step held.
+                val stack = remember { mutableStateListOf(PhoneAuthStep.EnterPhoneNumber) }
+                val flowState = rememberPhoneAuthFlowState(configuration)
+                // NOTE: `key` re-creates state on a switch; a real NavDisplay pop would restore it.
+                key(stack.last()) {
+                    PhoneAuthScreen(
+                        context = context,
+                        configuration = configuration,
+                        authUI = authUI,
+                        onSuccess = {},
+                        onError = { reportedErrors += it },
+                        onCancel = {},
+                        step = stack.last(),
+                        // Guarded like the library's navigateToPhoneStep: a resend asks for the step it
+                    // is already on, and stacking it again would break back.
+                    onNavigateToStep = { if (stack.last() != it) stack.add(it) },
+                        onNavigateBack = {
+                            if (stack.size > 1) stack.removeAt(stack.lastIndex)
+                        },
+                        flowState = flowState,
+                    ) { state -> capturedState = state }
+                }
             }
             if (withDialogs) controller.CurrentDialog()
         }

--- a/docs/upgrade-to-10.0.md
+++ b/docs/upgrade-to-10.0.md
@@ -409,18 +409,58 @@ import com.firebase.ui.auth.configuration.authUIConfiguration
 
 ### Issue: "How do I customize the UI?"
 
-**Solution:** Use content slots for custom UI:
+**Solution:** Use content slots for custom UI. `EmailAuthScreen` renders the mode it is given and
+never changes it on its own, so the host owns the mode and navigates between them — give each mode
+its own destination, or the fields of the one you leave carry over into the one you arrive at:
+
 ```kotlin
-EmailAuthScreen(
-    configuration = emailConfig,
-    onSuccess = { /* ... */ },
-    onError = { /* ... */ },
-    onCancel = { /* ... */ }
-) { state ->
-    // Your custom UI here
-    CustomSignInUI(state)
-}
+@Serializable
+data class EmailModeKey(val mode: EmailAuthMode, val email: String = "") : NavKey
+
+val backStack = rememberNavBackStack(EmailModeKey(EmailAuthMode.SignIn))
+
+NavDisplay(
+    backStack = backStack,
+    // NavDisplay throws on an empty back stack, and throws from recomposition, so the first
+    // mode must not pop.
+    onBack = { if (backStack.size > 1) backStack.removeLastOrNull() },
+    entryProvider = entryProvider {
+        entry<EmailModeKey> { key ->
+            EmailAuthScreen(
+                context = context,
+                configuration = emailConfig,
+                authUI = authUI,
+                prefillEmail = key.email.ifEmpty { null },
+                mode = key.mode,
+                // The typed address travels with the switch, so the mode you arrive at can
+                // prefill it. Replace a mode already on the stack rather than revisiting it
+                // with a stale address.
+                onNavigateToMode = { mode, email ->
+                    val existing = backStack.indexOfFirst { it is EmailModeKey && it.mode == mode }
+                    backStack.add(EmailModeKey(mode, email))
+                    if (existing >= 0) {
+                        while (backStack.size > existing + 1) backStack.removeAt(existing)
+                    }
+                },
+                onSuccess = { /* ... */ },
+                onError = { /* ... */ },
+                onCancel = { /* ... */ },
+            ) { state ->
+                // Your custom UI here
+                CustomSignInUI(state)
+            }
+        }
+    },
+)
 ```
+
+`PhoneAuthScreen` and `MfaEnrollmentScreen` work the same way, with `step` / `onNavigateToStep` /
+`onNavigateBack` plus a `flowState` from `rememberPhoneAuthFlowState` or
+`rememberMfaEnrollmentFlowState` remembered above the `NavDisplay`. If you would rather not own any
+of this, use `FirebaseAuthScreen`, which owns it for you.
+
+A back-stack key must be `@Serializable` to survive process death, so add the
+`org.jetbrains.kotlin.plugin.serialization` plugin to the module hosting these screens.
 
 ### Issue: "My XML themes aren't working"
 

--- a/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/MfaDisabledTest.kt
+++ b/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/MfaDisabledTest.kt
@@ -3,6 +3,7 @@ package com.firebase.ui.auth.ui.screens
 import android.content.Context
 import android.os.Looper
 import androidx.compose.material3.Text
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.test.assertIsDisplayed
@@ -24,7 +25,6 @@ import com.firebase.ui.auth.testutil.ensureTestFirebaseApp
 import com.google.common.truth.Truth.assertThat
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -140,8 +140,20 @@ class MfaDisabledTest {
             .assertIsNotEnabled()
     }
 
+    /**
+     * Was `@Ignore`d as "flaky in CI due to timing issues". Two causes, neither of them the
+     * product's:
+     *
+     * `capturedUiContext` was read off the back of the auth state, but `Success` is observable a
+     * composition before `authenticatedContent` hands the context over — so the assertion could
+     * run against a context that did not exist yet.
+     *
+     * More importantly, the error was asserted by *sampling* the current state.
+     * `FirebaseAuthScreen` gives an error to the dialog controller and retracts it to
+     * [AuthState.Idle] immediately, so `Error` is the current state for about a frame: waiting
+     * longer made the test *less* likely to see it. The emissions are recorded instead.
+     */
     @Test
-    @Ignore("Flaky in CI due to timing issues")
     fun `onManageMfa throws AuthCancelledException when MFA is disabled`() {
         val configuration = authUIConfiguration {
             context = applicationContext
@@ -159,6 +171,10 @@ class MfaDisabledTest {
 
         var currentAuthState: AuthState = AuthState.Idle
         var capturedUiContext: AuthSuccessUiContext? = null
+        // Every emission, not just the latest one. FirebaseAuthScreen hands an error to the dialog
+        // controller and retracts it to Idle in the same breath, so sampling the current state can
+        // step straight over the error this test is about.
+        val emitted = mutableListOf<AuthState>()
 
         composeTestRule.setContent {
             FirebaseAuthScreen(
@@ -173,6 +189,7 @@ class MfaDisabledTest {
                     Text("Custom authenticated content")
                 }
             )
+            LaunchedEffect(Unit) { authUI.authStateFlow().collect { emitted += it } }
             val authState by authUI.authStateFlow().collectAsState(AuthState.Idle)
             currentAuthState = authState
         }
@@ -188,10 +205,11 @@ class MfaDisabledTest {
         composeTestRule.waitForIdle()
         shadowOf(Looper.getMainLooper()).idle()
 
-        // Wait for auth state to transition to Success
+        // Wait for the authenticated content to have handed over its context, not merely for the
+        // auth state to say Success — the first happens a composition after the second.
         composeTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
             shadowOf(Looper.getMainLooper()).idle()
-            currentAuthState is AuthState.Success
+            currentAuthState is AuthState.Success && capturedUiContext != null
         }
 
         // Now call onManageMfa directly (simulating custom content calling it)
@@ -202,14 +220,18 @@ class MfaDisabledTest {
         composeTestRule.waitForIdle()
         shadowOf(Looper.getMainLooper()).idle()
 
-        // Verify that auth state is now Error with AuthCancelledException
+        // Verify an Error carrying AuthCancelledException was emitted, whether or not it is still
+        // the current state by the time this runs.
         composeTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
             shadowOf(Looper.getMainLooper()).idle()
-            currentAuthState is AuthState.Error &&
-                    (currentAuthState as AuthState.Error).exception is AuthException.AuthCancelledException
+            emitted.any {
+                it is AuthState.Error && it.exception is AuthException.AuthCancelledException
+            }
         }
 
-        val errorState = currentAuthState as AuthState.Error
+        val errorState = emitted.last {
+            it is AuthState.Error && it.exception is AuthException.AuthCancelledException
+        } as AuthState.Error
         assertThat(errorState.exception).isInstanceOf(AuthException.AuthCancelledException::class.java)
         assertThat(errorState.exception.message).contains("Multi-factor authentication is disabled")
     }

--- a/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/MfaEnrollmentScreenTest.kt
+++ b/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/MfaEnrollmentScreenTest.kt
@@ -20,6 +20,9 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
@@ -39,6 +42,7 @@ import com.firebase.ui.auth.mfa.getHelperText
 import com.firebase.ui.auth.mfa.getTitle
 import com.firebase.ui.auth.testutil.ensureTestFirebaseApp
 import com.firebase.ui.auth.ui.screens.mfa.MfaEnrollmentScreen
+import com.firebase.ui.auth.ui.screens.mfa.rememberMfaEnrollmentFlowState
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.MultiFactor
@@ -342,16 +346,36 @@ class MfaEnrollmentScreenTest {
         onError: (Exception) -> Unit = {},
         onStateChange: (MfaEnrollmentContentState) -> Unit = {}
     ) {
-        MfaEnrollmentScreen(
-            user = testUser,
-            auth = authUI.auth,
-            configuration = configuration,
-            onComplete = onComplete,
-            onSkip = onSkip,
-            onError = onError
-        ) { state ->
-            onStateChange(state)
-            TestMfaEnrollmentUI(state = state)
+        // The host resolves where the flow opens, exactly as the library's own does: a single
+        // allowed factor skips the picker and lands on that factor's configuration step.
+        val startStep = remember(configuration) {
+            when (configuration.allowedFactors.singleOrNull()) {
+                MfaFactor.Sms -> MfaEnrollmentStep.ConfigureSms
+                MfaFactor.Totp -> MfaEnrollmentStep.ConfigureTotp
+                null -> MfaEnrollmentStep.SelectFactor
+            }
+        }
+        // A stack of steps with a `key` on its top, so a step switch composes fresh rather than
+        // inheriting what the previous step held. The flow state deliberately outlives them.
+        val stack = remember(startStep) { mutableStateListOf(startStep) }
+        val flowState = rememberMfaEnrollmentFlowState()
+        // NOTE: `key` re-creates state on a switch; a real NavDisplay pop would restore it.
+        key(stack.last()) {
+            MfaEnrollmentScreen(
+                user = testUser,
+                auth = authUI.auth,
+                configuration = configuration,
+                onComplete = onComplete,
+                onSkip = onSkip,
+                onError = onError,
+                step = stack.last(),
+                onNavigateToStep = { stack.add(it) },
+                onNavigateBack = { if (stack.size > 1) stack.removeAt(stack.lastIndex) },
+                flowState = flowState,
+            ) { state ->
+                onStateChange(state)
+                TestMfaEnrollmentUI(state = state)
+            }
         }
     }
 

--- a/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/PhoneAuthScreenTest.kt
+++ b/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/PhoneAuthScreenTest.kt
@@ -6,11 +6,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -39,13 +44,13 @@ import com.firebase.ui.auth.ui.screens.phone.EnterPhoneNumberUI
 import com.firebase.ui.auth.ui.screens.phone.EnterVerificationCodeUI
 import com.firebase.ui.auth.ui.screens.phone.PhoneAuthScreen
 import com.firebase.ui.auth.ui.screens.phone.PhoneAuthStep
+import com.firebase.ui.auth.ui.screens.phone.rememberPhoneAuthFlowState
 import com.firebase.ui.auth.util.CountryUtils
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.auth.AuthResult
 import org.junit.After
 import org.junit.Assume
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -123,8 +128,14 @@ class PhoneAuthScreenTest {
             .assertIsDisplayed()
     }
 
+    /**
+     * Was `@Ignore`d as simply "flaky test". Three races, all the test's own: it typed the code
+     * without waiting for the verification step to arrive, it hunted for the code field before it
+     * existed, and it waited for the emulator to mint a code with `Thread.sleep` — which, under
+     * `LooperMode.PAUSED`, sleeps the one thread that would have driven the work it is waiting for.
+     * Each is now an explicit wait on the thing itself.
+     */
     @Test
-    @Ignore("Flaky test")
     fun `sign-in and verify SMS emits Success auth state`() {
         val country = CountryUtils.findByCountryCode("DE")!!
         val phone = "151${System.currentTimeMillis() % 100000000}"
@@ -144,9 +155,10 @@ class PhoneAuthScreenTest {
 
         // Track auth state changes
         var currentAuthState: AuthState = AuthState.Idle
+        var step: PhoneAuthStep? = null
 
         composeTestRule.setContent {
-            TestAuthScreen(configuration = configuration)
+            TestAuthScreen(configuration = configuration, onStepChange = { step = it })
             val authState by authUI.authStateFlow().collectAsState(AuthState.Idle)
             currentAuthState = authState
         }
@@ -178,47 +190,45 @@ class PhoneAuthScreenTest {
             .assertIsDisplayed()
             .assertIsEnabled()
             .performClick()
-        composeTestRule.waitForIdle()
 
-        // Wait for emulator to process and generate verification code
-        shadowOf(Looper.getMainLooper()).idle()
-
-        // Retry fetching the phone code since emulator may be slow
-        // NOTE: This test requires Firebase Auth Emulator to be running on localhost:9099
-        // Start the emulator with: firebase emulators:start --only auth
-        var phoneCode: String? = null
-        var retries = 0
-        val maxRetries = 5
-        while (phoneCode == null && retries < maxRetries) {
-            Thread.sleep(if (retries == 0) 200L else 500L * retries)
+        // The screen's own step, not a guess at how long the emulator round-trip takes.
+        composeTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
             shadowOf(Looper.getMainLooper()).idle()
-            try {
-                phoneCode = emulatorApi.fetchVerifyPhoneCode(phone)
-                println("TEST: Found phone code after ${retries + 1} attempts")
-            } catch (e: Exception) {
-                retries++
-                if (retries >= maxRetries) {
-                    // If we can't fetch verification codes, the emulator might not be configured
-                    // correctly or might not be running. Skip this test with a clear message.
-                    Assume.assumeTrue(
-                        "Skipping test: Firebase Auth Emulator verification codes endpoint not available. " +
-                                "Ensure emulator is running on localhost:9099. Error: ${e.message}",
-                        false
-                    )
-                }
-                println("TEST: Phone code not found yet, retrying... (attempt $retries/$maxRetries)")
-            }
+            step == PhoneAuthStep.EnterVerificationCode
         }
-        requireNotNull(phoneCode) { "Phone code should not be null at this point" }
 
-        // Check current page is Verify Phone Number & Enter verification code
-        composeTestRule.onNodeWithText(stringProvider.verifyPhoneNumber)
+        // Poll the emulator for the code it minted, pumping the looper between attempts rather
+        // than sleeping the thread that has to run the work.
+        // NOTE: requires the Firebase Auth Emulator on localhost:9099
+        // (`./scripts/start-firebase-emulator.sh`).
+        var phoneCode: String? = null
+        composeTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
+            shadowOf(Looper.getMainLooper()).idle()
+            phoneCode = try {
+                emulatorApi.fetchVerifyPhoneCode(phone)
+            } catch (_: Exception) {
+                null
+            }
+            phoneCode != null
+        }
+        // Absent after the full timeout means the emulator has no verification-codes endpoint,
+        // which is an environment problem rather than a failure of what is under test.
+        Assume.assumeTrue(
+            "Skipping test: Firebase Auth Emulator verification codes endpoint not available. " +
+                    "Ensure the emulator is running on localhost:9099.",
+            phoneCode != null
+        )
+
         // The whole code goes in via the published tag in one call, rather than selecting boxes
         // positionally out of onAllNodes(hasSetTextAction()).
-        composeTestRule.waitForIdle()
+        composeTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
+            shadowOf(Looper.getMainLooper()).idle()
+            composeTestRule.onAllNodesWithTag(FirebaseAuthTestTags.VerificationCode.CODE_FIELD)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
         composeTestRule
             .onNodeWithTag(FirebaseAuthTestTags.VerificationCode.CODE_FIELD)
-            .performTextInput(phoneCode)
+            .performTextInput(requireNotNull(phoneCode))
         composeTestRule.waitForIdle()
         // Submit verification code
         composeTestRule.onNodeWithText(stringProvider.verifyPhoneNumber.uppercase())
@@ -254,8 +264,14 @@ class PhoneAuthScreenTest {
         )
     }
 
+    /**
+     * Was `@Ignore`d as "flaky in CI due to timing/scrolling issues". The flakiness was the test's,
+     * not the product's: sending a code is an emulator round-trip, and this waited for it by
+     * pumping the looper a fixed number of times and hoping. Both transitions are now waited on by
+     * the step the screen actually reports, so there is nothing left to lose a race with — and the
+     * scroll no longer runs against a node that may not exist yet.
+     */
     @Test
-    @Ignore("Flaky in CI due to timing/scrolling issues - works locally")
     fun `change phone number navigates back to EnterPhoneNumber step`() {
         val defaultNumber = "+12025550123"
         val country = CountryUtils.findByCountryCode("US")!!
@@ -273,31 +289,29 @@ class PhoneAuthScreenTest {
             }
         }
 
+        var step: PhoneAuthStep? = null
         composeTestRule.setContent {
-            TestAuthScreen(configuration = configuration)
+            TestAuthScreen(configuration = configuration, onStepChange = { step = it })
         }
 
-        // Send verification code to get to verification screen
         composeTestRule.onNodeWithText(stringProvider.sendVerificationCode.uppercase())
             .performScrollTo()
             .performClick()
-        composeTestRule.waitForIdle()
 
-        // Wait for the verification screen to appear and pump looper (CI timing)
-        shadowOf(Looper.getMainLooper()).idle()
-        composeTestRule.waitForIdle()
+        composeTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
+            shadowOf(Looper.getMainLooper()).idle()
+            step == PhoneAuthStep.EnterVerificationCode
+        }
 
-        // Click change phone number
         composeTestRule.onNodeWithText(stringProvider.changePhoneNumber)
             .performScrollTo()
             .performClick()
-        composeTestRule.waitForIdle()
 
-        // Pump looper after navigation
-        shadowOf(Looper.getMainLooper()).idle()
-        composeTestRule.waitForIdle()
+        composeTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
+            shadowOf(Looper.getMainLooper()).idle()
+            step == PhoneAuthStep.EnterPhoneNumber
+        }
 
-        // Verify we are back to sign in with phone screen
         composeTestRule.onNodeWithText(stringProvider.signInWithPhone)
             .assertIsDisplayed()
     }
@@ -330,8 +344,13 @@ class PhoneAuthScreenTest {
             .assertIsDisplayed()
     }
 
+    /**
+     * Was `@Ignore`d as "flaky in CI due to timing issues with countdown timer". The countdown was
+     * never the problem — with `LooperMode.PAUSED` the clock does not advance, so the timer holds
+     * at the configured value. What raced was getting to the screen showing it: the assertion ran
+     * after a fixed amount of looper pumping rather than after the step actually changed.
+     */
     @Test
-    @Ignore("Flaky in CI due to timing issues with countdown timer")
     fun `resend code timer starts at configured timeout`() {
         val phone = "+12025550123"
         val timeout = 120L
@@ -349,22 +368,27 @@ class PhoneAuthScreenTest {
             }
         }
 
+        var step: PhoneAuthStep? = null
         composeTestRule.setContent {
-            TestAuthScreen(configuration = configuration)
+            TestAuthScreen(configuration = configuration, onStepChange = { step = it })
         }
 
-        // Send verification code
         composeTestRule.onNodeWithText(stringProvider.sendVerificationCode.uppercase())
             .performScrollTo()
             .performClick()
-        composeTestRule.waitForIdle()
 
-        // Process pending tasks to render the verification screen
-        shadowOf(Looper.getMainLooper()).idle()
+        composeTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
+            shadowOf(Looper.getMainLooper()).idle()
+            step == PhoneAuthStep.EnterVerificationCode
+        }
 
-        // With LooperMode.PAUSED, time doesn't advance automatically,
-        // so the timer will stay frozen at "2:00" (the configured timeout)
+        // The clock is frozen, so the timer reads the configured timeout: 120s as "2:00".
         val expectedTimerText = stringProvider.resendCodeTimer("2:00")
+        composeTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
+            shadowOf(Looper.getMainLooper()).idle()
+            composeTestRule.onAllNodesWithText(expectedTimerText, substring = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
         composeTestRule.onNodeWithText(expectedTimerText, substring = true)
             .assertIsDisplayed()
     }
@@ -524,41 +548,54 @@ class PhoneAuthScreenTest {
         CompositionLocalProvider(
             LocalAuthUIStringProvider provides DefaultAuthUIStringProvider(applicationContext)
         ) {
-            PhoneAuthScreen(
-                context = applicationContext,
-                configuration = configuration,
-                authUI = authUI,
-                onSuccess = onSuccess,
-                onError = onError,
-                onCancel = onCancel,
-            ) { state ->
-                onStepChange(state.step)
+            // Hosted the way production is: a stack of steps, and a `key` on its top, so a step
+            // switch composes fresh rather than inheriting what the previous step held.
+            val stack = remember { mutableStateListOf(PhoneAuthStep.EnterPhoneNumber) }
+            val flowState = rememberPhoneAuthFlowState(configuration)
+            // NOTE: `key` re-creates state on a switch; a real NavDisplay pop would restore it.
+            key(stack.last()) {
+                PhoneAuthScreen(
+                    context = applicationContext,
+                    configuration = configuration,
+                    authUI = authUI,
+                    onSuccess = onSuccess,
+                    onError = onError,
+                    onCancel = onCancel,
+                    step = stack.last(),
+                    // Guarded like the library's navigateToPhoneStep: a resend asks for the step it
+                    // is already on, and stacking it again would break back.
+                    onNavigateToStep = { if (stack.last() != it) stack.add(it) },
+                    onNavigateBack = { if (stack.size > 1) stack.removeAt(stack.lastIndex) },
+                    flowState = flowState,
+                ) { state ->
+                    onStepChange(state.step)
 
-                when (state.step) {
-                    PhoneAuthStep.EnterPhoneNumber -> {
-                        EnterPhoneNumberUI(
-                            configuration = configuration,
-                            isLoading = state.isLoading,
-                            phoneNumber = state.phoneNumber,
-                            selectedCountry = state.selectedCountry,
-                            onPhoneNumberChange = state.onPhoneNumberChange,
-                            onCountrySelected = state.onCountrySelected,
-                            onSendCodeClick = state.onSendCodeClick,
-                        )
-                    }
+                    when (state.step) {
+                        PhoneAuthStep.EnterPhoneNumber -> {
+                            EnterPhoneNumberUI(
+                                configuration = configuration,
+                                isLoading = state.isLoading,
+                                phoneNumber = state.phoneNumber,
+                                selectedCountry = state.selectedCountry,
+                                onPhoneNumberChange = state.onPhoneNumberChange,
+                                onCountrySelected = state.onCountrySelected,
+                                onSendCodeClick = state.onSendCodeClick,
+                            )
+                        }
 
-                    PhoneAuthStep.EnterVerificationCode -> {
-                        EnterVerificationCodeUI(
-                            configuration = configuration,
-                            isLoading = state.isLoading,
-                            verificationCode = state.verificationCode,
-                            fullPhoneNumber = state.fullPhoneNumber,
-                            resendTimer = state.resendTimer,
-                            onVerificationCodeChange = state.onVerificationCodeChange,
-                            onVerifyCodeClick = state.onVerifyCodeClick,
-                            onResendCodeClick = state.onResendCodeClick,
-                            onChangeNumberClick = state.onChangeNumberClick,
-                        )
+                        PhoneAuthStep.EnterVerificationCode -> {
+                            EnterVerificationCodeUI(
+                                configuration = configuration,
+                                isLoading = state.isLoading,
+                                verificationCode = state.verificationCode,
+                                fullPhoneNumber = state.fullPhoneNumber,
+                                resendTimer = state.resendTimer,
+                                onVerificationCodeChange = state.onVerificationCodeChange,
+                                onVerifyCodeClick = state.onVerifyCodeClick,
+                                onResendCodeClick = state.onResendCodeClick,
+                                onChangeNumberClick = state.onChangeNumberClick,
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
`EmailAuthScreen`, `PhoneAuthScreen` and `MfaEnrollmentScreen` took their navigation parameters as nullable and fell back to internal `localMode`/`localStep` state when they were omitted. That fallback had no back stack and no `BackHandler`, so system back did nothing and the in-UI switch controls were the only way to move between steps — while the KDoc described those same parameters as a supported way to drive the screens from outside.

The parameters are now required and the fallback is gone, so every caller brings real navigation. Nothing new was published to support that: both slot demos were rewritten to host the screens on their own Navigation 3 back stacks using only existing public API, which is what makes the documented capability real rather than implied.

- `EmailAuthSlotDemoActivity.kt` / `PhoneAuthSlotDemoActivity.kt`: each defines its own `NavKey` and back stack, so system back steps between modes/steps instead of leaving the flow. Verified on device.
- Un-ignored and de-flaked all four `@Ignore`d e2e tests, including `change phone number navigates back to EnterPhoneNumber step` — the back path this change reworks, which had no coverage before.

## ⚠️ Breaking Changes

- `EmailAuthScreen`: `mode` and `onNavigateToMode` are now required.
- `PhoneAuthScreen` and `MfaEnrollmentScreen`: `step`, `onNavigateToStep`, `onNavigateBack` and `flowState` are now required.
- `EmailAuthScreen` no longer shows an error dialog of its own. This only affected a caller that installed `LocalTopLevelDialogController` itself; every caller still receives `onError`.

---
Maintainer note: Fixes internal CPRN-415
