### PR TITLE
fix(auth)!: remove the sign-in controls made redundant by per-step navigation

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -1915,14 +1915,11 @@ Every input and button on the auth screens carries a stable, public test tag, an
 | | `SignUp.PASSWORD_FIELD` | `fui_sign_up_password_field` |
 | | `SignUp.CONFIRM_PASSWORD_FIELD` | `fui_sign_up_confirm_password_field` |
 | | `SignUp.SIGN_UP_BUTTON` | `fui_sign_up_sign_up_button` |
-| | `SignUp.SIGN_IN_BUTTON` | `fui_sign_up_sign_in_button` |
 | Password recovery | `ResetPassword.EMAIL_FIELD` | `fui_reset_password_email_field` |
 | | `ResetPassword.SEND_BUTTON` | `fui_reset_password_send_button` |
-| | `ResetPassword.SIGN_IN_BUTTON` | `fui_reset_password_sign_in_button` |
 | | `ResetPassword.DISMISS_BUTTON` | `fui_reset_password_dismiss_button` |
 | Email link sign-in | `EmailLink.EMAIL_FIELD` | `fui_email_link_email_field` |
 | | `EmailLink.SEND_LINK_BUTTON` | `fui_email_link_send_link_button` |
-| | `EmailLink.PASSWORD_SIGN_IN_BUTTON` | `fui_email_link_password_sign_in_button` |
 | | `EmailLink.DISMISS_BUTTON` | `fui_email_link_dismiss_button` |
 | Phone number entry | `PhoneNumber.PHONE_NUMBER_FIELD` | `fui_phone_number_phone_number_field` |
 | | `PhoneNumber.COUNTRY_SELECTOR_BUTTON` | `fui_phone_number_country_selector_button` |

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/string_provider/AuthUIStringProvider.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/string_provider/AuthUIStringProvider.kt
@@ -248,9 +248,6 @@ interface AuthUIStringProvider {
     /** Button text to sign in with email link */
     val signInWithEmailLink: String
 
-    /** Button text to sign in with password */
-    val signInWithPassword: String
-
     /** Title shown when prompting the user to confirm their email for cross-device flows */
     val emailLinkPromptForEmailTitle: String
 

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/string_provider/DefaultAuthUIStringProvider.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/string_provider/DefaultAuthUIStringProvider.kt
@@ -210,9 +210,6 @@ class DefaultAuthUIStringProvider(
     override val signInWithEmailLink: String
         get() = localizedContext.getString(R.string.fui_sign_in_with_email_link)
 
-    override val signInWithPassword: String
-        get() = localizedContext.getString(R.string.fui_sign_in_with_password)
-
     override val emailLinkPromptForEmailTitle: String
         get() = localizedContext.getString(R.string.fui_email_link_confirm_email_header)
 

--- a/auth/src/main/java/com/firebase/ui/auth/ui/FirebaseAuthTestTags.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/FirebaseAuthTestTags.kt
@@ -124,9 +124,6 @@ object FirebaseAuthTestTags {
         /** The button that sends the sign-in link. */
         const val SEND_LINK_BUTTON = "fui_email_link_send_link_button"
 
-        /** The button that switches back to password sign-in. */
-        const val PASSWORD_SIGN_IN_BUTTON = "fui_email_link_password_sign_in_button"
-
         /** The dismiss button of the "sign-in link sent" dialog. */
         const val DISMISS_BUTTON = "fui_email_link_dismiss_button"
 

--- a/auth/src/main/java/com/firebase/ui/auth/ui/FirebaseAuthTestTags.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/FirebaseAuthTestTags.kt
@@ -88,9 +88,6 @@ object FirebaseAuthTestTags {
         /** The button that submits the new account. */
         const val SIGN_UP_BUTTON = "fui_sign_up_sign_up_button"
 
-        /** The button that navigates back to the sign-in screen. */
-        const val SIGN_IN_BUTTON = "fui_sign_up_sign_in_button"
-
         /** The toggle that shows or hides the entered password. */
         const val PASSWORD_VISIBILITY_TOGGLE = "fui_sign_up_password_visibility_toggle"
 
@@ -110,9 +107,6 @@ object FirebaseAuthTestTags {
 
         /** The button that sends the password reset link. */
         const val SEND_BUTTON = "fui_reset_password_send_button"
-
-        /** The button that navigates back to the sign-in screen. */
-        const val SIGN_IN_BUTTON = "fui_reset_password_sign_in_button"
 
         /** The dismiss button of the "reset link sent" dialog. */
         const val DISMISS_BUTTON = "fui_reset_password_dismiss_button"

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
@@ -102,6 +102,7 @@ import com.firebase.ui.auth.ui.screens.mfa.exitMfaEnrollment
 import com.firebase.ui.auth.ui.screens.mfa.mfaEnrollmentDestinations
 import com.firebase.ui.auth.ui.screens.mfa.rememberMfaEnrollmentFlowState
 import com.firebase.ui.auth.ui.screens.phone.PhoneAuthContentState
+import com.firebase.ui.auth.ui.screens.phone.abandonVerification
 import com.firebase.ui.auth.ui.screens.phone.exitPhoneAuth
 import com.firebase.ui.auth.ui.screens.phone.phoneAuthDestinations
 import com.firebase.ui.auth.ui.screens.phone.rememberPhoneAuthFlowState
@@ -369,9 +370,30 @@ fun FirebaseAuthScreen(
             NavDisplay(
                 backStack = backStack,
                 sceneStrategies = listOf(reauthSceneStrategy),
+                // Back off a step that abandons work owes the same teardown the step's own control
+                // does; anything else is a plain pop.
                 onBack = {
-                    val top = backStack.lastOrNull()
-                    if (top is AuthRoute.Reauth) onLeaveReauthStep(top) else backStack.popOrNull()
+                    when (val top = backStack.lastOrNull()) {
+                        is AuthRoute.Reauth -> {
+                            if (top.step is AuthRoute.Phone.EnterVerificationCode) {
+                                reauthPhoneFlowState.abandonVerification(
+                                    "system back from reauthentication code entry"
+                                )
+                            }
+                            // Owns the phase move as well as the pop, so nothing is retracted here.
+                            onLeaveReauthStep(top)
+                        }
+
+                        is AuthRoute.Phone.EnterVerificationCode -> {
+                            phoneAuthFlowState.abandonVerification("system back from code entry")
+                            // Number entry is exempt from Idle's reset, so this lands there rather
+                            // than unwinding the flow.
+                            authUI.updateAuthState(AuthState.Idle)
+                            backStack.popOrNull()
+                        }
+
+                        else -> backStack.popOrNull()
+                    }
                 },
                 transitionSpec = stepTransitionSpec,
                 popTransitionSpec = stepPopTransitionSpec,

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
@@ -374,15 +374,9 @@ fun FirebaseAuthScreen(
                 // does; anything else is a plain pop.
                 onBack = {
                     when (val top = backStack.lastOrNull()) {
-                        is AuthRoute.Reauth -> {
-                            if (top.step is AuthRoute.Phone.EnterVerificationCode) {
-                                reauthPhoneFlowState.abandonVerification(
-                                    "system back from reauthentication code entry"
-                                )
-                            }
-                            // Owns the phase move as well as the pop, so nothing is retracted here.
-                            onLeaveReauthStep(top)
-                        }
+                        // Unreachable for a sheet-presented step, which swallows the gesture, but
+                        // a bare reauth entry still routes here; the phase move is onLeaveStep's.
+                        is AuthRoute.Reauth -> onLeaveReauthStep(top)
 
                         is AuthRoute.Phone.EnterVerificationCode -> {
                             phoneAuthFlowState.abandonVerification("system back from code entry")

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
@@ -134,8 +134,11 @@ class EmailAuthContentState(
  *
  * Hosting it yourself means a real back stack, not a variable holding the current mode. The screen
  * offers no in-form control for stepping back to sign-in, so system back is the way back, and only
- * a stack gives it something to pop. Bring your own key, built from the public [EmailAuthMode] and
- * the address the switch hands over:
+ * a stack gives it something to pop — which also means the flow has to **start** at
+ * [EmailAuthMode.SignIn]. Every other mode is reached from it, and back is inert at the bottom of a
+ * stack, so a flow opened straight onto sign-up, password recovery or email-link sign-in leaves the
+ * user with no way to reach the password form. Bring your own key, built from the public
+ * [EmailAuthMode] and the address the switch hands over:
  *
  * ```kotlin
  * @Serializable

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
@@ -441,7 +441,6 @@ private fun DefaultEmailAuthContent(
                 emailSignInLinkSent = state.emailSignInLinkSent,
                 onEmailChange = state.onEmailChange,
                 onSignInWithEmailLink = state.onSignInEmailLinkClick,
-                onGoToSignIn = state.onGoToSignIn,
                 onGoToResetPassword = state.onGoToResetPassword,
                 onNavigateBack = onCancel
             )

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
@@ -423,7 +423,6 @@ private fun DefaultEmailAuthContent(
                 onPasswordChange = state.onPasswordChange,
                 onConfirmPasswordChange = state.onConfirmPasswordChange,
                 onSignUpClick = state.onSignUpClick,
-                onGoToSignIn = state.onGoToSignIn,
                 onNavigateBack = onCancel,
                 isEmailLocked = state.isEmailLocked,
             )

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreen.kt
@@ -132,6 +132,43 @@ class EmailAuthContentState(
  * destination and passes [mode] and [onNavigateToMode]. Callers that do not want to own that are
  * served by [com.firebase.ui.auth.ui.screens.FirebaseAuthScreen], which owns it for them.
  *
+ * Hosting it yourself means a real back stack, not a variable holding the current mode. The screen
+ * offers no in-form control for stepping back to sign-in, so system back is the way back, and only
+ * a stack gives it something to pop. Bring your own key, built from the public [EmailAuthMode] and
+ * the address the switch hands over:
+ *
+ * ```kotlin
+ * @Serializable
+ * data class EmailModeKey(val mode: EmailAuthMode, val email: String = "") : NavKey
+ *
+ * val backStack = rememberNavBackStack(EmailModeKey(EmailAuthMode.SignIn))
+ * NavDisplay(
+ *     backStack = backStack,
+ *     onBack = { backStack.removeLastOrNull() },
+ *     entryProvider = entryProvider {
+ *         entry<EmailModeKey> { key ->
+ *             EmailAuthScreen(
+ *                 context = context,
+ *                 configuration = configuration,
+ *                 authUI = authUI,
+ *                 prefillEmail = key.email.ifEmpty { null },
+ *                 mode = key.mode,
+ *                 // Replace a mode already on the stack rather than stacking a second copy;
+ *                 // add before trimming, so no single write empties it.
+ *                 onNavigateToMode = { mode, email ->
+ *                     val existing = backStack.indexOfFirst { it is EmailModeKey && it.mode == mode }
+ *                     backStack.add(EmailModeKey(mode, email))
+ *                     if (existing >= 0) { while (backStack.size > existing + 1) backStack.removeAt(existing) }
+ *                 },
+ *                 onSuccess = { /* … */ },
+ *                 onError = { /* … */ },
+ *                 onCancel = { /* … */ },
+ *             )
+ *         }
+ *     },
+ * )
+ * ```
+ *
  * This composable never changes mode on its own in response to an error. Signing in with an
  * address that has no account leaves the user on the sign-in form rather than moving them to
  * sign-up; acting on an error is the host's job alone.

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/ResetPasswordUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/ResetPasswordUI.kt
@@ -15,14 +15,12 @@
 package com.firebase.ui.auth.ui.screens.email
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
@@ -165,26 +163,22 @@ fun ResetPasswordUI(
                 }
             )
             Spacer(modifier = Modifier.height(8.dp))
-            Row(
+            Button(
                 modifier = Modifier
-                    .align(Alignment.End),
+                    .align(Alignment.End)
+                    .testTag(FirebaseAuthTestTags.ResetPassword.SEND_BUTTON),
+                onClick = {
+                    onSendResetLink()
+                },
+                enabled = !isLoading && isFormValid.value,
             ) {
-                Button(
-                    modifier = Modifier
-                        .testTag(FirebaseAuthTestTags.ResetPassword.SEND_BUTTON),
-                    onClick = {
-                        onSendResetLink()
-                    },
-                    enabled = !isLoading && isFormValid.value,
-                ) {
-                    if (isLoading) {
-                        CircularProgressIndicator(
-                            modifier = Modifier
-                                .size(16.dp)
-                        )
-                    } else {
-                        Text(stringProvider.sendButtonText.uppercase())
-                    }
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .size(16.dp)
+                    )
+                } else {
+                    Text(stringProvider.sendButtonText.uppercase())
                 }
             }
             Spacer(modifier = Modifier.height(16.dp))

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/ResetPasswordUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/ResetPasswordUI.kt
@@ -171,17 +171,6 @@ fun ResetPasswordUI(
             ) {
                 Button(
                     modifier = Modifier
-                        .testTag(FirebaseAuthTestTags.ResetPassword.SIGN_IN_BUTTON),
-                    onClick = {
-                        onGoToSignIn()
-                    },
-                    enabled = !isLoading,
-                ) {
-                    Text(stringProvider.signInDefault.uppercase())
-                }
-                Spacer(modifier = Modifier.width(16.dp))
-                Button(
-                    modifier = Modifier
                         .testTag(FirebaseAuthTestTags.ResetPassword.SEND_BUTTON),
                     onClick = {
                         onSendResetLink()

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/SignInEmailLinkUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/SignInEmailLinkUI.kt
@@ -16,9 +16,7 @@ package com.firebase.ui.auth.ui.screens.email
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -30,7 +28,6 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/SignInEmailLinkUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/SignInEmailLinkUI.kt
@@ -74,7 +74,6 @@ fun SignInEmailLinkUI(
     email: String,
     onEmailChange: (String) -> Unit,
     onSignInWithEmailLink: () -> Unit,
-    onGoToSignIn: () -> Unit,
     onGoToResetPassword: () -> Unit,
     onNavigateBack: (() -> Unit)? = null,
     isEmailLocked: Boolean = false,
@@ -210,33 +209,6 @@ fun SignInEmailLinkUI(
                 }
             }
 
-            // Show toggle to go back to password mode
-            Spacer(modifier = Modifier.height(64.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                HorizontalDivider(modifier = Modifier.weight(1f))
-                Text(
-                    text = stringProvider.orContinueWith,
-                    modifier = Modifier.padding(horizontal = 8.dp),
-                    style = MaterialTheme.typography.bodySmall
-                )
-                HorizontalDivider(modifier = Modifier.weight(1f))
-            }
-            Spacer(modifier = Modifier.height(24.dp))
-            Button(
-                onClick = {
-                    onGoToSignIn()
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .testTag(FirebaseAuthTestTags.EmailLink.PASSWORD_SIGN_IN_BUTTON),
-                enabled = !isLoading
-            ) {
-                Text(stringProvider.signInWithPassword.uppercase())
-            }
-
             Spacer(modifier = Modifier.height(16.dp))
             TermsAndPrivacyForm(
                 modifier = Modifier.align(Alignment.End),
@@ -282,7 +254,6 @@ fun PreviewSignInEmailLinkUI() {
             emailSignInLinkSent = false,
             onEmailChange = { email -> },
             onSignInWithEmailLink = {},
-            onGoToSignIn = {},
             onGoToResetPassword = {},
         )
     }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/SignUpUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/SignUpUI.kt
@@ -15,12 +15,10 @@
 package com.firebase.ui.auth.ui.screens.email
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -198,26 +196,22 @@ fun SignUpUI(
                 )
             )
             Spacer(modifier = Modifier.height(8.dp))
-            Row(
+            Button(
                 modifier = Modifier
-                    .align(Alignment.End),
+                    .align(Alignment.End)
+                    .testTag(FirebaseAuthTestTags.SignUp.SIGN_UP_BUTTON),
+                onClick = {
+                    onSignUpClick()
+                },
+                enabled = !isLoading && isFormValid.value,
             ) {
-                Button(
-                    modifier = Modifier
-                        .testTag(FirebaseAuthTestTags.SignUp.SIGN_UP_BUTTON),
-                    onClick = {
-                        onSignUpClick()
-                    },
-                    enabled = !isLoading && isFormValid.value,
-                ) {
-                    if (isLoading) {
-                        CircularProgressIndicator(
-                            modifier = Modifier
-                                .size(16.dp)
-                        )
-                    } else {
-                        Text(stringProvider.signupPageTitle.uppercase())
-                    }
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .size(16.dp)
+                    )
+                } else {
+                    Text(stringProvider.signupPageTitle.uppercase())
                 }
             }
             Spacer(modifier = Modifier.height(16.dp))

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/SignUpUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/SignUpUI.kt
@@ -69,7 +69,6 @@ fun SignUpUI(
     onEmailChange: (String) -> Unit,
     onPasswordChange: (String) -> Unit,
     onConfirmPasswordChange: (String) -> Unit,
-    onGoToSignIn: () -> Unit,
     onSignUpClick: () -> Unit,
     onNavigateBack: (() -> Unit)? = null,
     isEmailLocked: Boolean = false,
@@ -205,17 +204,6 @@ fun SignUpUI(
             ) {
                 Button(
                     modifier = Modifier
-                        .testTag(FirebaseAuthTestTags.SignUp.SIGN_IN_BUTTON),
-                    onClick = {
-                        onGoToSignIn()
-                    },
-                    enabled = !isLoading,
-                ) {
-                    Text(stringProvider.signInDefault.uppercase())
-                }
-                Spacer(modifier = Modifier.width(16.dp))
-                Button(
-                    modifier = Modifier
                         .testTag(FirebaseAuthTestTags.SignUp.SIGN_UP_BUTTON),
                     onClick = {
                         onSignUpClick()
@@ -274,7 +262,6 @@ fun PreviewSignUpUI() {
             onPasswordChange = { password -> },
             onConfirmPasswordChange = { confirmPassword -> },
             onSignUpClick = {},
-            onGoToSignIn = {}
         )
     }
 }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthDestinations.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthDestinations.kt
@@ -15,6 +15,7 @@
 package com.firebase.ui.auth.ui.screens.phone
 
 import android.content.Context
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableIntState
 import androidx.compose.runtime.MutableState
@@ -84,6 +85,33 @@ class PhoneAuthFlowState internal constructor(
     internal val navigatedVerificationId: MutableState<String?>,
     internal val consumedAutoCredential: MutableState<PhoneAuthCredential?>,
 )
+
+/**
+ * Cancels the verification in flight and clears everything code entry was working with, so the
+ * flow is back to what number entry started from.
+ *
+ * Shared by every way of abandoning an attempt — the "change number" control and a system back
+ * press off code entry both land on number entry, so both owe the same teardown. Leaves
+ * [PhoneAuthFlowState.pendingVerificationPhoneNumber] and
+ * [PhoneAuthFlowState.verificationStartTime] alone: the cooldown is about the number Firebase was
+ * last asked about, which abandoning the attempt does not change.
+ *
+ * Retracts nothing. The auth state a cancelled attempt leaves behind is the caller's, because who
+ * owns it differs: an ordinary flow retracts to [com.firebase.ui.auth.AuthState.Idle] via its
+ * [com.firebase.ui.auth.AuthFlowScope], while a reauthentication request moves its own phase
+ * instead.
+ */
+internal fun PhoneAuthFlowState.abandonVerification(reason: String) {
+    verificationJob.value?.let { job ->
+        Log.d("PhoneAuthScreen", "Cancelling verification attempt ($reason)")
+        job.cancel()
+    }
+    verificationJob.value = null
+    verificationCode.value = ""
+    verificationId.value = null
+    forceResendingToken.value = null
+    resendTimerSeconds.intValue = 0
+}
 
 /**
  * Creates and remembers the [PhoneAuthFlowState] a host installs [phoneAuthDestinations] with.

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreen.kt
@@ -177,6 +177,16 @@ fun PhoneAuthScreen(
     val navigatedVerificationId = flowState.navigatedVerificationId
     val consumedAutoCredential = flowState.consumedAutoCredential
 
+    /**
+     * Leaving the flow, rather than stepping inside it. Abandons the attempt on the way out: the
+     * verification outlives this step, so a live one would go on to sign in on a number the user
+     * has walked away from.
+     */
+    val leaveFlow: () -> Unit = {
+        flowState.abandonVerification("leaving the phone flow")
+        onCancel()
+    }
+
     val fullPhoneNumber = remember(selectedCountry.value, phoneNumberValue.value) {
         CountryUtils.formatPhoneNumber(selectedCountry.value.dialCode, phoneNumberValue.value)
     }
@@ -347,7 +357,7 @@ fun PhoneAuthScreen(
             }
 
             is AuthState.Cancelled -> {
-                onCancel()
+                leaveFlow()
                 // Consumed so this doesn't leak to a freshly created screen.
                 authFlowScope.emit(AuthState.Idle)
             }
@@ -495,7 +505,7 @@ fun PhoneAuthScreen(
             DefaultPhoneAuthContent(
                 configuration = configuration,
                 state = state,
-                onCancel = onCancel
+                onCancel = leaveFlow
             )
         }
     }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreen.kt
@@ -477,17 +477,12 @@ fun PhoneAuthScreen(
         },
         resendTimer = resendTimerSeconds.intValue,
         onChangeNumberClick = {
-            cancelVerification("changing phone number")
+            flowState.abandonVerification("changing phone number")
             // Nothing replaces the cancelled attempt here, so this handler retracts its Loading -
             // as the outstanding request's provider-selection phase when one is running, Idle otherwise.
             onNotificationConsumed?.invoke() ?: authFlowScope.emit(AuthState.Idle)
-            verificationJob.value = null
             isSubmittingCode.value = false
             onNavigateBack()
-            verificationCodeValue.value = ""
-            verificationId.value = null
-            forceResendingToken.value = null
-            resendTimerSeconds.intValue = 0
         }
     )
 

--- a/auth/src/main/res/values-ar/strings.xml
+++ b/auth/src/main/res/values-ar/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">لقد بدأت هذه العملية بهدف ربط %1$s ببريدك الإلكتروني إلّا أنك فتحت الرابط على جهاز آخر لم يتمّ تسجيل الدخول عليه.\n\nلربط حسابك على %1$s، يجب فتح الرابط على الجهاز نفسه حيث سجّلت الدخول في البداية. ولإلغاء عملية الربط، يُرجى النقر على \"متابعة\" لتسجيل الدخول على هذا الجهاز.</string>
     <string name="fui_or_continue_with">أو المتابعة باستخدام</string>
     <string name="fui_sign_in_with_email_link">تسجيل الدخول باستخدام رابط البريد الإلكتروني</string>
-    <string name="fui_sign_in_with_password">تسجيل الدخول باستخدام كلمة المرور</string>
     <string name="fui_verify_phone_number_title">أدخل رقم هاتفك</string>
     <string name="fui_invalid_phone_number">يُرجى إدخال رقم هاتف صالح</string>
     <string name="fui_enter_confirmation_code">أدخل الرمز المكوّن من 6 أرقام الذي أرسلناه إلى</string>

--- a/auth/src/main/res/values-b+es+419/strings.xml
+++ b/auth/src/main/res/values-b+es+419/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-bg/strings.xml
+++ b/auth/src/main/res/values-bg/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Първоначално искахте да свържете %1$s с имейла на профила си, но отворихте връзката на различно устройство без вход в профила.\n\nАко все още искате да свържете профила си в(ъв) %1$s, отворете връзката на същото устройство, на което започнахте влизането в профила. В противен случай докоснете „Напред“, за да влезете на това устройство.</string>
     <string name="fui_or_continue_with">или Продължете с</string>
     <string name="fui_sign_in_with_email_link">Вход чрез имейл връзка</string>
-    <string name="fui_sign_in_with_password">Вход с парола</string>
     <string name="fui_verify_phone_number_title">Въвеждане на телефонния ви номер</string>
     <string name="fui_invalid_phone_number">Въведете валиден телефонен номер</string>
     <string name="fui_enter_confirmation_code">Въведете 6-цифрения код, който изпратихме до</string>

--- a/auth/src/main/res/values-bn/strings.xml
+++ b/auth/src/main/res/values-bn/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">আপনি %1$s অ্যাকাউন্ট ইমেল অ্যাকাউন্টের সাথে কানেক্ট করতে চেয়েছিলেন কিন্তু এমন একটি ডিভাইসে লিঙ্কটি খুলেছেন যেখানে সাইন-ইন করেননি।\n\nআপনি যদি এখনও %1$s অ্যাকাউন্টটি কানেক্ট করতে চান, যে ডিভাইসে সাইন-ইন করেছিলেন সেখানেই লিঙ্কটি খুলুন। নাহলে, ডিভাইসের সাইন-ইন বিকল্পে ট্যাপ করুন।</string>
     <string name="fui_or_continue_with">বা এটি দিয়ে চালিয়ে যান</string>
     <string name="fui_sign_in_with_email_link">ইমেল লিঙ্ক দিয়ে সাইন ইন করুন</string>
-    <string name="fui_sign_in_with_password">পাসওয়ার্ড দিয়ে সাইন ইন করুন</string>
     <string name="fui_verify_phone_number_title">আপনার ফোন নম্বর লিখুন</string>
     <string name="fui_invalid_phone_number">একটি সঠিক ফোন নম্বর লিখুন</string>
     <string name="fui_enter_confirmation_code">আমাদের পাঠানো ৬-সংখ্যার কোডটি লিখুন</string>

--- a/auth/src/main/res/values-ca/strings.xml
+++ b/auth/src/main/res/values-ca/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Inicialment has intentat connectar %1$s amb el teu compte de correu electrònic, però has obert l\'enllaç amb un dispositiu diferent en què no has iniciat la sessió.\n\nSi encara vols connectar el compte que tens a %1$s, obre l\'enllaç al mateix dispositiu en què has començat a iniciar la sessió. Si no, toca Continua per iniciar la sessió en aquest dispositiu.</string>
     <string name="fui_or_continue_with">o Continua amb</string>
     <string name="fui_sign_in_with_email_link">Inicia la sessió amb l\'enllaç de correu electrònic</string>
-    <string name="fui_sign_in_with_password">Inicia la sessió amb la contrasenya</string>
     <string name="fui_verify_phone_number_title">Introdueix el número de telèfon</string>
     <string name="fui_invalid_phone_number">Introdueix un número de telèfon vàlid</string>
     <string name="fui_enter_confirmation_code">Introdueix el codi de 6 dígits que s\'ha enviat al número</string>

--- a/auth/src/main/res/values-cs/strings.xml
+++ b/auth/src/main/res/values-cs/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Původně jste chtěli propojit %1$s se svým e-mailovým účtem, ale otevřeli jste odkaz na jiném zařízení, na kterém nejste přihlášení.\n\nPokud stále chcete propojit svůj účet %1$s, otevřete odkaz na stejném zařízení, na kterém jste se začali přihlašovat. V opačném případě klepněte na možnost Pokračovat a přihlaste se na tomto zařízení.</string>
     <string name="fui_or_continue_with">nebo Pokračovat s</string>
     <string name="fui_sign_in_with_email_link">Přihlásit se pomocí e-mailového odkazu</string>
-    <string name="fui_sign_in_with_password">Přihlásit se pomocí hesla</string>
     <string name="fui_verify_phone_number_title">Zadejte své telefonní číslo</string>
     <string name="fui_invalid_phone_number">Zadejte platné telefonní číslo</string>
     <string name="fui_enter_confirmation_code">Zadejte šestimístný kód, který jsme vám zaslali</string>

--- a/auth/src/main/res/values-da/strings.xml
+++ b/auth/src/main/res/values-da/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Du ville egentlig knytte %1$s til din mailkonto, men du har åbnet linket på en anden enhed, som du ikke er logget ind på.\n\nHvis du stadig vil tilknytte din %1$s-konto, skal du åbne linket på den enhed, hvor du startede loginprocessen. Ellers kan du klikke på Fortsæt for at fortsætte med at logge ind på denne enhed.</string>
     <string name="fui_or_continue_with">eller Fortsæt med</string>
     <string name="fui_sign_in_with_email_link">Log ind med maillink</string>
-    <string name="fui_sign_in_with_password">Log ind med adgangskode</string>
     <string name="fui_verify_phone_number_title">Angiv dit telefonnummer</string>
     <string name="fui_invalid_phone_number">Angiv et gyldigt telefonnummer</string>
     <string name="fui_enter_confirmation_code">Angiv den 6-cifrede kode, vi sendte til</string>

--- a/auth/src/main/res/values-de-rAT/strings.xml
+++ b/auth/src/main/res/values-de-rAT/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Sie haben versucht, %1$s auf einem Gerät, auf dem Sie nicht angemeldet sind, mit Ihrem E-Mail-Konto zu verbinden.\n\nWenn Sie Ihr %1$s-Konto weiterhin verbinden möchten, öffnen Sie den Link bitte auf dem Gerät, auf dem Sie den Anmeldevorgang gestartet haben. Andernfalls tippen Sie auf \"Weiter\", um sich auf diesem Gerät anzumelden.</string>
     <string name="fui_or_continue_with">oder Fortfahren mit</string>
     <string name="fui_sign_in_with_email_link">Mit E-Mail-Link anmelden</string>
-    <string name="fui_sign_in_with_password">Mit Passwort anmelden</string>
     <string name="fui_verify_phone_number_title">Telefonnummer eingeben</string>
     <string name="fui_invalid_phone_number">Geben Sie eine gültige Telefonnummer ein</string>
     <string name="fui_enter_confirmation_code">Geben Sie den 6-stelligen Code ein, der gesendet wurde an</string>

--- a/auth/src/main/res/values-de-rCH/strings.xml
+++ b/auth/src/main/res/values-de-rCH/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Sie haben versucht, %1$s auf einem Gerät, auf dem Sie nicht angemeldet sind, mit Ihrem E-Mail-Konto zu verbinden.\n\nWenn Sie Ihr %1$s-Konto weiterhin verbinden möchten, öffnen Sie den Link bitte auf dem Gerät, auf dem Sie den Anmeldevorgang gestartet haben. Andernfalls tippen Sie auf \"Weiter\", um sich auf diesem Gerät anzumelden.</string>
     <string name="fui_or_continue_with">oder Fortfahren mit</string>
     <string name="fui_sign_in_with_email_link">Mit E-Mail-Link anmelden</string>
-    <string name="fui_sign_in_with_password">Mit Passwort anmelden</string>
     <string name="fui_verify_phone_number_title">Telefonnummer eingeben</string>
     <string name="fui_invalid_phone_number">Geben Sie eine gültige Telefonnummer ein</string>
     <string name="fui_enter_confirmation_code">Geben Sie den 6-stelligen Code ein, der gesendet wurde an</string>

--- a/auth/src/main/res/values-de/strings.xml
+++ b/auth/src/main/res/values-de/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Sie haben versucht, %1$s auf einem Gerät, auf dem Sie nicht angemeldet sind, mit Ihrem E-Mail-Konto zu verbinden.\n\nWenn Sie Ihr %1$s-Konto weiterhin verbinden möchten, öffnen Sie den Link bitte auf dem Gerät, auf dem Sie den Anmeldevorgang gestartet haben. Andernfalls tippen Sie auf \"Weiter\", um sich auf diesem Gerät anzumelden.</string>
     <string name="fui_or_continue_with">oder Fortfahren mit</string>
     <string name="fui_sign_in_with_email_link">Mit E-Mail-Link anmelden</string>
-    <string name="fui_sign_in_with_password">Mit Passwort anmelden</string>
     <string name="fui_verify_phone_number_title">Telefonnummer eingeben</string>
     <string name="fui_invalid_phone_number">Geben Sie eine gültige Telefonnummer ein</string>
     <string name="fui_enter_confirmation_code">Geben Sie den 6-stelligen Code ein, der gesendet wurde an</string>

--- a/auth/src/main/res/values-el/strings.xml
+++ b/auth/src/main/res/values-el/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Αρχικά, σκοπεύατε να συνδέσετε το %1$s με τον λογαριασμό ηλεκτρονικού ταχυδρομείου, αλλά, για το άνοιγμα του συνδέσμου, χρησιμοποιήσατε άλλη συσκευή στην οποία δεν είστε συνδεδεμένοι.\n\nΑν θέλετε να συνεχίσετε τη σύνδεση του λογαριασμού %1$s, ανοίξτε τον σύνδεσμο στην ίδια συσκευή από την οποία ξεκινήσατε τη σύνδεση. Διαφορετικά, πατήστε Συνέχεια για να συνδεθείτε σε αυτήν τη συσκευή.</string>
     <string name="fui_or_continue_with">ή Συνέχεια με</string>
     <string name="fui_sign_in_with_email_link">Σύνδεση με σύνδεσμο email</string>
-    <string name="fui_sign_in_with_password">Σύνδεση με κωδικό πρόσβασης</string>
     <string name="fui_verify_phone_number_title">Εισαγάγετε τον αριθμό τηλεφώνου σας</string>
     <string name="fui_invalid_phone_number">Καταχωρίστε έναν έγκυρο αριθμό τηλεφώνου</string>
     <string name="fui_enter_confirmation_code">Εισαγάγετε τον 6ψήφιο κωδικό που σας στείλαμε στο</string>

--- a/auth/src/main/res/values-en-rAU/strings.xml
+++ b/auth/src/main/res/values-en-rAU/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">You originally intended to connect %1$s to your email account, but have opened the link on a different device where you are not signed in.\n\nIf you still want to connect your %1$s account, open the link on the same device on which you started sign-in. Otherwise, tap \'Continue\' to sign in on this device.</string>
     <string name="fui_or_continue_with">or Continue with</string>
     <string name="fui_sign_in_with_email_link">Sign in with email link</string>
-    <string name="fui_sign_in_with_password">Sign in with password</string>
     <string name="fui_verify_phone_number_title">Enter your phone number</string>
     <string name="fui_invalid_phone_number">Enter a valid phone number</string>
     <string name="fui_enter_confirmation_code">Enter the 6-digit code that we sent to</string>

--- a/auth/src/main/res/values-en-rCA/strings.xml
+++ b/auth/src/main/res/values-en-rCA/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">You originally intended to connect %1$s to your email account, but have opened the link on a different device where you are not signed in.\n\nIf you still want to connect your %1$s account, open the link on the same device on which you started sign-in. Otherwise, tap \'Continue\' to sign in on this device.</string>
     <string name="fui_or_continue_with">or Continue with</string>
     <string name="fui_sign_in_with_email_link">Sign in with email link</string>
-    <string name="fui_sign_in_with_password">Sign in with password</string>
     <string name="fui_verify_phone_number_title">Enter your phone number</string>
     <string name="fui_invalid_phone_number">Enter a valid phone number</string>
     <string name="fui_enter_confirmation_code">Enter the 6-digit code that we sent to</string>

--- a/auth/src/main/res/values-en-rGB/strings.xml
+++ b/auth/src/main/res/values-en-rGB/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">You originally intended to connect %1$s to your email account, but have opened the link on a different device where you are not signed in.\n\nIf you still want to connect your %1$s account, open the link on the same device on which you started sign-in. Otherwise, tap \'Continue\' to sign in on this device.</string>
     <string name="fui_or_continue_with">or Continue with</string>
     <string name="fui_sign_in_with_email_link">Sign in with email link</string>
-    <string name="fui_sign_in_with_password">Sign in with password</string>
     <string name="fui_verify_phone_number_title">Enter your phone number</string>
     <string name="fui_invalid_phone_number">Enter a valid phone number</string>
     <string name="fui_enter_confirmation_code">Enter the 6-digit code that we sent to</string>

--- a/auth/src/main/res/values-en-rIE/strings.xml
+++ b/auth/src/main/res/values-en-rIE/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">You originally intended to connect %1$s to your email account, but have opened the link on a different device where you are not signed in.\n\nIf you still want to connect your %1$s account, open the link on the same device on which you started sign-in. Otherwise, tap \'Continue\' to sign in on this device.</string>
     <string name="fui_or_continue_with">or Continue with</string>
     <string name="fui_sign_in_with_email_link">Sign in with email link</string>
-    <string name="fui_sign_in_with_password">Sign in with password</string>
     <string name="fui_verify_phone_number_title">Enter your phone number</string>
     <string name="fui_invalid_phone_number">Enter a valid phone number</string>
     <string name="fui_enter_confirmation_code">Enter the 6-digit code that we sent to</string>

--- a/auth/src/main/res/values-en-rIN/strings.xml
+++ b/auth/src/main/res/values-en-rIN/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">You originally intended to connect %1$s to your email account, but have opened the link on a different device where you are not signed in.\n\nIf you still want to connect your %1$s account, open the link on the same device on which you started sign-in. Otherwise, tap \'Continue\' to sign in on this device.</string>
     <string name="fui_or_continue_with">or Continue with</string>
     <string name="fui_sign_in_with_email_link">Sign in with email link</string>
-    <string name="fui_sign_in_with_password">Sign in with password</string>
     <string name="fui_verify_phone_number_title">Enter your phone number</string>
     <string name="fui_invalid_phone_number">Enter a valid phone number</string>
     <string name="fui_enter_confirmation_code">Enter the 6-digit code that we sent to</string>

--- a/auth/src/main/res/values-en-rSG/strings.xml
+++ b/auth/src/main/res/values-en-rSG/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">You originally intended to connect %1$s to your email account, but have opened the link on a different device where you are not signed in.\n\nIf you still want to connect your %1$s account, open the link on the same device on which you started sign-in. Otherwise, tap \'Continue\' to sign in on this device.</string>
     <string name="fui_or_continue_with">or Continue with</string>
     <string name="fui_sign_in_with_email_link">Sign in with email link</string>
-    <string name="fui_sign_in_with_password">Sign in with password</string>
     <string name="fui_verify_phone_number_title">Enter your phone number</string>
     <string name="fui_invalid_phone_number">Enter a valid phone number</string>
     <string name="fui_enter_confirmation_code">Enter the 6-digit code that we sent to</string>

--- a/auth/src/main/res/values-en-rZA/strings.xml
+++ b/auth/src/main/res/values-en-rZA/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">You originally intended to connect %1$s to your email account, but have opened the link on a different device where you are not signed in.\n\nIf you still want to connect your %1$s account, open the link on the same device on which you started sign-in. Otherwise, tap \'Continue\' to sign in on this device.</string>
     <string name="fui_or_continue_with">or Continue with</string>
     <string name="fui_sign_in_with_email_link">Sign in with email link</string>
-    <string name="fui_sign_in_with_password">Sign in with password</string>
     <string name="fui_verify_phone_number_title">Enter your phone number</string>
     <string name="fui_invalid_phone_number">Enter a valid phone number</string>
     <string name="fui_enter_confirmation_code">Enter the 6-digit code that we sent to</string>

--- a/auth/src/main/res/values-es-rAR/strings.xml
+++ b/auth/src/main/res/values-es-rAR/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rBO/strings.xml
+++ b/auth/src/main/res/values-es-rBO/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rCL/strings.xml
+++ b/auth/src/main/res/values-es-rCL/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rCO/strings.xml
+++ b/auth/src/main/res/values-es-rCO/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rCR/strings.xml
+++ b/auth/src/main/res/values-es-rCR/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rDO/strings.xml
+++ b/auth/src/main/res/values-es-rDO/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rEC/strings.xml
+++ b/auth/src/main/res/values-es-rEC/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rGT/strings.xml
+++ b/auth/src/main/res/values-es-rGT/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rHN/strings.xml
+++ b/auth/src/main/res/values-es-rHN/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rMX/strings.xml
+++ b/auth/src/main/res/values-es-rMX/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rNI/strings.xml
+++ b/auth/src/main/res/values-es-rNI/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rPA/strings.xml
+++ b/auth/src/main/res/values-es-rPA/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rPE/strings.xml
+++ b/auth/src/main/res/values-es-rPE/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rPR/strings.xml
+++ b/auth/src/main/res/values-es-rPR/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rPY/strings.xml
+++ b/auth/src/main/res/values-es-rPY/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rSV/strings.xml
+++ b/auth/src/main/res/values-es-rSV/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rUS/strings.xml
+++ b/auth/src/main/res/values-es-rUS/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rUY/strings.xml
+++ b/auth/src/main/res/values-es-rUY/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es-rVE/strings.xml
+++ b/auth/src/main/res/values-es-rVE/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, intentaste conectar tu cuenta de correo electrónico con %1$s, pero abriste el vínculo en un dispositivo diferente en el que no accediste.\n\nSi quieres conectar tu cuenta de %1$s, abre el vínculo en el mismo dispositivo con el que iniciaste el acceso. De lo contrario, presiona Continuar para acceder en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Ingresa tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Ingresa un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Ingresa el código de 6 dígitos que enviamos al número</string>

--- a/auth/src/main/res/values-es/strings.xml
+++ b/auth/src/main/res/values-es/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">En un principio intentaste conectar %1$s a tu cuenta de correo electrónico, pero has abierto el enlace en un dispositivo diferente en el que no has iniciado sesión.\n\nSi sigues queriendo vincular tu cuenta de %1$s, abre el enlace en el mismo dispositivo en el que empezaste el inicio de sesión. De lo contrario, toca Continuar para iniciar sesión en este dispositivo.</string>
     <string name="fui_or_continue_with">o Continuar con</string>
     <string name="fui_sign_in_with_email_link">Iniciar sesión con enlace de correo</string>
-    <string name="fui_sign_in_with_password">Iniciar sesión con contraseña</string>
     <string name="fui_verify_phone_number_title">Introduce tu número de teléfono</string>
     <string name="fui_invalid_phone_number">Introduce un número de teléfono válido</string>
     <string name="fui_enter_confirmation_code">Introduce el código de seis dígitos que hemos enviado a</string>

--- a/auth/src/main/res/values-fa/strings.xml
+++ b/auth/src/main/res/values-fa/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">ابتدا قصد داشتید %1$s را به حساب ایمیلتان متصل کنید، اما پیوند را در دستگاه دیگری باز کردید که در آن وارد سیستم نشده‌اید.\n\nاگر همچنان می‌خواهید حساب %1$s را متصل کنید، پیوند را در همان دستگاهی باز کنید که ورود به سیستم را با آن شروع کرده‌اید. درغیراین‌صورت، برای ورود به سیستم با این دستگاه، روی «ادامه» ضربه بزنید.</string>
     <string name="fui_or_continue_with">یا ادامه با</string>
     <string name="fui_sign_in_with_email_link">ورود با پیوند ایمیل</string>
-    <string name="fui_sign_in_with_password">ورود با رمز عبور</string>
     <string name="fui_verify_phone_number_title">شماره تلفن خود را وارد کنید</string>
     <string name="fui_invalid_phone_number">شماره تلفن معتبری وارد کنید</string>
     <string name="fui_enter_confirmation_code">وارد کردن کد ۶ رقمی ارسال‌شده به</string>

--- a/auth/src/main/res/values-fi/strings.xml
+++ b/auth/src/main/res/values-fi/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Tarkoituksesi oli yhdistää palvelu %1$s sähköpostiosoitteeseesi, mutta avasit linkin eri laitteella, johon et ollut kirjautunut.\n\Jos haluat edelleen yhdistää palvelun %1$s tilisi, avaa linkki samalla laitteella, jolla aloitit kirjautumisen. Jos haluat jatkaa kirjautumista tällä laitteella, napauta Jatka.</string>
     <string name="fui_or_continue_with">tai Jatka käyttäen</string>
     <string name="fui_sign_in_with_email_link">Kirjaudu sähköpostilinkillä</string>
-    <string name="fui_sign_in_with_password">Kirjaudu salasanalla</string>
     <string name="fui_verify_phone_number_title">Anna puhelinnumerosi</string>
     <string name="fui_invalid_phone_number">Anna voimassa oleva puhelinnumero.</string>
     <string name="fui_enter_confirmation_code">Anna 6 merkin pituinen koodi, jonka lähetimme numeroon</string>

--- a/auth/src/main/res/values-fil/strings.xml
+++ b/auth/src/main/res/values-fil/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Orihinal na sinadya mong ikonekta ang %1$s sa iyong email account pero nabuksan ang link sa ibang device kung saan hindi ka naka-sign in.\n\nKung gusto mo pa ring ikonekta ang iyong %1$s account, buksan ang link sa parehong device kung saan ka nagsimulang mag-sign in. Kung hindi, i-tap ang Magpatuloy para makapag-sign in sa device na ito.</string>
     <string name="fui_or_continue_with">o Magpatuloy gamit ang</string>
     <string name="fui_sign_in_with_email_link">Mag-sign in gamit ang email link</string>
-    <string name="fui_sign_in_with_password">Mag-sign in gamit ang password</string>
     <string name="fui_verify_phone_number_title">Ilagay ang numero ng iyong telepono</string>
     <string name="fui_invalid_phone_number">Maglagay ng wastong numero ng telepono</string>
     <string name="fui_enter_confirmation_code">Ilagay ang 6-digit na code na ipinadala namin sa</string>

--- a/auth/src/main/res/values-fr-rCH/strings.xml
+++ b/auth/src/main/res/values-fr-rCH/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Vous aviez décidé d\'associer votre compte %1$s à votre adresse e-mail, mais vous avez ouvert le lien sur un appareil différent de celui avec lequel vous vous êtes connecté.\n\nSi vous souhaitez toujours associer votre compte %1$s, ouvrez le lien sur l\'appareil avec lequel vous avez commencé à vous connecter. Sinon, appuyez sur \"Continuer\" pour vous connecter depuis un autre appareil.</string>
     <string name="fui_or_continue_with">ou Continuer avec</string>
     <string name="fui_sign_in_with_email_link">Se connecter avec le lien e-mail</string>
-    <string name="fui_sign_in_with_password">Se connecter avec le mot de passe</string>
     <string name="fui_verify_phone_number_title">Saisissez votre numéro de téléphone</string>
     <string name="fui_invalid_phone_number">Saisissez un numéro de téléphone valide</string>
     <string name="fui_enter_confirmation_code">Saisissez le code à six chiffres envoyé au</string>

--- a/auth/src/main/res/values-fr/strings.xml
+++ b/auth/src/main/res/values-fr/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Vous aviez décidé d\'associer votre compte %1$s à votre adresse e-mail, mais vous avez ouvert le lien sur un appareil différent de celui avec lequel vous vous êtes connecté.\n\nSi vous souhaitez toujours associer votre compte %1$s, ouvrez le lien sur l\'appareil avec lequel vous avez commencé à vous connecter. Sinon, appuyez sur \"Continuer\" pour vous connecter depuis un autre appareil.</string>
     <string name="fui_or_continue_with">ou Continuer avec</string>
     <string name="fui_sign_in_with_email_link">Se connecter avec un lien e-mail</string>
-    <string name="fui_sign_in_with_password">Se connecter avec un mot de passe</string>
     <string name="fui_verify_phone_number_title">Saisissez votre numéro de téléphone</string>
     <string name="fui_invalid_phone_number">Saisissez un numéro de téléphone valide</string>
     <string name="fui_enter_confirmation_code">Saisissez le code à six chiffres envoyé au</string>

--- a/auth/src/main/res/values-gsw/strings.xml
+++ b/auth/src/main/res/values-gsw/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Sie haben versucht, %1$s auf einem Gerät, auf dem Sie nicht angemeldet sind, mit Ihrem E-Mail-Konto zu verbinden.\n\nWenn Sie Ihr %1$s-Konto weiterhin verbinden möchten, öffnen Sie den Link bitte auf dem Gerät, auf dem Sie den Anmeldevorgang gestartet haben. Andernfalls tippen Sie auf \"Weiter\", um sich auf diesem Gerät anzumelden.</string>
     <string name="fui_or_continue_with">oder Fortfahren mit</string>
     <string name="fui_sign_in_with_email_link">Mit E-Mail-Link anmelden</string>
-    <string name="fui_sign_in_with_password">Mit Passwort anmelden</string>
     <string name="fui_verify_phone_number_title">Telefonnummer eingeben</string>
     <string name="fui_invalid_phone_number">Geben Sie eine gültige Telefonnummer ein</string>
     <string name="fui_enter_confirmation_code">Geben Sie den 6-stelligen Code ein, der gesendet wurde an</string>

--- a/auth/src/main/res/values-gu/strings.xml
+++ b/auth/src/main/res/values-gu/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">તમે ઑરિજિનલ રીતે %1$sને તમારા ઇમેઇલ એકાઉન્ટ જોડે કનેક્ટ કરવા માગતા હતા પણ તમે લિંકને કોઈ અલગ ડિવાઇસ પરથી ખોલી છે, જેમાં તમે સાઇન ઇન થયા નથી.\n\nજો તમે હજી પણ તમારા %1$s એકાઉન્ટને કનેક્ટ કરવા માગતા હો, તો તમે જે ડિવાઇસ પરથી સાઇન-ઇન કરવાની પ્રક્રિયા શરૂ કરી હોય એના પરથી જ લિંક ખોલો. અન્યથા, આ ડિવાઇસ પરથી સાઇન-ઇન કરવા માટે આગળ વધો પર ટૅપ કરો.</string>
     <string name="fui_or_continue_with">અથવા આનાથી ચાલુ રાખો</string>
     <string name="fui_sign_in_with_email_link">ઇમેઇલ લિંક વડે સાઇન ઇન કરો</string>
-    <string name="fui_sign_in_with_password">પાસવર્ડ વડે સાઇન ઇન કરો</string>
     <string name="fui_verify_phone_number_title">તમારો ફોન નંબર દાખલ કરો</string>
     <string name="fui_invalid_phone_number">એક માન્ય ફોન નંબર દાખલ કરો</string>
     <string name="fui_enter_confirmation_code">અમે આ ફોન નંબર પર મોકલેલ 6-અંકનો કોડ દાખલ કરો</string>

--- a/auth/src/main/res/values-hi/strings.xml
+++ b/auth/src/main/res/values-hi/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">आप पहले %1$s को अपने ईमेल खाते से जोड़ना चाहते थे, लेकिन आपने ऐसे किसी अलग डिवाइस से लिंक खोला है, जहां आप साइन-इन नहीं हैं.\n\nअगर आप अब भी अपने %1$s खाते को जोड़ना चाहते हैं, तो उसी डिवाइस पर लिंक खोलें जिस पर आपने साइन-इन करना शुरू किया था. या फिर, इस डिवाइस से साइन इन करने के लिए \'जारी रखें\' पर टैप करें.</string>
     <string name="fui_or_continue_with">या इसके साथ जारी रखें</string>
     <string name="fui_sign_in_with_email_link">ईमेल लिंक से साइन इन करें</string>
-    <string name="fui_sign_in_with_password">पासवर्ड से साइन इन करें</string>
     <string name="fui_verify_phone_number_title">अपना फ़ोन नंबर डालें</string>
     <string name="fui_invalid_phone_number">कोई मान्य फ़ोन नंबर डालें</string>
     <string name="fui_enter_confirmation_code">हमारी ओर से भेजा गया 6-अंकों वाला कोड डालें</string>

--- a/auth/src/main/res/values-hr/strings.xml
+++ b/auth/src/main/res/values-hr/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Izvorno ste namjeravali povezati %1$s račun sa svojim računom e-pošte, no otvorili ste vezu na drugom uređaju na kojem niste prijavljeni.\n\nAko i dalje želite povezati svoj %1$s račun, otvorite vezu na uređaju na kojem ste pokrenuli postupak prijave. U suprotnom dodirnite Nastavi da biste se prijavili na ovom uređaju.</string>
     <string name="fui_or_continue_with">ili Nastavi s</string>
     <string name="fui_sign_in_with_email_link">Prijavite se pomoću poveznice e-pošte</string>
-    <string name="fui_sign_in_with_password">Prijavite se pomoću lozinke</string>
     <string name="fui_verify_phone_number_title">Unesite telefonski broj</string>
     <string name="fui_invalid_phone_number">Unesite važeći telefonski broj</string>
     <string name="fui_enter_confirmation_code">Unesite 6-znamenkasti kôd koji smo poslali na broj</string>

--- a/auth/src/main/res/values-hu/strings.xml
+++ b/auth/src/main/res/values-hu/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Eredetileg össze szerette volna kapcsolni %1$s-fiókját az e-mail-fiókjával, a linket azonban olyan eszközön nyitotta meg, amelyen nem jelentkezett be.\n\nHa továbbra is össze kívánja kapcsolni %1$s-fiókját, akkor azon az eszközön nyissa meg a linket, amelyen megkezdte a bejelentkezést. Ha ezen az eszközön kíván bejelentkezni, akkor koppintson a Tovább gombra.</string>
     <string name="fui_or_continue_with">vagy Tovább ezzel</string>
     <string name="fui_sign_in_with_email_link">Bejelentkezés e-mail linkkel</string>
-    <string name="fui_sign_in_with_password">Bejelentkezés jelszóval</string>
     <string name="fui_verify_phone_number_title">Adja meg telefonszámát</string>
     <string name="fui_invalid_phone_number">Érvényes telefonszámot adjon meg.</string>
     <string name="fui_enter_confirmation_code">Adja meg a telefonszámra elküldött 6 számjegyű kódot</string>

--- a/auth/src/main/res/values-in/strings.xml
+++ b/auth/src/main/res/values-in/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Anda sebelumnya ingin menghubungkan %1$s ke akun email Anda, tapi telah membuka link di perangkat berbeda yang tidak digunakan untuk login.\n\nJika Anda masih ingin menghubungkan ke akun %1$s, buka link di perangkat yang sama yang digunakan untuk login. Jika tidak, ketuk Lanjutkan untuk login di perangkat ini.</string>
     <string name="fui_or_continue_with">atau Lanjutkan dengan</string>
     <string name="fui_sign_in_with_email_link">Login dengan link email</string>
-    <string name="fui_sign_in_with_password">Login dengan kata sandi</string>
     <string name="fui_verify_phone_number_title">Masukkan nomor telepon Anda</string>
     <string name="fui_invalid_phone_number">Masukkan nomor telepon yang valid</string>
     <string name="fui_enter_confirmation_code">Masukkan kode 6 digit yang kami kirimkan ke</string>

--- a/auth/src/main/res/values-it/strings.xml
+++ b/auth/src/main/res/values-it/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Inizialmente intendevi collegare %1$s al tuo account email, ma hai aperto il link su un altro dispositivo, sul quale non hai eseguito l\'accesso.\n\nSe vuoi continuare a collegare l\'account su %1$s, apri il link sullo stesso dispositivo su cui hai iniziato la procedura di accesso. Altrimenti, tocca Continua per accedere su questo dispositivo.</string>
     <string name="fui_or_continue_with">o Continua con</string>
     <string name="fui_sign_in_with_email_link">Accedi con link email</string>
-    <string name="fui_sign_in_with_password">Accedi con password</string>
     <string name="fui_verify_phone_number_title">Inserisci il numero di telefono</string>
     <string name="fui_invalid_phone_number">Inserisci un numero di telefono valido</string>
     <string name="fui_enter_confirmation_code">Inserisci il codice a 6 cifre che abbiamo inviato al numero</string>

--- a/auth/src/main/res/values-iw/strings.xml
+++ b/auth/src/main/res/values-iw/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">כוונתך המקורית הייתה לקשר את חשבון %1$s לחשבון שלך, אבל פתחת את הקישור במכשיר אחר שממנו לא נכנסת לחשבון.\n\nבכל זאת רוצה לקשר את חשבון %1$s לחשבון שלך? אם כן, יש לפתוח את הקישור באותו מכשיר שבו התחלת את תהליך הכניסה. אם לא, יש להקיש על \'המשך\' כדי להיכנס לחשבון במכשיר הזה.</string>
     <string name="fui_or_continue_with">או המשך עם</string>
     <string name="fui_sign_in_with_email_link">היכנס באמצעות קישור אימייל</string>
-    <string name="fui_sign_in_with_password">היכנס באמצעות סיסמה</string>
     <string name="fui_verify_phone_number_title">הזן את מספר הטלפון שלך</string>
     <string name="fui_invalid_phone_number">מספר הטלפון שהזנת לא תקין</string>
     <string name="fui_enter_confirmation_code">הזן את הקוד בן 6 הספרות ששלחנו אל</string>

--- a/auth/src/main/res/values-ja/strings.xml
+++ b/auth/src/main/res/values-ja/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">元々は %1$s をメール アカウントに接続しようとしましたが、ログインしていないデバイスでリンクが開かれました。%1$s アカウントの接続を続行する場合は、ログインを開始したデバイスでリンクを開いてください。接続しない場合は、[続行] をタップしてこのデバイスでログインします。</string>
     <string name="fui_or_continue_with">または次で続行</string>
     <string name="fui_sign_in_with_email_link">メールリンクでログイン</string>
-    <string name="fui_sign_in_with_password">パスワードでログイン</string>
     <string name="fui_verify_phone_number_title">電話番号を入力してください</string>
     <string name="fui_invalid_phone_number">有効な電話番号を入力してください</string>
     <string name="fui_enter_confirmation_code">送信された 6 桁のコードを入力してください</string>

--- a/auth/src/main/res/values-kn/strings.xml
+++ b/auth/src/main/res/values-kn/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">ನೀವು ಮೂಲತಃ %1$s ಅನ್ನು ನಿಮ್ಮ ಇಮೇಲ್ ಜೊತೆಗೆ ಸಂಪರ್ಕಿಸಲು ಬಯಸಿದ್ದೀರಿ ಆದರೆ ನೀವು ಸೈನ್ ಇನ್ ಮಾಡದಿರುವ ಬೇರೆ ಸಾಧನದಲ್ಲಿ ಲಿಂಕ್ ಅನ್ನು ತೆರೆದಿದ್ದೀರಿ.n\nನಿಮ್ಮ %1$s ಖಾತೆಯನ್ನು ಇನ್ನೂ ನೀವು ಸಂಪರ್ಕಿಸಲು ಬಯಸಿದರೆ, ನೀವು ಸೈನ್ ಇನ್ ಮಾಡದೇ ಇರುವ ಅದೇ ಸಾಧನದಲ್ಲಿ ಲಿಂಕ್ ತೆರೆಯಿರಿ. ಇಲ್ಲದಿದ್ದರೆ ಈ ಸಾಧನದಲ್ಲಿ ಸೈನ್ ಇನ್ ಮಾಡಲು ಮುಂದುವರಿಸಿ ಟ್ಯಾಪ್ ಮಾಡಿ.</string>
     <string name="fui_or_continue_with">ಅಥವಾ ಇದರೊಂದಿಗೆ ಮುಂದುವರಿಸಿ</string>
     <string name="fui_sign_in_with_email_link">ಇಮೇಲ್ ಲಿಂಕ್‌ನೊಂದಿಗೆ ಸೈನ್ ಇನ್ ಮಾಡಿ</string>
-    <string name="fui_sign_in_with_password">ಪಾಸ್‌ವರ್ಡ್‌ನೊಂದಿಗೆ ಸೈನ್ ಇನ್ ಮಾಡಿ</string>
     <string name="fui_verify_phone_number_title">ನಿಮ್ಮ ಫೋನ್‌ ಸಂಖ್ಯೆಯನ್ನು ನಮೂದಿಸಿ</string>
     <string name="fui_invalid_phone_number">ಮಾನ್ಯವಾದ ಫೋನ್ ಸಂಖ್ಯೆಯನ್ನು ನಮೂದಿಸಿ</string>
     <string name="fui_enter_confirmation_code">ನಾವು ಕಳುಹಿಸಿರುವ 6 ಅಂಕಿಯ ಕೋಡ್‌ ನಮೂದಿಸಿ</string>

--- a/auth/src/main/res/values-ko/strings.xml
+++ b/auth/src/main/res/values-ko/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">원래 이메일 계정에 %1$s을(를) 연결하려고 했지만 로그인되지 않은 다른 기기에서 링크를 열었습니다.\n\n%1$s 계정에 연결하려는 경우 로그인을 시작한 것과 동일한 기기에서 링크를 여세요. 또는 \'계속\'을 탭하여 이 기기에서 로그인하세요.</string>
     <string name="fui_or_continue_with">또는 계속</string>
     <string name="fui_sign_in_with_email_link">이메일 링크로 로그인</string>
-    <string name="fui_sign_in_with_password">비밀번호로 로그인</string>
     <string name="fui_verify_phone_number_title">전화번호 입력</string>
     <string name="fui_invalid_phone_number">올바른 전화번호를 입력하세요.</string>
     <string name="fui_enter_confirmation_code">전송된 6자리 코드를 입력하세요.</string>

--- a/auth/src/main/res/values-ln/strings.xml
+++ b/auth/src/main/res/values-ln/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Vous aviez décidé d\'associer votre compte %1$s à votre adresse e-mail, mais vous avez ouvert le lien sur un appareil différent de celui avec lequel vous vous êtes connecté.\n\nSi vous souhaitez toujours associer votre compte %1$s, ouvrez le lien sur l\'appareil avec lequel vous avez commencé à vous connecter. Sinon, appuyez sur \"Continuer\" pour vous connecter depuis un autre appareil.</string>
     <string name="fui_or_continue_with">to Kokoba na</string>
     <string name="fui_sign_in_with_email_link">Kokɔta na nzela ya lien ya email</string>
-    <string name="fui_sign_in_with_password">Kokɔta na nzela ya mot ya kobombama</string>
     <string name="fui_verify_phone_number_title">Saisissez votre numéro de téléphone</string>
     <string name="fui_invalid_phone_number">Saisissez un numéro de téléphone valide</string>
     <string name="fui_enter_confirmation_code">Saisissez le code à six chiffres envoyé au</string>

--- a/auth/src/main/res/values-lt/strings.xml
+++ b/auth/src/main/res/values-lt/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Iš pradžių ketinote susieti %1$s ir el. pašto paskyras, bet atidarėte nuorodą kitame įrenginyje, kuriame nesate prisijungę.\n\nJei vis tiek norite susieti %1$s paskyrą, atidarykite nuorodą tame pačiame įrenginyje, kuriame pradėjote prisijungimo procesą. Jei nenorite, palieskite „Tęsti“ ir prisijunkite šiame įrenginyje.</string>
     <string name="fui_or_continue_with">arba Tęsti su</string>
     <string name="fui_sign_in_with_email_link">Prisijungti el. pašto nuoroda</string>
-    <string name="fui_sign_in_with_password">Prisijungti slaptažodžiu</string>
     <string name="fui_verify_phone_number_title">Įveskite telefono numerį</string>
     <string name="fui_invalid_phone_number">Įveskite tinkamą telefono numerį</string>
     <string name="fui_enter_confirmation_code">Įveskite 6 skaitmenų kodą, kurį išsiuntėme</string>

--- a/auth/src/main/res/values-lv/strings.xml
+++ b/auth/src/main/res/values-lv/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Sākotnēji vēlējāties saistīt %1$s ar savu e-pasta kontu, tomēr saiti atvērāt citā ierīcē, kurā neesat pierakstījies.\n\nJa joprojām vēlaties saistīt savu %1$s kontu, atveriet saiti tajā pašā ierīcē, kurā sākāt pierakstīšanos. Pretējā gadījumā pieskarieties vienumam Turpināt, lai pierakstītos šajā ierīcē.</string>
     <string name="fui_or_continue_with">vai Turpināt ar</string>
     <string name="fui_sign_in_with_email_link">Pierakstīties ar e-pasta saiti</string>
-    <string name="fui_sign_in_with_password">Pierakstīties ar paroli</string>
     <string name="fui_verify_phone_number_title">Ievadiet savu tālruņa numuru</string>
     <string name="fui_invalid_phone_number">Ievadiet derīgu tālruņa numuru</string>
     <string name="fui_enter_confirmation_code">Ievadiet 6 ciparu kodu, ko nosūtījām</string>

--- a/auth/src/main/res/values-mo/strings.xml
+++ b/auth/src/main/res/values-mo/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Inițial ați intenționat să conectați %1$s la contul de e-mail, dar ați deschis linkul pe un dispozitiv pe care nu sunteți conectat(ă).\n\nDacă doriți să continuați conectarea contului %1$s, deschideți linkul pe același dispozitiv pe care ați început conectarea. În caz contrar, atingeți Continuați pentru a vă conecta pe acest dispozitiv.</string>
     <string name="fui_or_continue_with">sau Continuă cu</string>
     <string name="fui_sign_in_with_email_link">Conectați-vă cu linkul din e-mail</string>
-    <string name="fui_sign_in_with_password">Conectați-vă cu parola</string>
     <string name="fui_verify_phone_number_title">Introduceți numărul de telefon</string>
     <string name="fui_invalid_phone_number">Introduceți un număr valid de telefon</string>
     <string name="fui_enter_confirmation_code">Introduceți codul din 6 cifre pe care l-am trimis la</string>

--- a/auth/src/main/res/values-mr/strings.xml
+++ b/auth/src/main/res/values-mr/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">तुमचे ईमेल खाते %1$s सह कनेक्ट करणे हा तुमचा मूळ उद्देश होता पण तुम्ही साइन इन न केलेल्या वेगळ्या डिव्हाइसवर लिंक उघडली आहे. \n\nतुम्हाला तरीही तुमचे %1$s खाते कनेक्ट करायचे असल्यास, तुम्ही साइन इन सुरू केले त्याच डिव्हाइसवर लिंक उघडा. नाहीतर, या डिव्हाइसवर साइन इन करण्यासाठी सुरू ठेवा वर टॅप करा.</string>
     <string name="fui_or_continue_with">किंवा यासह सुरू ठेवा</string>
     <string name="fui_sign_in_with_email_link">ईमेल लिंक वापरून साइन इन करा</string>
-    <string name="fui_sign_in_with_password">पासवर्ड वापरून साइन इन करा</string>
     <string name="fui_verify_phone_number_title">तुमचा फोन नंबर टाका</string>
     <string name="fui_invalid_phone_number">कृपया वैध फोन नंबर टाका</string>
     <string name="fui_enter_confirmation_code">वर आम्ही पाठवलेला 6 अंकी कोड टाका</string>

--- a/auth/src/main/res/values-ms/strings.xml
+++ b/auth/src/main/res/values-ms/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Pada asalnya, anda mahu menyambungkan %1$s kepada akaun e-mel anda tetapi telah membuka pautan pada peranti berbeza yang tidak dilog masuk.\n\nJika anda masih mahu memautkan akaun %1$s anda, buka pautan pada peranti yang anda gunakan untuk log masuk. Jika tidak, ketik Teruskan untuk log masuk pada peranti ini.</string>
     <string name="fui_or_continue_with">atau Teruskan dengan</string>
     <string name="fui_sign_in_with_email_link">Log masuk dengan pautan e-mel</string>
-    <string name="fui_sign_in_with_password">Log masuk dengan kata laluan</string>
     <string name="fui_verify_phone_number_title">Masukkan nombor telefon anda</string>
     <string name="fui_invalid_phone_number">Masukkan nombor telefon yang sah</string>
     <string name="fui_enter_confirmation_code">Masukkan kod 6 digit yang kami hantar ke</string>

--- a/auth/src/main/res/values-nb/strings.xml
+++ b/auth/src/main/res/values-nb/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Du forsøkte opprinnelig å koble %1$s til e-postkontoen din, men du åpnet linken på en annen enhet enn den du er pålogget med.\n\nHvis du fortsatt ønsker å koble til %1$s-kontoen din, åpner du linken på enheten du er pålogget med. Hvis ikke trykker du på Fortsett for å logge på med denne enheten.</string>
     <string name="fui_or_continue_with">eller Fortsett med</string>
     <string name="fui_sign_in_with_email_link">Logg på med e-postlenke</string>
-    <string name="fui_sign_in_with_password">Logg på med passord</string>
     <string name="fui_verify_phone_number_title">Oppgi telefonnummeret ditt</string>
     <string name="fui_invalid_phone_number">Oppgi et gyldig telefonnummer</string>
     <string name="fui_enter_confirmation_code">Oppgi den 6-sifrede koden vi sendte til</string>

--- a/auth/src/main/res/values-nl/strings.xml
+++ b/auth/src/main/res/values-nl/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">U wilde aanvankelijk %1$s aan uw e-mailaccount koppelen, maar u heeft de link geopend op een andere apparaat, waarop u niet ingelogd bent.\n\nAls u nog steeds verbinding wilt maken met uw %1$s-account, opent u de link op het apparaat waarop u het inlogproces bent gestart. Tik anders op Doorgaan om in te loggen op dit apparaat.</string>
     <string name="fui_or_continue_with">of Doorgaan met</string>
     <string name="fui_sign_in_with_email_link">Inloggen met e-maillink</string>
-    <string name="fui_sign_in_with_password">Inloggen met wachtwoord</string>
     <string name="fui_verify_phone_number_title">Voer uw telefoonnummer in</string>
     <string name="fui_invalid_phone_number">Voer een geldig telefoonnummer in</string>
     <string name="fui_enter_confirmation_code">Voer de zescijferige code in die we hebben verzonden naar</string>

--- a/auth/src/main/res/values-no/strings.xml
+++ b/auth/src/main/res/values-no/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Du forsøkte opprinnelig å koble %1$s til e-postkontoen din, men du åpnet linken på en annen enhet enn den du er pålogget med.\n\nHvis du fortsatt ønsker å koble til %1$s-kontoen din, åpner du linken på enheten du er pålogget med. Hvis ikke trykker du på Fortsett for å logge på med denne enheten.</string>
     <string name="fui_or_continue_with">eller Fortsett med</string>
     <string name="fui_sign_in_with_email_link">Logg på med e-postlenke</string>
-    <string name="fui_sign_in_with_password">Logg på med passord</string>
     <string name="fui_verify_phone_number_title">Oppgi telefonnummeret ditt</string>
     <string name="fui_invalid_phone_number">Oppgi et gyldig telefonnummer</string>
     <string name="fui_enter_confirmation_code">Oppgi den 6-sifrede koden vi sendte til</string>

--- a/auth/src/main/res/values-pl/strings.xml
+++ b/auth/src/main/res/values-pl/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Podjęto próbę połączenia konta %1$s z kontem, na którym używasz podanego adresu e-mail, ale link został otwarty na innym urządzeniu, na którym użytkownik nie był zalogowany.\n\nJeśli nadal chcesz połączyć konto w serwisie %1$s, otwórz link na urządzeniu, na którym rozpoczęto logowanie. W przeciwnym razie wybierz Dalej, by zalogować się na tym urządzeniu.</string>
     <string name="fui_or_continue_with">lub Kontynuuj z</string>
     <string name="fui_sign_in_with_email_link">Zaloguj się za pomocą linku e-mail</string>
-    <string name="fui_sign_in_with_password">Zaloguj się za pomocą hasła</string>
     <string name="fui_verify_phone_number_title">Wpisz numer telefonu</string>
     <string name="fui_invalid_phone_number">Wpisz prawidłowy numer telefonu</string>
     <string name="fui_enter_confirmation_code">Wpisz sześciocyfrowy kod, który wysłaliśmy na numer</string>

--- a/auth/src/main/res/values-pt-rBR/strings.xml
+++ b/auth/src/main/res/values-pt-rBR/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Inicialmente, você quis conectar %1$s à sua conta de e-mail, mas abriu o link em outro dispositivo no qual você não está conectado.\n\nSe você ainda quiser conectar sua conta de %1$s, abra o link no mesmo dispositivo em que fez login. Se preferir, toque em \"Continuar\" para fazer login neste dispositivo.</string>
     <string name="fui_or_continue_with">ou Continuar com</string>
     <string name="fui_sign_in_with_email_link">Fazer login com link de e-mail</string>
-    <string name="fui_sign_in_with_password">Fazer login com senha</string>
     <string name="fui_verify_phone_number_title">Insira o número do seu telefone</string>
     <string name="fui_invalid_phone_number">Insira um número de telefone válido</string>
     <string name="fui_enter_confirmation_code">Insira o código de 6 dígitos enviado para</string>

--- a/auth/src/main/res/values-pt-rPT/strings.xml
+++ b/auth/src/main/res/values-pt-rPT/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Originalmente, pretendia associar %1$s à sua conta de email, mas abriu o link num dispositivo diferente no qual não tem sessão iniciada.\n\nSe ainda pretender associar a sua conta do %1$s, abra o link no mesmo dispositivo em que iniciou sessão. Caso contrário, toque em Continuar para iniciar sessão neste dispositivo.</string>
     <string name="fui_or_continue_with">ou Continuar com</string>
     <string name="fui_sign_in_with_email_link">Iniciar sessão com link de e-mail</string>
-    <string name="fui_sign_in_with_password">Iniciar sessão com palavra-passe</string>
     <string name="fui_verify_phone_number_title">Introduza o seu número de telefone</string>
     <string name="fui_invalid_phone_number">Introduza um número de telefone válido</string>
     <string name="fui_enter_confirmation_code">Introduza o código de 6 dígitos que enviámos para</string>

--- a/auth/src/main/res/values-pt/strings.xml
+++ b/auth/src/main/res/values-pt/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Inicialmente, você quis conectar %1$s à sua conta de e-mail, mas abriu o link em outro dispositivo no qual você não está conectado.\n\nSe você ainda quiser conectar sua conta de %1$s, abra o link no mesmo dispositivo em que fez login. Se preferir, toque em \"Continuar\" para fazer login neste dispositivo.</string>
     <string name="fui_or_continue_with">ou Continuar com</string>
     <string name="fui_sign_in_with_email_link">Fazer login com link de e-mail</string>
-    <string name="fui_sign_in_with_password">Fazer login com senha</string>
     <string name="fui_verify_phone_number_title">Insira o número do seu telefone</string>
     <string name="fui_invalid_phone_number">Insira um número de telefone válido</string>
     <string name="fui_enter_confirmation_code">Insira o código de 6 dígitos enviado para</string>

--- a/auth/src/main/res/values-ro/strings.xml
+++ b/auth/src/main/res/values-ro/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Inițial ați intenționat să conectați %1$s la contul de e-mail, dar ați deschis linkul pe un dispozitiv pe care nu sunteți conectat(ă).\n\nDacă doriți să continuați conectarea contului %1$s, deschideți linkul pe același dispozitiv pe care ați început conectarea. În caz contrar, atingeți Continuați pentru a vă conecta pe acest dispozitiv.</string>
     <string name="fui_or_continue_with">sau Continuă cu</string>
     <string name="fui_sign_in_with_email_link">Conectați-vă cu linkul din e-mail</string>
-    <string name="fui_sign_in_with_password">Conectați-vă cu parola</string>
     <string name="fui_verify_phone_number_title">Introduceți numărul de telefon</string>
     <string name="fui_invalid_phone_number">Introduceți un număr valid de telefon</string>
     <string name="fui_enter_confirmation_code">Introduceți codul din 6 cifre pe care l-am trimis la</string>

--- a/auth/src/main/res/values-ru/strings.xml
+++ b/auth/src/main/res/values-ru/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Вы пытались связать аккаунт сервиса %1$s со своим адресом электронной почты, однако перешли по ссылке на устройстве, на котором у вас не выполнен вход.\n\nЧтобы пройти авторизацию на текущем компьютере, телефоне или планшете, нажмите \"Продолжить\". Если вы все-таки хотите связать аккаунт сервиса %1$s со своим адресом электронной почты, откройте ссылку на устройстве, на котором начали процесс входа.</string>
     <string name="fui_or_continue_with">или Продолжить с</string>
     <string name="fui_sign_in_with_email_link">Войти по ссылке из письма</string>
-    <string name="fui_sign_in_with_password">Войти с паролем</string>
     <string name="fui_verify_phone_number_title">Введите номер телефона</string>
     <string name="fui_invalid_phone_number">Введите действительный номер телефона.</string>
     <string name="fui_enter_confirmation_code">Введите 6-значный код, отправленный на номер</string>

--- a/auth/src/main/res/values-sk/strings.xml
+++ b/auth/src/main/res/values-sk/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Pôvodne ste chceli prepojiť svoj účet v službe %1$s so svojím e‑mailovým účtom, ale odkaz ste otvorili v inom zariadení, v ktorom ste sa neprihlásili.\n\nAk stále chcete prepojiť svoj účet v službe %1$s, otvorte odkaz v rovnakom zariadení, v ktorom ste sa začali prihlasovať. V opačnom prípade klepnite na tlačidlo Pokračovať a prihláste sa v tomto zariadení.</string>
     <string name="fui_or_continue_with">alebo Pokračovať s</string>
     <string name="fui_sign_in_with_email_link">Prihlásiť sa pomocou e-mailového odkazu</string>
-    <string name="fui_sign_in_with_password">Prihlásiť sa pomocou hesla</string>
     <string name="fui_verify_phone_number_title">Zadajte svoje telefónne číslo</string>
     <string name="fui_invalid_phone_number">Zadajte platné telefónne číslo</string>
     <string name="fui_enter_confirmation_code">Zadajte 6-ciferný kód, ktorý sme odoslali na adresu</string>

--- a/auth/src/main/res/values-sl/strings.xml
+++ b/auth/src/main/res/values-sl/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Najprej ste želeli račun %1$s povezati z e-poštnim računom, vendar ste povezavo odprli v drugi napravi, kjer niste prijavljeni.\n\nČe želite še vedno povezati račun %1$s, odprite povezavo v napravi, v kateri ste začeli s prijavo. V nasprotnem primeru se dotaknite možnosti »Nadaljuj«, da se prijavite v tej napravi.</string>
     <string name="fui_or_continue_with">ali Nadaljuj z</string>
     <string name="fui_sign_in_with_email_link">Prijavite se z e-poštno povezavo</string>
-    <string name="fui_sign_in_with_password">Prijavite se z geslom</string>
     <string name="fui_verify_phone_number_title">Vnesite telefonsko številko</string>
     <string name="fui_invalid_phone_number">Vnesite veljavno telefonsko številko</string>
     <string name="fui_enter_confirmation_code">Vnesite 6-mestno kodo, ki smo jo poslali na številko</string>

--- a/auth/src/main/res/values-sr/strings.xml
+++ b/auth/src/main/res/values-sr/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Првобитна намера вам је била да повежете %1$s налог са имејл налогом, али сте отворили линк на другом уређају, на ком нисте пријављени.\n\nАко и даље желите да повежете %1$s налог, отворите линк на истом уређају на ком сте почели пријављивање. У супротном, додирните Настави да бисте се пријавили на овом уређају.</string>
     <string name="fui_or_continue_with">или Наставите са</string>
     <string name="fui_sign_in_with_email_link">Пријавите се помоћу имејл линка</string>
-    <string name="fui_sign_in_with_password">Пријавите се помоћу лозинке</string>
     <string name="fui_verify_phone_number_title">Унесите број телефона</string>
     <string name="fui_invalid_phone_number">Унесите важећи број телефона</string>
     <string name="fui_enter_confirmation_code">Унесите 6-цифрени кôд који смо послали на</string>

--- a/auth/src/main/res/values-sv/strings.xml
+++ b/auth/src/main/res/values-sv/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Du skulle ansluta %1$s till ditt e-postkonto men har öppnat länken på en annan enhet där du inte är inloggad.\n\nOm du fortfarande vill ansluta ditt %1$s-konto ska du öppna länken på den enhet där du påbörjade inloggningen. Annars kan du klicka på Fortsätt för att logga in på den här enheten.</string>
     <string name="fui_or_continue_with">eller Fortsätt med</string>
     <string name="fui_sign_in_with_email_link">Logga in med e-postlänk</string>
-    <string name="fui_sign_in_with_password">Logga in med lösenord</string>
     <string name="fui_verify_phone_number_title">Ange ditt telefonnummer</string>
     <string name="fui_invalid_phone_number">Ange ett giltigt telefonnummer</string>
     <string name="fui_enter_confirmation_code">Ange den sexsiffriga koden vi skickade till</string>

--- a/auth/src/main/res/values-ta/strings.xml
+++ b/auth/src/main/res/values-ta/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">முதலில் %1$sஐ உங்கள் மின்னஞ்சல் கணக்குடன் இணைப்பதற்காக முயற்சித்தீர்கள், ஆனால் உள்நுழைந்திராத வேறொரு சாதனத்தில் இணைப்பைத் திறந்துள்ளீர்கள்.\n\nஉங்கள் %1$s கணக்கை இணைக்க விரும்பினால், நீங்கள் உள்நுழைய தொடங்கிய அதே சாதனத்தில் இணைப்பைத் திறக்கவும். இல்லையெனில் இந்தச் சாதனத்தில் உள்நுழைய தொடர்க என்பதைத் தட்டவும்.</string>
     <string name="fui_or_continue_with">அல்லது இதனுடன் தொடரவும்</string>
     <string name="fui_sign_in_with_email_link">மின்னஞ்சல் இணைப்பு மூலம் உள்நுழைக</string>
-    <string name="fui_sign_in_with_password">கடவுச்சொல் மூலம் உள்நுழைக</string>
     <string name="fui_verify_phone_number_title">ஃபோன் எண்ணை உள்ளிடவும்</string>
     <string name="fui_invalid_phone_number">சரியான ஃபோன் எண்ணை உள்ளிடவும்</string>
     <string name="fui_enter_confirmation_code">இந்த எண்ணுக்கு நாங்கள் அனுப்பிய 6 இலக்கக் குறியீட்டை உள்ளிடவும்:</string>

--- a/auth/src/main/res/values-th/strings.xml
+++ b/auth/src/main/res/values-th/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">แต่เดิมคุณตั้งใจที่จะเชื่อม %1$s เข้ากับบัญชีอีเมลแต่ได้เปิดลิงก์บนอุปกรณ์อื่นที่ไม่ได้ลงชื่อเข้าใช้\n\nหากยังต้องการเชื่อมบัญชี %1$s ให้เปิดลิงก์บนอุปกรณ์เดียวกันกับที่เริ่มลงชื่อเข้าใช้ หรือแตะ \"ต่อไป\" เพื่อลงชื่อเข้าใช้บนอุปกรณ์นี้</string>
     <string name="fui_or_continue_with">หรือดำเนินการต่อด้วย</string>
     <string name="fui_sign_in_with_email_link">ลงชื่อเข้าใช้ด้วยลิงก์อีเมล</string>
-    <string name="fui_sign_in_with_password">ลงชื่อเข้าใช้ด้วยรหัสผ่าน</string>
     <string name="fui_verify_phone_number_title">ป้อนหมายเลขโทรศัพท์ของคุณ</string>
     <string name="fui_invalid_phone_number">ป้อนหมายเลขโทรศัพท์ที่ถูกต้อง</string>
     <string name="fui_enter_confirmation_code">ป้อนรหัส 6 หลักที่เราส่งไปยัง</string>

--- a/auth/src/main/res/values-tl/strings.xml
+++ b/auth/src/main/res/values-tl/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Orihinal na sinadya mong ikonekta ang %1$s sa iyong email account pero nabuksan ang link sa ibang device kung saan hindi ka naka-sign in.\n\nKung gusto mo pa ring ikonekta ang iyong %1$s account, buksan ang link sa parehong device kung saan ka nagsimulang mag-sign in. Kung hindi, i-tap ang Magpatuloy para makapag-sign in sa device na ito.</string>
     <string name="fui_or_continue_with">o Magpatuloy gamit ang</string>
     <string name="fui_sign_in_with_email_link">Mag-sign in gamit ang email link</string>
-    <string name="fui_sign_in_with_password">Mag-sign in gamit ang password</string>
     <string name="fui_verify_phone_number_title">Ilagay ang numero ng iyong telepono</string>
     <string name="fui_invalid_phone_number">Maglagay ng wastong numero ng telepono</string>
     <string name="fui_enter_confirmation_code">Ilagay ang 6-digit na code na ipinadala namin sa</string>

--- a/auth/src/main/res/values-tr/strings.xml
+++ b/auth/src/main/res/values-tr/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Aslında %1$s adlı sağlayıcıyı e-posta hesabınıza bağlamak istediniz ancak bağlantıyı, oturum açmadığınız farklı bir cihazda açtınız.\n\nHâlâ %1$s hesabınızı bağlamak istiyorsanız bağlantıyı oturum açma işlemini başlattığınız cihazda açın. Aksi takdirde bu cihazda oturum açmak için Devam\'a dokunun.</string>
     <string name="fui_or_continue_with">veya Şununla Devam Et</string>
     <string name="fui_sign_in_with_email_link">E-posta bağlantısı ile oturum aç</string>
-    <string name="fui_sign_in_with_password">Şifre ile oturum aç</string>
     <string name="fui_verify_phone_number_title">Telefon numaranızı girin</string>
     <string name="fui_invalid_phone_number">Geçerli bir telefon numarası girin</string>
     <string name="fui_enter_confirmation_code">Şu telefon numarasına gönderdiğimiz 6 haneli kodu girin:</string>

--- a/auth/src/main/res/values-uk/strings.xml
+++ b/auth/src/main/res/values-uk/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Ви збиралися зв’язати %1$s зі своєю електронною адресою, але відкрили надане посилання на пристрої, на якому не ввійшли в обліковий запис.\n\nЩоб зв’язати обліковий запис %1$s, відкрийте посилання на пристрої, де ви почали входити, або натисніть \"Продовжити\", щоб увійти на цьому пристрої.</string>
     <string name="fui_or_continue_with">або Продовжити з</string>
     <string name="fui_sign_in_with_email_link">Увійти за посиланням з електронного листа</string>
-    <string name="fui_sign_in_with_password">Увійти з паролем</string>
     <string name="fui_verify_phone_number_title">Введіть свій номер телефону</string>
     <string name="fui_invalid_phone_number">Введіть дійсний номер телефону</string>
     <string name="fui_enter_confirmation_code">Введіть 6-значний код, який ми надіслали на номер</string>

--- a/auth/src/main/res/values-ur/strings.xml
+++ b/auth/src/main/res/values-ur/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">آپ نے اصل میں اپنے ای میل اکاؤنٹ کو %1$s کے ساتھ منسلک کرنا چاہتے تھے لیکن آپ نے لنک کو دوسرے آلہ پر کھولا ہے جہاں آپ سائن ان نہیں ہیں۔‎\n\nاگر آپ ابھی بھی اپنے %1$s اکاؤنٹ سے منسلک ہونا چاہتے ہیں، تو اسی آلہ پر لنک کو کھولیں جہاں سے آپ نے سائن ان شروع کیا تھا۔ بصورت دیگر، اس آلہ پر مسلسل سائن کرنے کے لیے تھپتھپائيں۔</string>
     <string name="fui_or_continue_with">یا اس کے ساتھ جاری رکھیں</string>
     <string name="fui_sign_in_with_email_link">ای میل لنک سے سائن ان کریں</string>
-    <string name="fui_sign_in_with_password">پاس ورڈ سے سائن ان کریں</string>
     <string name="fui_verify_phone_number_title">اپنا فون نمبر درج کریں</string>
     <string name="fui_invalid_phone_number">براہ کرم ایک درست فون نمبر درج کریں</string>
     <string name="fui_enter_confirmation_code">ہماری جانب سے حسبِ ذیل کو بھیجا گیا 6 عدد کا کوڈ درج کریں</string>

--- a/auth/src/main/res/values-vi/strings.xml
+++ b/auth/src/main/res/values-vi/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">Ban đầu, bạn có ý định kết nối %1$s với tài khoản email của bạn nhưng đã mở đường liên kết trên một thiết bị khác mà bạn chưa đăng nhập.\n\nNếu bạn vẫn muốn kết nối với tài khoản %1$s của mình, hãy mở đường liên kết này trên cùng một thiết bị mà bạn đã đăng nhập từ đầu. Nếu không, hãy nhấn Tiếp tục để đăng nhập trên thiết bị này.</string>
     <string name="fui_or_continue_with">hoặc Tiếp tục với</string>
     <string name="fui_sign_in_with_email_link">Đăng nhập bằng liên kết email</string>
-    <string name="fui_sign_in_with_password">Đăng nhập bằng mật khẩu</string>
     <string name="fui_verify_phone_number_title">Nhập số điện thoại của bạn</string>
     <string name="fui_invalid_phone_number">Nhập số điện thoại hợp lệ</string>
     <string name="fui_enter_confirmation_code">Nhập mã 6 chữ số mà chúng tôi đã gửi cho bạn</string>

--- a/auth/src/main/res/values-zh-rCN/strings.xml
+++ b/auth/src/main/res/values-zh-rCN/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">您最初是想将%1$s与您的电子邮件帐号关联起来，但是您换用其他未登录的设备打开了此链接。\n\n如果您仍希望关联您的%1$s帐号，请在您最初开始登录时所用的设备上打开此链接。否则，请点按“继续”以在当前设备上登录。</string>
     <string name="fui_or_continue_with">或继续使用</string>
     <string name="fui_sign_in_with_email_link">使用电子邮件链接登录</string>
-    <string name="fui_sign_in_with_password">使用密码登录</string>
     <string name="fui_verify_phone_number_title">输入您的电话号码</string>
     <string name="fui_invalid_phone_number">请输入有效的电话号码</string>
     <string name="fui_enter_confirmation_code">输入我们发送至以下电话号码的 6 位数验证码</string>

--- a/auth/src/main/res/values-zh-rHK/strings.xml
+++ b/auth/src/main/res/values-zh-rHK/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">您原先想將 %1$s 連結至您的電子郵件帳戶，卻在另一部未登入帳戶的裝置上開啟了連結。\n\n如果您仍想連結您的 %1$s 帳戶，請在開始登入程序的同一部裝置上開啟連結。如不想連結帳戶，請輕觸 [繼續] 以在這部裝置上進行登入程序。</string>
     <string name="fui_or_continue_with">或繼續使用</string>
     <string name="fui_sign_in_with_email_link">使用電郵連結登入</string>
-    <string name="fui_sign_in_with_password">使用密碼登入</string>
     <string name="fui_verify_phone_number_title">請輸入您的電話號碼</string>
     <string name="fui_invalid_phone_number">請輸入有效的電話號碼</string>
     <string name="fui_enter_confirmation_code">請輸入傳送至以下電話號碼的 6 位數驗證碼</string>

--- a/auth/src/main/res/values-zh-rTW/strings.xml
+++ b/auth/src/main/res/values-zh-rTW/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">您原先想將 %1$s 連結至您的電子郵件帳戶，卻在另一部未登入帳戶的裝置上開啟了連結。\n\n如果您仍想連結您的 %1$s 帳戶，請在開始登入程序的同一部裝置上開啟連結。如不想連結帳戶，請輕觸 [繼續] 以在這部裝置上進行登入程序。</string>
     <string name="fui_or_continue_with">或繼續使用</string>
     <string name="fui_sign_in_with_email_link">使用電子郵件連結登入</string>
-    <string name="fui_sign_in_with_password">使用密碼登入</string>
     <string name="fui_verify_phone_number_title">請輸入您的電話號碼</string>
     <string name="fui_invalid_phone_number">請輸入有效的電話號碼</string>
     <string name="fui_enter_confirmation_code">請輸入傳送至以下電話號碼的 6 位數驗證碼</string>

--- a/auth/src/main/res/values-zh/strings.xml
+++ b/auth/src/main/res/values-zh/strings.xml
@@ -86,7 +86,6 @@
     <string name="fui_email_link_cross_device_linking_text">您最初是想将%1$s与您的电子邮件帐号关联起来，但是您换用其他未登录的设备打开了此链接。\n\n如果您仍希望关联您的%1$s帐号，请在您最初开始登录时所用的设备上打开此链接。否则，请点按“继续”以在当前设备上登录。</string>
     <string name="fui_or_continue_with">或继续使用</string>
     <string name="fui_sign_in_with_email_link">使用电子邮件链接登录</string>
-    <string name="fui_sign_in_with_password">使用密码登录</string>
     <string name="fui_verify_phone_number_title">输入您的电话号码</string>
     <string name="fui_invalid_phone_number">请输入有效的电话号码</string>
     <string name="fui_enter_confirmation_code">输入我们发送至以下电话号码的 6 位数验证码</string>

--- a/auth/src/main/res/values/strings.xml
+++ b/auth/src/main/res/values/strings.xml
@@ -207,7 +207,6 @@
     <!-- Email Link Sign In -->
     <string name="fui_or_continue_with" translation_description="Divider text for alternate sign-in options">or Continue with</string>
     <string name="fui_sign_in_with_email_link" translation_description="Button text to sign in with email link">Sign in with email link</string>
-    <string name="fui_sign_in_with_password" translation_description="Button text to sign in with password">Sign in with password</string>
     <string name="fui_email_link_header" translation_description="Email link sign in email sent header">Sign-in email sent\n</string>
     <string name="fui_email_link_email_sent" translation_description="Text to tell the user that the email has been sent">A sign-in email with additional instructions was sent to %1$s. Check your email to complete sign-in.</string>
     <string name="fui_email_link_trouble_getting_email_header" translation_description="Header that is displayed on the trouble signing in activity">Trouble getting email?</string>

--- a/auth/src/test/java/com/firebase/ui/auth/ui/MainSourceTestTagUsageTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/MainSourceTestTagUsageTest.kt
@@ -504,7 +504,7 @@ class MainSourceTestTagUsageTest {
          * Lower bound on `testTag` applications, so a scan that stops reaching files announces
          * itself; a floor, not a pin, since tagging more nodes is expected.
          */
-        const val MINIMUM_TAG_CALL_SITES = 62
+        const val MINIMUM_TAG_CALL_SITES = 60
 
         /** Lower bound on recognised owner constructions, for the same reason as above. */
         const val MINIMUM_SEMANTICS_OWNER_SITES = 20

--- a/auth/src/test/java/com/firebase/ui/auth/ui/MainSourceTestTagUsageTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/MainSourceTestTagUsageTest.kt
@@ -504,7 +504,7 @@ class MainSourceTestTagUsageTest {
          * Lower bound on `testTag` applications, so a scan that stops reaching files announces
          * itself; a floor, not a pin, since tagging more nodes is expected.
          */
-        const val MINIMUM_TAG_CALL_SITES = 60
+        const val MINIMUM_TAG_CALL_SITES = 59
 
         /** Lower bound on recognised owner constructions, for the same reason as above. */
         const val MINIMUM_SEMANTICS_OWNER_SITES = 20

--- a/auth/src/test/java/com/firebase/ui/auth/ui/TestTagsAsResourceIdsTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/TestTagsAsResourceIdsTest.kt
@@ -416,7 +416,6 @@ class TestTagsAsResourceIdsTest {
     fun `email link screen exposes its field and actions`() {
         setContent {
             SignInEmailLinkUI(
-                onGoToSignIn = { },
                 configuration = emailConfiguration(),
                 isLoading = false,
                 emailSignInLinkSent = false,
@@ -430,7 +429,6 @@ class TestTagsAsResourceIdsTest {
 
         assertExposedAsResourceId(FirebaseAuthTestTags.EmailLink.EMAIL_FIELD, field())
         assertExposedAsResourceId(FirebaseAuthTestTags.EmailLink.SEND_LINK_BUTTON, button())
-        assertExposedAsResourceId(FirebaseAuthTestTags.EmailLink.PASSWORD_SIGN_IN_BUTTON, button())
         assertExposedAsResourceId(FirebaseAuthTestTags.EmailLink.FORGOT_PASSWORD_BUTTON, button())
         assertExposedAsResourceId(FirebaseAuthTestTags.EmailLink.BACK_BUTTON, button())
     }
@@ -654,7 +652,6 @@ class TestTagsAsResourceIdsTest {
     fun `email link sent dialog exposes its dismiss button`() {
         setContent {
             SignInEmailLinkUI(
-                onGoToSignIn = { },
                 configuration = emailConfiguration(),
                 isLoading = false,
                 emailSignInLinkSent = true,

--- a/auth/src/test/java/com/firebase/ui/auth/ui/TestTagsAsResourceIdsTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/TestTagsAsResourceIdsTest.kt
@@ -374,7 +374,6 @@ class TestTagsAsResourceIdsTest {
                 onEmailChange = { },
                 onPasswordChange = { },
                 onConfirmPasswordChange = { },
-                onGoToSignIn = { },
                 onSignUpClick = { },
                 onNavigateBack = { },
             )
@@ -385,7 +384,6 @@ class TestTagsAsResourceIdsTest {
         assertExposedAsResourceId(FirebaseAuthTestTags.SignUp.PASSWORD_FIELD, field())
         assertExposedAsResourceId(FirebaseAuthTestTags.SignUp.CONFIRM_PASSWORD_FIELD, field())
         assertExposedAsResourceId(FirebaseAuthTestTags.SignUp.SIGN_UP_BUTTON, button())
-        assertExposedAsResourceId(FirebaseAuthTestTags.SignUp.SIGN_IN_BUTTON, button())
         assertExposedAsResourceId(FirebaseAuthTestTags.SignUp.BACK_BUTTON, button())
         assertExposedAsResourceId(FirebaseAuthTestTags.SignUp.PASSWORD_VISIBILITY_TOGGLE, button())
         assertExposedAsResourceId(
@@ -398,20 +396,19 @@ class TestTagsAsResourceIdsTest {
     fun `reset password screen exposes its field and actions`() {
         setContent {
             ResetPasswordUI(
+                onGoToSignIn = { },
                 configuration = emailConfiguration(),
                 isLoading = false,
                 email = "",
                 resetLinkSent = false,
                 onEmailChange = { },
                 onSendResetLink = { },
-                onGoToSignIn = { },
                 onNavigateBack = { },
             )
         }
 
         assertExposedAsResourceId(FirebaseAuthTestTags.ResetPassword.EMAIL_FIELD, field())
         assertExposedAsResourceId(FirebaseAuthTestTags.ResetPassword.SEND_BUTTON, button())
-        assertExposedAsResourceId(FirebaseAuthTestTags.ResetPassword.SIGN_IN_BUTTON, button())
         assertExposedAsResourceId(FirebaseAuthTestTags.ResetPassword.BACK_BUTTON, button())
     }
 
@@ -419,13 +416,13 @@ class TestTagsAsResourceIdsTest {
     fun `email link screen exposes its field and actions`() {
         setContent {
             SignInEmailLinkUI(
+                onGoToSignIn = { },
                 configuration = emailConfiguration(),
                 isLoading = false,
                 emailSignInLinkSent = false,
                 email = "",
                 onEmailChange = { },
                 onSignInWithEmailLink = { },
-                onGoToSignIn = { },
                 onGoToResetPassword = { },
                 onNavigateBack = { },
             )
@@ -640,13 +637,13 @@ class TestTagsAsResourceIdsTest {
     fun `reset password sent dialog exposes its dismiss button`() {
         setContent {
             ResetPasswordUI(
+                onGoToSignIn = { },
                 configuration = emailConfiguration(),
                 isLoading = false,
                 email = "user@example.com",
                 resetLinkSent = true,
                 onEmailChange = { },
                 onSendResetLink = { },
-                onGoToSignIn = { },
             )
         }
 
@@ -657,13 +654,13 @@ class TestTagsAsResourceIdsTest {
     fun `email link sent dialog exposes its dismiss button`() {
         setContent {
             SignInEmailLinkUI(
+                onGoToSignIn = { },
                 configuration = emailConfiguration(),
                 isLoading = false,
                 emailSignInLinkSent = true,
                 email = "user@example.com",
                 onEmailChange = { },
                 onSignInWithEmailLink = { },
-                onGoToSignIn = { },
                 onGoToResetPassword = { },
             )
         }

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreenModeSwitchTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreenModeSwitchTest.kt
@@ -184,32 +184,13 @@ class EmailAuthScreenModeSwitchTest {
     }
 
     /**
-     * The shape this screen cannot defend itself against, pinned so the hazard is visible: a host
-     * that satisfies [EmailAuthScreen]'s `mode` and `onNavigateToMode` out of plain state, without
-     * giving the target mode a composition of its own.
-     *
-     * Compose sees one call site and keeps the composition, so every `rememberSaveable` the screen
-     * holds survives the switch — including the password typed on the sign-in form, which then
-     * greets the user pre-filled on sign-up.
+     * Navigating to a mode gives it its own destination, and so its own composition: the password
+     * typed on the sign-in form stays with the entry it was typed into, rather than greeting the
+     * user pre-filled on sign-up.
      */
     @Test
-    fun `flipping the mode parameter within one composition carries the password over`() {
-        startFlippingAParameter(fresh = false)
-
-        type { it.onPasswordChange("hunter2") }
-        goTo(EmailAuthMode.SignUp)
-
-        assertThat(state().mode).isEqualTo(EmailAuthMode.SignUp)
-        assertThat(state().password).isEqualTo("hunter2")
-    }
-
-    /**
-     * The same host, one line different: the target mode gets its own composition. That is all real
-     * navigation does here, and it is the whole of the difference — nothing in the screen changes.
-     */
-    @Test
-    fun `giving the target mode its own composition leaves the password behind`() {
-        startFlippingAParameter(fresh = true)
+    fun `a switch to another mode leaves the password behind`() {
+        startOnABackStack()
 
         type { it.onPasswordChange("hunter2") }
         goTo(EmailAuthMode.SignUp)
@@ -218,27 +199,23 @@ class EmailAuthScreenModeSwitchTest {
         assertThat(state().password).isEmpty()
     }
 
-    /**
-     * A host driving the mode from plain state. [fresh] is the only variable under test: whether
-     * the target mode is composed anew, the way a navigation destination is.
-     */
-    private fun startFlippingAParameter(fresh: Boolean) {
+    /** A host driving the modes the only way the screen supports them: as real destinations. */
+    private fun startOnABackStack() {
         composeTestRule.setContent {
-            var mode by remember { mutableStateOf(EmailAuthMode.SignIn) }
             CompositionLocalProvider(
                 LocalAuthUIStringProvider provides DefaultAuthUIStringProvider(applicationContext)
             ) {
-                // NOTE: `key` re-creates state on a switch; a real NavDisplay pop would restore it.
-                key(if (fresh) mode else Unit) {
+                EmailModeBackStackHost(startMode = EmailAuthMode.SignIn) { key, goToMode ->
                     EmailAuthScreen(
                         context = applicationContext,
                         configuration = configuration(),
                         authUI = authUI,
+                        prefillEmail = key.email.ifEmpty { null },
                         onSuccess = {},
                         onError = {},
                         onCancel = {},
-                        mode = mode,
-                        onNavigateToMode = { target, _ -> mode = target },
+                        mode = key.mode,
+                        onNavigateToMode = goToMode,
                         content = { state -> lastState = state },
                     )
                 }

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreenReauthEmailLockTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreenReauthEmailLockTest.kt
@@ -15,6 +15,8 @@
 package com.firebase.ui.auth.ui.screens.email
 
 import android.content.Context
+import androidx.compose.runtime.SideEffect
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -74,6 +76,8 @@ class EmailAuthScreenReauthEmailLockTest {
     private lateinit var applicationContext: Context
     private lateinit var stringProvider: AuthUIStringProvider
     private lateinit var authUI: FirebaseAuthUI
+
+    private var pressBack: (() -> Unit)? = null
 
     private val prefillEmail = "linked@example.com"
 
@@ -153,9 +157,9 @@ class EmailAuthScreenReauthEmailLockTest {
     }
 
     /**
-     * Hosts the screen the way production does: a mode switch navigates, so [key] gives the target
-     * mode its own composition, seeded with the address the switch carried — which is what a host
-     * puts on the destination's key.
+     * Hosts the screen the way a caller outside `FirebaseAuthScreen` has to: every mode is a real
+     * destination on the host's own back stack, so a switch navigates and system back pops one
+     * mode. The address rides on the key, which is what carries it across a switch.
      */
     @Composable
     private fun EmailAuthScreenUnderTest(
@@ -164,21 +168,17 @@ class EmailAuthScreenReauthEmailLockTest {
         startMode: EmailAuthMode = EmailAuthMode.SignIn,
         content: (@Composable (EmailAuthContentState) -> Unit)? = null,
     ) {
-        var mode by remember { mutableStateOf(startMode) }
-        var email by remember { mutableStateOf(prefill) }
+        val dispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+        SideEffect { pressBack = dispatcher?.let { { it.onBackPressed() } } }
         CompositionLocalProvider(LocalAuthUIStringProvider provides stringProvider) {
-            // NOTE: `key` re-creates state on a switch; a real NavDisplay pop would restore it.
-            key(mode) {
+            EmailModeBackStackHost(startMode = startMode, startEmail = prefill) { key, goToMode ->
                 EmailAuthScreen(
                     context = applicationContext,
                     configuration = configuration,
                     authUI = authUI,
-                    prefillEmail = email,
-                    mode = mode,
-                    onNavigateToMode = { target, typed ->
-                        email = typed.ifEmpty { null }
-                        mode = target
-                    },
+                    prefillEmail = key.email.ifEmpty { null } ?: prefill,
+                    mode = key.mode,
+                    onNavigateToMode = goToMode,
                     onSuccess = {},
                     onError = {},
                     onCancel = {},
@@ -342,8 +342,8 @@ class EmailAuthScreenReauthEmailLockTest {
 
         composeTestRule.onNodeWithText(stringProvider.troubleSigningIn).performClick()
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText(stringProvider.signInDefault, ignoreCase = true)
-            .performClick()
+        // Back, not an in-form control: recovery is a push, so the way back off it is the stack.
+        composeTestRule.runOnUiThread { requireNotNull(pressBack).invoke() }
         composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithText(stringProvider.emailHint)

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreenReauthEmailLockTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailAuthScreenReauthEmailLockTest.kt
@@ -253,7 +253,6 @@ class EmailAuthScreenReauthEmailLockTest {
                     email = prefillEmail,
                     onEmailChange = {},
                     onSignInWithEmailLink = {},
-                    onGoToSignIn = {},
                     onGoToResetPassword = {},
                     isEmailLocked = true,
                 )

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailModeBackStackHost.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/EmailModeBackStackHost.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens.email
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.togetherWith
+import androidx.compose.runtime.Composable
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
+import kotlinx.serialization.Serializable
+
+/**
+ * One email mode, as a caller's own back-stack key — the same shape the slot demos define.
+ *
+ * The library's own keys are internal, so a host outside
+ * [com.firebase.ui.auth.ui.screens.FirebaseAuthScreen] builds its own from the public
+ * [EmailAuthMode] and the address the screen hands back.
+ *
+ * @suppress Internal test support
+ */
+@Serializable
+internal data class EmailModeKey(val mode: EmailAuthMode, val email: String = "") : NavKey
+
+/**
+ * Moves to [mode], carrying the address so a switch keeps what the user typed.
+ *
+ * Adds before trimming, so no single write empties the stack: a mode already on the stack is
+ * replaced by the fresh key rather than revisited with a stale address; one that is not is pushed,
+ * leaving the mode below reachable by back.
+ */
+internal fun NavBackStack<NavKey>.goToEmailMode(mode: EmailAuthMode, email: String) {
+    val existing = indexOfFirst { it is EmailModeKey && it.mode == mode }
+    add(EmailModeKey(mode, email))
+    if (existing >= 0) {
+        while (size > existing + 1) removeAt(existing)
+    }
+}
+
+/**
+ * Hosts an email flow the way a caller outside `FirebaseAuthScreen` has to: every mode is a real
+ * destination on the host's own stack, so a switch is navigation and system back pops one mode.
+ *
+ * Transitions are off. Two entries composed at once during a crossfade would put two copies of the
+ * form on screen, which is about the animation rather than anything a test here asserts.
+ *
+ * @suppress Internal test support
+ */
+@Composable
+internal fun EmailModeBackStackHost(
+    startMode: EmailAuthMode,
+    startEmail: String? = null,
+    content: @Composable (key: EmailModeKey, goToMode: (EmailAuthMode, String) -> Unit) -> Unit,
+) {
+    val backStack = rememberNavBackStack(EmailModeKey(startMode, startEmail.orEmpty()))
+    NavDisplay(
+        backStack = backStack,
+        onBack = { backStack.removeLastOrNull() },
+        transitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+        popTransitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+        predictivePopTransitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+        entryProvider = entryProvider {
+            entry<EmailModeKey> { key ->
+                content(key) { mode, email -> backStack.goToEmailMode(mode, email) }
+            }
+        },
+    )
+}

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/SignInEmailLinkUIModifierTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/SignInEmailLinkUIModifierTest.kt
@@ -78,7 +78,6 @@ class SignInEmailLinkUIModifierTest {
                     email = "",
                     onEmailChange = { },
                     onSignInWithEmailLink = { },
-                    onGoToSignIn = { },
                     onGoToResetPassword = { },
                 )
             }

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/SignUpUITest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/SignUpUITest.kt
@@ -89,7 +89,6 @@ class SignUpUITest {
                     onEmailChange = { email = it },
                     onPasswordChange = { password = it },
                     onConfirmPasswordChange = { confirmPassword = it },
-                    onGoToSignIn = { },
                     onSignUpClick = { }
                 )
             }
@@ -142,7 +141,6 @@ class SignUpUITest {
                     onEmailChange = { email = it },
                     onPasswordChange = { password = it },
                     onConfirmPasswordChange = { confirmPassword = it },
-                    onGoToSignIn = { },
                     onSignUpClick = { }
                 )
             }
@@ -195,7 +193,6 @@ class SignUpUITest {
                     onEmailChange = { email = it },
                     onPasswordChange = { password = it },
                     onConfirmPasswordChange = { confirmPassword = it },
-                    onGoToSignIn = { },
                     onSignUpClick = { }
                 )
             }

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthHostDestinationsTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthHostDestinationsTest.kt
@@ -419,6 +419,25 @@ class PhoneAuthHostDestinationsTest {
         assertThat(reauthDismissals).isEqualTo(0)
     }
 
+    /**
+     * System back is inert inside the reauthentication sheet: it reaches neither the display's
+     * `onBack` nor the sheet's own `onDismissRequest`, so the step stays put. Pinned because it is
+     * why the host needs no attempt-teardown branch for a reauthentication entry — the only way out
+     * of a step is the back arrow, which goes through the screen's own `onCancel`.
+     */
+    @Test
+    fun `system back inside the reauthentication sheet does nothing`() {
+        startReauthSheet()
+        sendReauthCode()
+        assertAtCodeEntry()
+
+        composeTestRule.runOnUiThread { requireNotNull(pressBack).invoke() }
+        composeTestRule.waitForIdle()
+
+        assertAtCodeEntry()
+        assertThat(reauthDismissals).isEqualTo(0)
+    }
+
     // =============================================================================================
     // Harness
     // =============================================================================================
@@ -592,7 +611,11 @@ class PhoneAuthHostDestinationsTest {
             AuthRoute.Success,
             AuthRoute.Reauth(REQUEST_ID, REAUTH_UID, startStep),
         )
-        SideEffect { reauthBackStack = backStack }
+        val dispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+        SideEffect {
+            reauthBackStack = backStack
+            pressBack = dispatcher?.let { { it.onBackPressed() } }
+        }
         val surface = remember {
             mutableStateOf(
                 AuthState.Reauthentication.Required(request).toReauthSurface(config)

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthHostDestinationsTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthHostDestinationsTest.kt
@@ -254,11 +254,6 @@ class PhoneAuthHostDestinationsTest {
     }
 
     /**
-     * "Change number" retracts the attempt it is abandoning, and that retraction runs through the
-     * host's own abandonment reset on its way back — which used to send a multi-provider
-     * configuration all the way out to the method picker.
-     */
-    /**
      * The teardown gap. Code entry has two ways back to number entry and they used to disagree:
      * "change number" cancelled the attempt in flight, while the system back gesture was a bare
      * pop. The attempt outlives the step, so a late auto-verification then signed the user in on
@@ -290,6 +285,40 @@ class PhoneAuthHostDestinationsTest {
     }
 
     /**
+     * Leaving the flow abandons the attempt too, not only stepping back inside it. Code entry's own
+     * back arrow exits the whole flow by design, and the verification outlives the step — so
+     * without the teardown a late auto-verification signs the user in on the number they left.
+     */
+    @Test
+    fun `the back arrow out of code entry cancels the attempt`() {
+        `when`(mockAuth.signInWithCredential(any()))
+            .thenReturn(TaskCompletionSource<AuthResult>().task)
+
+        mockStatic(PhoneAuthProvider::class.java).use { statics ->
+            val credential = mock(PhoneAuthCredential::class.java)
+            statics.`when`<PhoneAuthCredential> {
+                PhoneAuthProvider.getCredential(any(), any())
+            }.thenReturn(credential)
+            start()
+            enterPhoneFlow()
+            val callbacks = sendCodeForReal(statics)
+            assertAtCodeEntry()
+
+            composeTestRule.onNodeWithTag(FirebaseAuthTestTags.VerificationCode.BACK_BUTTON)
+                .performClick()
+            composeTestRule.waitForIdle()
+            composeTestRule.runOnUiThread { callbacks.onVerificationCompleted(credential) }
+            repeat(3) { composeTestRule.waitForIdle() }
+
+            // Re-entered, because that is what makes the leak reachable: with the flow left there
+            // is no screen composed to act on the emission, and a fresh one would act on it.
+            enterPhoneFlow()
+
+            verify(mockAuth, never()).signInWithCredential(any())
+        }
+    }
+
+    /**
      * The other half of the same teardown: nothing replaces the cancelled attempt, so the state it
      * left up has to come down too. Number entry is exempt from an [AuthState.Idle] reset, so the
      * retraction lands there rather than unwinding the flow.
@@ -310,6 +339,11 @@ class PhoneAuthHostDestinationsTest {
         assertStillInTheFlow()
     }
 
+    /**
+     * "Change number" retracts the attempt it is abandoning, and that retraction runs through the
+     * host's own abandonment reset on its way back — which used to send a multi-provider
+     * configuration all the way out to the method picker.
+     */
     @Test
     fun `changing the number returns to number entry rather than the method picker`() {
         start()
@@ -441,7 +475,6 @@ class PhoneAuthHostDestinationsTest {
         composeTestRule.waitForIdle()
     }
 
-    /** Puts the screen on its authenticated destination, where `onNavigate` is reachable. */
     /**
      * The send the user performs, through the default UI, so a real verification attempt is in
      * flight for the teardown to cancel. Returns the callbacks Firebase was handed.
@@ -487,6 +520,7 @@ class PhoneAuthHostDestinationsTest {
             .invoke(captor.allValues.last()) as OnVerificationStateChangedCallbacks
     }
 
+    /** Puts the screen on its authenticated destination, where `onNavigate` is reachable. */
     private fun signIn() {
         val user = mock(FirebaseUser::class.java)
         `when`(user.uid).thenReturn("phone-host-user")

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthHostDestinationsTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthHostDestinationsTest.kt
@@ -77,6 +77,19 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import androidx.compose.runtime.LaunchedEffect
+import com.google.android.gms.tasks.TaskCompletionSource
+import com.google.firebase.auth.AuthResult
+import com.google.firebase.auth.PhoneAuthCredential
+import com.google.firebase.auth.PhoneAuthOptions
+import com.google.firebase.auth.PhoneAuthProvider.OnVerificationStateChangedCallbacks
+import org.mockito.ArgumentCaptor
+import org.mockito.MockedStatic
+import org.mockito.Mockito.any
+import org.mockito.Mockito.atLeastOnce
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
@@ -127,6 +140,9 @@ class PhoneAuthHostDestinationsTest {
 
     private var reauthDismissals = 0
 
+    /** Every state the host observed, so a retraction can be asserted after the fact. */
+    private val observedStates = mutableListOf<AuthState>()
+
     @Before
     fun setUp() {
         FirebaseAuthUI.clearInstanceCache()
@@ -153,6 +169,7 @@ class PhoneAuthHostDestinationsTest {
         reauthBackStack = null
         reauthRequest = null
         reauthDismissals = 0
+        observedStates.clear()
         FirebaseAuthUI.clearInstanceCache()
         FirebaseApp.getApps(applicationContext).forEach {
             try {
@@ -241,6 +258,58 @@ class PhoneAuthHostDestinationsTest {
      * host's own abandonment reset on its way back — which used to send a multi-provider
      * configuration all the way out to the method picker.
      */
+    /**
+     * The teardown gap. Code entry has two ways back to number entry and they used to disagree:
+     * "change number" cancelled the attempt in flight, while the system back gesture was a bare
+     * pop. The attempt outlives the step, so a late auto-verification then signed the user in on
+     * the number they had just backed away from.
+     */
+    @Test
+    fun `system back from code entry cancels the attempt started on number entry`() {
+        `when`(mockAuth.signInWithCredential(any()))
+            .thenReturn(TaskCompletionSource<AuthResult>().task)
+
+        mockStatic(PhoneAuthProvider::class.java).use { statics ->
+            val credential = mock(PhoneAuthCredential::class.java)
+            statics.`when`<PhoneAuthCredential> {
+                PhoneAuthProvider.getCredential(any(), any())
+            }.thenReturn(credential)
+            start()
+            enterPhoneFlow()
+            val callbacks = sendCodeForReal(statics)
+            assertAtCodeEntry()
+
+            back()
+            composeTestRule.runOnUiThread { callbacks.onVerificationCompleted(credential) }
+            repeat(3) { composeTestRule.waitForIdle() }
+
+            assertAtNumberEntry()
+            assertStillInTheFlow()
+            verify(mockAuth, never()).signInWithCredential(any())
+        }
+    }
+
+    /**
+     * The other half of the same teardown: nothing replaces the cancelled attempt, so the state it
+     * left up has to come down too. Number entry is exempt from an [AuthState.Idle] reset, so the
+     * retraction lands there rather than unwinding the flow.
+     */
+    @Test
+    fun `system back from code entry retracts the verification state`() {
+        start()
+        enterPhoneFlow()
+        sendCode()
+        assertAtCodeEntry()
+        assertThat(observedStates.last())
+            .isInstanceOf(AuthState.PhoneNumberVerificationRequired::class.java)
+
+        back()
+
+        assertThat(observedStates.last()).isInstanceOf(AuthState.Idle::class.java)
+        assertAtNumberEntry()
+        assertStillInTheFlow()
+    }
+
     @Test
     fun `changing the number returns to number entry rather than the method picker`() {
         start()
@@ -334,6 +403,7 @@ class PhoneAuthHostDestinationsTest {
     private fun Host() {
         val dispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
         SideEffect { pressBack = dispatcher?.let { { it.onBackPressed() } } }
+        LaunchedEffect(authUI) { authUI.authStateFlow().collect { observedStates += it } }
 
         FirebaseAuthScreen(
             configuration = emailAndPhoneConfiguration(),
@@ -372,6 +442,51 @@ class PhoneAuthHostDestinationsTest {
     }
 
     /** Puts the screen on its authenticated destination, where `onNavigate` is reachable. */
+    /**
+     * The send the user performs, through the default UI, so a real verification attempt is in
+     * flight for the teardown to cancel. Returns the callbacks Firebase was handed.
+     */
+    private fun sendCodeForReal(
+        statics: MockedStatic<PhoneAuthProvider>,
+        verificationId: String = "verification-id-1",
+    ): OnVerificationStateChangedCallbacks {
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.PhoneNumber.PHONE_NUMBER_FIELD)
+            .performTextInput(VALID_PHONE_NUMBER)
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.PhoneNumber.SEND_CODE_BUTTON)
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        val callbacks = latestCallbacks(statics)
+        composeTestRule.runOnUiThread {
+            callbacks.onCodeSent(
+                verificationId,
+                mock(PhoneAuthProvider.ForceResendingToken::class.java),
+            )
+        }
+        composeTestRule.waitForIdle()
+        return callbacks
+    }
+
+    /** The callbacks handed to the most recent `verifyPhoneNumber` call. */
+    private fun latestCallbacks(
+        statics: MockedStatic<PhoneAuthProvider>
+    ): OnVerificationStateChangedCallbacks {
+        val captor = ArgumentCaptor.forClass(PhoneAuthOptions::class.java)
+        statics.verify({ PhoneAuthProvider.verifyPhoneNumber(captor.capture()) }, atLeastOnce())
+        val candidates = PhoneAuthOptions::class.java.declaredMethods.filter {
+            it.parameterCount == 0 &&
+                it.returnType == OnVerificationStateChangedCallbacks::class.java
+        }
+        check(candidates.size == 1) {
+            "Expected exactly one zero-arg accessor returning " +
+                "OnVerificationStateChangedCallbacks on PhoneAuthOptions, found " +
+                "${candidates.size}: $candidates"
+        }
+        return candidates.single().also { it.isAccessible = true }
+            .invoke(captor.allValues.last()) as OnVerificationStateChangedCallbacks
+    }
+
     private fun signIn() {
         val user = mock(FirebaseUser::class.java)
         `when`(user.uid).thenReturn("phone-host-user")
@@ -587,6 +702,9 @@ class PhoneAuthHostDestinationsTest {
         const val AUTHENTICATED_TAG = "authenticated-destination"
         const val PHONE_PROVIDER_LABEL = "Sign in with phone"
         const val PHONE_NUMBER = "5555550123"
+
+        /** Passes libphonenumber, which rejects the 555 range the display tests use. */
+        const val VALID_PHONE_NUMBER = "2024561111"
         const val FULL_PHONE_NUMBER = "+15555550123"
         const val REQUEST_ID = "reauth-request-id"
         const val REAUTH_UID = "reauth-uid"

--- a/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/PhoneAuthScreenTest.kt
+++ b/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/PhoneAuthScreenTest.kt
@@ -138,7 +138,9 @@ class PhoneAuthScreenTest {
     @Test
     fun `sign-in and verify SMS emits Success auth state`() {
         val country = CountryUtils.findByCountryCode("DE")!!
-        val phone = "151${System.currentTimeMillis() % 100000000}"
+        // Zero-padded: the modulo alone yields fewer than 8 digits for ~2.8h out of every 27.8h,
+        // and a short 151 number is not a valid German mobile, so the send button stays disabled.
+        val phone = "151%08d".format(System.currentTimeMillis() % 100000000)
 
         val configuration = authUIConfiguration {
             context = applicationContext


### PR DESCRIPTION
- Related to #2480

#2480 made every email mode its own destination, but three in-form controls still duplicated what system back does — and back itself fell short in two places, so removing them first would have made the flow worse.

Leaving phone code entry now runs the same teardown "change number" does — by system back, by the top-bar arrow, and inside reauthentication — so a late auto-verification can no longer sign the user in on the number they just abandoned. The verification outlives the step, so without that the attempt survived being walked away from.

- `SignUpUI.kt` / `ResetPasswordUI.kt`: the `SIGN IN` action-row buttons are removed — the reset-link dialog's dismiss still navigates to sign-in.
- `SignInEmailLinkUI.kt`: the `SIGN IN WITH PASSWORD` toggle and its divider are removed. `SignInUI`'s email-link toggle stays, being the only way into that mode.
- `EmailAuthScreen.kt`: the KDoc sample now states that a self-hosted flow has to start at `SignIn` — back is inert at the bottom of a stack, so opening straight onto another mode leaves no route to the password form.
- `PhoneAuthScreenTest.kt`: zero-pad the generated German mobile number — unpadded it was an invalid length for ~2.8h out of every 27.8h, failing that test deterministically inside the window.

Two harnesses drove the modes from a plain variable rather than a back stack, one of them pinning the resulting password carry-over as expected behaviour; both now host on a real `NavDisplay`, which is what lets the removals stand. The full unit and e2e suites pass.

## ⚠️ Breaking Changes

- `SignUpUI` and `SignInEmailLinkUI`: `onGoToSignIn` removed.
- `FirebaseAuthTestTags`: `SignUp.SIGN_IN_BUTTON`, `ResetPassword.SIGN_IN_BUTTON` and `EmailLink.PASSWORD_SIGN_IN_BUTTON` removed.
- `AuthUIStringProvider`: `signInWithPassword` removed, along with its 85 translations.

## Preview

**Sign up**

| Before | After |
|---|---|
| <img width="300" alt="before-1-signup" src="https://github.com/user-attachments/assets/0ada0cb0-5c96-42f2-971c-41f382760f79" /> | <img width="300" alt="after-1-signup" src="https://github.com/user-attachments/assets/1db5ae95-b5ee-4039-b99f-9449d0ecfd6f" /> |

**Recover password**

| Before | After |
|---|---|
| <img width="300" alt="before-2-reset-password" src="https://github.com/user-attachments/assets/7dd0df35-d0f6-4720-8d3c-b601ec849b1d" /> | <img width="300" alt="after-2-reset-password" src="https://github.com/user-attachments/assets/623d5e4f-8e46-4aba-927a-29655eb1a50a" /> |

**Email-link sign-in**

| Before | After |
|---|---|
| <img width="300" alt="before-3-email-link" src="https://github.com/user-attachments/assets/bd627acf-dd3f-4285-b489-a8e3ef96a3ae" /> | <img width="300" alt="after-3-email-link" src="https://github.com/user-attachments/assets/90c6eb48-ebf0-4ab2-bb14-410c81df575a" /> |

---
Maintainer note: Fixes internal CPRN-408, CPRN-410


