### PR TITLE
feat(auth)!: decouple SMS multi-factor configuration from the phone sign-in provider

### DIFF
--- a/app/src/main/java/com/firebaseui/android/demo/auth/AuthFlowControllerDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/AuthFlowControllerDemoActivity.kt
@@ -103,7 +103,6 @@ class AuthFlowControllerDemoActivity : ComponentActivity() {
                     defaultNumber = null,
                     defaultCountryCode = null,
                     allowedCountries = emptyList(),
-                    smsCodeLength = 6,
                     timeout = 120L,
                     isInstantVerificationEnabled = true
                 ),

--- a/app/src/main/java/com/firebaseui/android/demo/auth/HighLevelApiDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/HighLevelApiDemoActivity.kt
@@ -153,7 +153,6 @@ class HighLevelApiDemoActivity : ComponentActivity() {
                             defaultNumber = null,
                             defaultCountryCode = null,
                             allowedCountries = emptyList(),
-                            smsCodeLength = 6,
                             timeout = 120L,
                             isInstantVerificationEnabled = true
                         )

--- a/app/src/main/java/com/firebaseui/android/demo/auth/PhoneAuthSlotDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/PhoneAuthSlotDemoActivity.kt
@@ -95,7 +95,6 @@ class PhoneAuthSlotDemoActivity : ComponentActivity() {
                         defaultNumber = null,
                         defaultCountryCode = "US",
                         allowedCountries = emptyList(),
-                        smsCodeLength = 6,
                         timeout = 60L,
                         isInstantVerificationEnabled = true
                     )

--- a/auth/README.md
+++ b/auth/README.md
@@ -1114,10 +1114,14 @@ fun MfaEnrollmentFlow() {
 
     if (currentUser != null) {
         val mfaConfig = MfaConfiguration(
-            allowedFactors = listOf(MfaFactor.Sms, MfaFactor.Totp)
+            allowedFactors = listOf(MfaFactor.Sms, MfaFactor.Totp),
+            allowedCountries = listOf("US", "CA", "GB")
         )
         val backStack = rememberNavBackStack(MfaStepKey(MfaEnrollmentStep.SelectFactor))
-        val flowState = rememberMfaEnrollmentFlowState()
+        // Pass the restriction so the SMS step opens on a country the selector will offer. The
+        // screen also reconciles this itself, so a host that forgets cannot end up sending to an
+        // unpermitted dial code.
+        val flowState = rememberMfaEnrollmentFlowState(mfaConfig.allowedCountries)
 
         NavDisplay(
             backStack = backStack,

--- a/auth/README.md
+++ b/auth/README.md
@@ -455,7 +455,6 @@ val phoneProvider = AuthProvider.Phone(
     allowedCountries = listOf("US", "CA", "GB"),
 
     // Optional: SMS code length (default: 6)
-    smsCodeLength = 6,
 
     // Optional: Timeout for SMS delivery in seconds (default: 60)
     timeout = 60L,

--- a/auth/README.md
+++ b/auth/README.md
@@ -454,8 +454,6 @@ val phoneProvider = AuthProvider.Phone(
     // Optional: Allowed countries
     allowedCountries = listOf("US", "CA", "GB"),
 
-    // Optional: SMS code length (default: 6)
-
     // Optional: Timeout for SMS delivery in seconds (default: 60)
     timeout = 60L,
 
@@ -1081,7 +1079,12 @@ val mfaConfig = MfaConfiguration(
     allowedFactors = listOf(MfaFactor.Sms, MfaFactor.Totp),
 
     // Optional: Require MFA enrollment (default: false)
-    requireEnrollment = false
+    requireEnrollment = false,
+
+    // Optional: restrict the SMS enrollment step's country selector, as ISO 3166-1 alpha-2
+    // codes (default: null, no restriction). Independent of the phone sign-in provider's own
+    // allowedCountries — an SMS second factor is configured separately from phone sign-in.
+    allowedCountries = listOf("US", "CA", "GB")
 )
 
 val configuration = authUIConfiguration {

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/MfaConfiguration.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/MfaConfiguration.kt
@@ -25,10 +25,17 @@ package com.firebase.ui.auth.configuration
  * @property requireEnrollment Whether MFA enrollment is mandatory for all users.
  *                             When true, users must enroll in at least one MFA factor.
  *                             Defaults to false.
+ * @property allowedCountries Country codes the [MfaFactor.Sms] enrollment step restricts its
+ *                            country selector to, or `null` for no restriction. Lives here rather
+ *                            than on the phone sign-in provider because a second factor is
+ *                            configured independently of the first: Firebase enables SMS second
+ *                            factors separately from phone sign-in, and phone sign-in cannot carry
+ *                            a second factor at all. Defaults to null.
  */
 class MfaConfiguration(
     val allowedFactors: List<MfaFactor> = listOf(MfaFactor.Sms, MfaFactor.Totp),
-    val requireEnrollment: Boolean = false
+    val requireEnrollment: Boolean = false,
+    val allowedCountries: List<String>? = null
 ) {
     init {
         require(allowedFactors.isNotEmpty()) {

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/MfaConfiguration.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/MfaConfiguration.kt
@@ -14,6 +14,8 @@
 
 package com.firebase.ui.auth.configuration
 
+import com.firebase.ui.auth.util.CountryUtils
+
 /**
  * Configuration class for Multi-Factor Authentication (MFA) enrollment and verification behavior.
  *
@@ -25,8 +27,10 @@ package com.firebase.ui.auth.configuration
  * @property requireEnrollment Whether MFA enrollment is mandatory for all users.
  *                             When true, users must enroll in at least one MFA factor.
  *                             Defaults to false.
- * @property allowedCountries Country codes the [MfaFactor.Sms] enrollment step restricts its
- *                            country selector to, or `null` for no restriction. Lives here rather
+ * @property allowedCountries ISO 3166-1 alpha-2 country codes the [MfaFactor.Sms] enrollment step
+ *                            restricts its country selector to, or `null` for no restriction. Dial
+ *                            codes are rejected: the filter behind this matches alpha-2 only, so a
+ *                            dial code would silently restrict to nothing. Lives here rather
  *                            than on the phone sign-in provider because a second factor is
  *                            configured independently of the first: Firebase enables SMS second
  *                            factors separately from phone sign-in, and phone sign-in cannot carry
@@ -40,6 +44,12 @@ class MfaConfiguration(
     init {
         require(allowedFactors.isNotEmpty()) {
             "At least one MFA factor must be allowed"
+        }
+        allowedCountries?.forEach { code ->
+            require(CountryUtils.findByCountryCode(code) != null) {
+                "Invalid country code: $code. allowedCountries takes ISO 3166-1 alpha-2 codes " +
+                        "(e.g. 'us', 'GB'). Dial codes are not accepted."
+            }
         }
     }
 }

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AuthProvider.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AuthProvider.kt
@@ -274,11 +274,6 @@ abstract class AuthProvider(open val providerId: String, open val providerName: 
         val allowedCountries: List<String>?,
 
         /**
-         * The expected length of the SMS verification code. Defaults to 6.
-         */
-        val smsCodeLength: Int = 6,
-
-        /**
          * The timeout in seconds for receiving the SMS. Defaults to 60L.
          */
         val timeout: Long = 60L,

--- a/auth/src/main/java/com/firebase/ui/auth/mfa/MfaEnrollmentContentState.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/mfa/MfaEnrollmentContentState.kt
@@ -69,6 +69,7 @@ import com.google.firebase.auth.MultiFactorInfo
  * @property phoneNumber (Step: [MfaEnrollmentStep.ConfigureSms]) The current value of the phone number input field. Does not include country code prefix.
  * @property onPhoneNumberChange (Step: [MfaEnrollmentStep.ConfigureSms]) Callback invoked when the phone number input changes. Receives the new phone number string.
  * @property selectedCountry (Step: [MfaEnrollmentStep.ConfigureSms]) The currently selected country for phone number formatting. Contains dial code, country code, and flag.
+ * @property allowedCountries (Step: [MfaEnrollmentStep.ConfigureSms]) Country codes the selector is restricted to, or `null` for no restriction. Determined by [com.firebase.ui.auth.configuration.MfaConfiguration.allowedCountries].
  * @property onCountrySelected (Step: [MfaEnrollmentStep.ConfigureSms]) Callback invoked when the user selects a different country. Receives the new [CountryData].
  * @property onSendSmsCodeClick (Step: [MfaEnrollmentStep.ConfigureSms]) Callback to send the SMS verification code to the entered phone number.
  *
@@ -118,6 +119,8 @@ data class MfaEnrollmentContentState(
     val onPhoneNumberChange: (String) -> Unit = {},
 
     val selectedCountry: CountryData? = null,
+
+    val allowedCountries: List<String>? = null,
 
     val onCountrySelected: (CountryData) -> Unit = {},
 

--- a/auth/src/main/java/com/firebase/ui/auth/mfa/SmsEnrollmentHandler.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/mfa/SmsEnrollmentHandler.kt
@@ -72,7 +72,6 @@ class SmsEnrollmentHandler(
         defaultNumber = null,
         defaultCountryCode = null,
         allowedCountries = null,
-        smsCodeLength = SMS_CODE_LENGTH,
         timeout = VERIFICATION_TIMEOUT_SECONDS,
         isInstantVerificationEnabled = true
     )

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/FirebaseAuthScreen.kt
@@ -197,7 +197,7 @@ fun FirebaseAuthScreen(
     val lastSuccessfulUserId = remember { mutableStateOf<String?>(null) }
     val pendingLinkingCredential = remember { mutableStateOf<AuthCredential?>(null) }
     val pendingResolver = remember { mutableStateOf<MultiFactorResolver?>(null) }
-    val mfaEnrollmentFlowState = rememberMfaEnrollmentFlowState()
+    val mfaEnrollmentFlowState = rememberMfaEnrollmentFlowState(mfaConfiguration.allowedCountries)
     val phoneAuthFlowState = rememberPhoneAuthFlowState(configuration)
     val reauthRequest = reauthState?.request
     val reauthConfig = reauthRequest?.let { configuration.toReauthConfiguration(it.user) }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentDefaults.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentDefaults.kt
@@ -160,7 +160,9 @@ internal fun DefaultMfaEnrollmentContent(
                         onPhoneNumberChange = state.onPhoneNumberChange,
                         onCountrySelected = state.onCountrySelected,
                         onSendCodeClick = state.onSendSmsCodeClick,
-                        allowedCountries = state.allowedCountries?.toSet(),
+                        allowedCountries = remember(state.allowedCountries) {
+                            state.allowedCountries?.toSet()
+                        },
                         title = stringProvider.mfaEnrollmentEnterPhoneNumber
                     )
                 }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentDefaults.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentDefaults.kt
@@ -160,6 +160,7 @@ internal fun DefaultMfaEnrollmentContent(
                         onPhoneNumberChange = state.onPhoneNumberChange,
                         onCountrySelected = state.onCountrySelected,
                         onSendCodeClick = state.onSendSmsCodeClick,
+                        allowedCountries = state.allowedCountries?.toSet(),
                         title = stringProvider.mfaEnrollmentEnterPhoneNumber
                     )
                 }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentDestinations.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentDestinations.kt
@@ -114,11 +114,6 @@ class MfaEnrollmentFlowState internal constructor(
 }
 
 /**
- * Creates and remembers the [MfaEnrollmentFlowState] a host installs [mfaEnrollmentDestinations]
- * with. Called once, above the `NavDisplay`, so the same instance is handed to every step — see
- * [MfaEnrollmentFlowState] for which of its fields actually survive Activity recreation.
- */
-/**
  * The country the SMS step opens on: the device's own when [allowedCountries] permits it, else the
  * first permitted one — so a restricted configuration cannot open pre-set to a country its own
  * selector will not offer.
@@ -132,6 +127,11 @@ internal fun initialEnrollmentCountry(allowedCountries: List<String>?): CountryD
         ?: deviceCountry
 }
 
+/**
+ * Creates and remembers the [MfaEnrollmentFlowState] a host installs [mfaEnrollmentDestinations]
+ * with. Called once, above the `NavDisplay`, so the same instance is handed to every step — see
+ * [MfaEnrollmentFlowState] for which of its fields actually survive Activity recreation.
+ */
 @Composable
 fun rememberMfaEnrollmentFlowState(
     allowedCountries: List<String>? = null,

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentDestinations.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentDestinations.kt
@@ -75,6 +75,7 @@ class MfaEnrollmentFlowState internal constructor(
     val totpQrCodeUrl: MutableState<String?>,
     val selectedCountry: MutableState<CountryData>,
     val totpSecretExpiredMessage: MutableState<String?>,
+    private val initialCountry: CountryData,
 ) {
 
     /**
@@ -107,7 +108,7 @@ class MfaEnrollmentFlowState internal constructor(
         smsSession.value = null
         totpSecret.value = null
         totpQrCodeUrl.value = null
-        selectedCountry.value = CountryUtils.getDefaultCountry()
+        selectedCountry.value = initialCountry
         totpSecretExpiredMessage.value = null
     }
 }
@@ -117,8 +118,25 @@ class MfaEnrollmentFlowState internal constructor(
  * with. Called once, above the `NavDisplay`, so the same instance is handed to every step — see
  * [MfaEnrollmentFlowState] for which of its fields actually survive Activity recreation.
  */
+/**
+ * The country the SMS step opens on: the device's own when [allowedCountries] permits it, else the
+ * first permitted one — so a restricted configuration cannot open pre-set to a country its own
+ * selector will not offer.
+ */
+internal fun initialEnrollmentCountry(allowedCountries: List<String>?): CountryData {
+    val deviceCountry = CountryUtils.getDefaultCountry()
+    if (allowedCountries.isNullOrEmpty()) return deviceCountry
+    val permitted = CountryUtils.filterByAllowedCountries(allowedCountries.toSet())
+    return permitted.firstOrNull { it.countryCode == deviceCountry.countryCode }
+        ?: permitted.firstOrNull()
+        ?: deviceCountry
+}
+
 @Composable
-fun rememberMfaEnrollmentFlowState(): MfaEnrollmentFlowState {
+fun rememberMfaEnrollmentFlowState(
+    allowedCountries: List<String>? = null,
+): MfaEnrollmentFlowState {
+    val initialCountry = remember(allowedCountries) { initialEnrollmentCountry(allowedCountries) }
     val selectedFactor = rememberSaveable { mutableStateOf<MfaFactor?>(null) }
     val phoneNumber = rememberSaveable { mutableStateOf("") }
     val verificationCode = rememberSaveable { mutableStateOf("") }
@@ -129,10 +147,10 @@ fun rememberMfaEnrollmentFlowState(): MfaEnrollmentFlowState {
     val totpSecret = remember { mutableStateOf<TotpSecret?>(null) }
     val totpQrCodeUrl = remember { mutableStateOf<String?>(null) }
     val selectedCountry = rememberSaveable(stateSaver = CountryDataSaver) {
-        mutableStateOf(CountryUtils.getDefaultCountry())
+        mutableStateOf(initialCountry)
     }
     val totpSecretExpiredMessage = remember { mutableStateOf<String?>(null) }
-    return remember {
+    return remember(initialCountry) {
         MfaEnrollmentFlowState(
             selectedFactor = selectedFactor,
             phoneNumber = phoneNumber,
@@ -143,6 +161,7 @@ fun rememberMfaEnrollmentFlowState(): MfaEnrollmentFlowState {
             totpQrCodeUrl = totpQrCodeUrl,
             selectedCountry = selectedCountry,
             totpSecretExpiredMessage = totpSecretExpiredMessage,
+            initialCountry = initialCountry,
         )
     }
 }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentScreen.kt
@@ -30,6 +30,7 @@ import com.firebase.ui.auth.mfa.MfaEnrollmentContentState
 import com.firebase.ui.auth.mfa.MfaEnrollmentStep
 import com.firebase.ui.auth.mfa.SmsEnrollmentHandler
 import com.firebase.ui.auth.mfa.TotpEnrollmentHandler
+import com.firebase.ui.auth.util.CountryUtils
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import kotlinx.coroutines.delay
@@ -218,6 +219,22 @@ internal fun MfaEnrollmentScreenInternal(
                 }
             }
             MfaEnrollmentStep.SelectFactor -> Unit
+        }
+    }
+
+    // Snapped here rather than only where the flow state is created, because the selected country
+    // has two other ways of holding a value this configuration does not permit: a host driving
+    // this screen supplies `flowState` itself and may never have passed the list to
+    // `rememberMfaEnrollmentFlowState`, and a `rememberSaveable` restore can bring back a country
+    // allowed by an earlier configuration. Without this, the selector filters the list while the
+    // send still uses the unpermitted dial code.
+    LaunchedEffect(configuration.allowedCountries) {
+        val permitted = configuration.allowedCountries
+        if (!permitted.isNullOrEmpty() &&
+            CountryUtils.filterByAllowedCountries(permitted.toSet())
+                .none { it.countryCode == selectedCountry.value.countryCode }
+        ) {
+            selectedCountry.value = initialEnrollmentCountry(permitted)
         }
     }
 

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentScreen.kt
@@ -157,7 +157,10 @@ internal fun MfaEnrollmentScreenInternal(
     val lastException = remember { mutableStateOf<Exception?>(null) }
     val enrolledFactors = remember { mutableStateOf(user.multiFactor.enrolledFactors) }
 
-    val phoneAuthConfiguration = remember(authConfiguration, applicationContext) {
+    // The SMS steps read only the terms and privacy URLs off this, so a host that supplied no
+    // configuration gets a stand-in. Its provider is arbitrary — a configuration must declare at
+    // least one — and nothing reads it: the country restriction comes from [MfaConfiguration].
+    val stepConfiguration = remember(authConfiguration, applicationContext) {
         authConfiguration ?: authUIConfiguration {
             context = applicationContext
             providers {
@@ -277,6 +280,7 @@ internal fun MfaEnrollmentScreenInternal(
             error.value = null
         },
         selectedCountry = selectedCountry.value,
+        allowedCountries = configuration.allowedCountries,
         onCountrySelected = { country ->
             selectedCountry.value = country
         },
@@ -388,7 +392,7 @@ internal fun MfaEnrollmentScreenInternal(
     } else {
         DefaultMfaEnrollmentContent(
             state = state,
-            authConfiguration = phoneAuthConfiguration,
+            authConfiguration = stepConfiguration,
             user = user
         )
     }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/EnterPhoneNumberUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/EnterPhoneNumberUI.kt
@@ -65,6 +65,8 @@ import com.firebase.ui.auth.util.CountryUtils
  * because MFA enrollment reaches this step on configurations that declare no phone provider —
  * it restricts countries through
  * [com.firebase.ui.auth.configuration.MfaConfiguration.allowedCountries] instead.
+ * Deliberately has no default: a host that upgrades has to decide, rather than silently losing
+ * the restriction it used to get from [configuration].
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -74,10 +76,10 @@ fun EnterPhoneNumberUI(
     isLoading: Boolean,
     phoneNumber: String,
     selectedCountry: CountryData,
+    allowedCountries: Set<String>?,
     onPhoneNumberChange: (String) -> Unit,
     onCountrySelected: (CountryData) -> Unit,
     onSendCodeClick: () -> Unit,
-    allowedCountries: Set<String>? = null,
     title: String? = null,
     onNavigateBack: (() -> Unit)? = null,
 ) {
@@ -205,6 +207,7 @@ fun PreviewEnterPhoneNumberUI() {
             isLoading = false,
             phoneNumber = "",
             selectedCountry = CountryUtils.getDefaultCountry(),
+            allowedCountries = null,
             onPhoneNumberChange = {},
             onCountrySelected = {},
             onSendCodeClick = {},

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/EnterPhoneNumberUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/EnterPhoneNumberUI.kt
@@ -57,6 +57,15 @@ import com.firebase.ui.auth.ui.components.TermsAndPrivacyForm
 import com.firebase.ui.auth.ui.exposeTestTagsAsResourceIds
 import com.firebase.ui.auth.util.CountryUtils
 
+/**
+ * The phone number entry step, shared by phone sign-in and SMS multi-factor enrollment.
+ *
+ * @param allowedCountries Country codes the selector is restricted to, or `null` for no
+ * restriction. Supplied by the caller rather than read off [configuration]'s phone provider,
+ * because MFA enrollment reaches this step on configurations that declare no phone provider —
+ * it restricts countries through
+ * [com.firebase.ui.auth.configuration.MfaConfiguration.allowedCountries] instead.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EnterPhoneNumberUI(
@@ -68,11 +77,11 @@ fun EnterPhoneNumberUI(
     onPhoneNumberChange: (String) -> Unit,
     onCountrySelected: (CountryData) -> Unit,
     onSendCodeClick: () -> Unit,
+    allowedCountries: Set<String>? = null,
     title: String? = null,
     onNavigateBack: (() -> Unit)? = null,
 ) {
     val context = LocalContext.current
-    val provider = configuration.providers.filterIsInstance<AuthProvider.Phone>().firstOrNull()
     val stringProvider = LocalAuthUIStringProvider.current
     val phoneNumberValidator = remember(selectedCountry) {
         PhoneNumberValidator(stringProvider, selectedCountry)
@@ -134,7 +143,7 @@ fun EnterPhoneNumberUI(
                         selectedCountry = selectedCountry,
                         onCountrySelected = onCountrySelected,
                         enabled = !isLoading,
-                        allowedCountries = provider?.allowedCountries?.toSet()
+                        allowedCountries = allowedCountries
                     )
                 },
                 onValueChange = {

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/EnterPhoneNumberUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/EnterPhoneNumberUI.kt
@@ -72,7 +72,7 @@ fun EnterPhoneNumberUI(
     onNavigateBack: (() -> Unit)? = null,
 ) {
     val context = LocalContext.current
-    val provider = configuration.providers.filterIsInstance<AuthProvider.Phone>().first()
+    val provider = configuration.providers.filterIsInstance<AuthProvider.Phone>().firstOrNull()
     val stringProvider = LocalAuthUIStringProvider.current
     val phoneNumberValidator = remember(selectedCountry) {
         PhoneNumberValidator(stringProvider, selectedCountry)
@@ -134,7 +134,7 @@ fun EnterPhoneNumberUI(
                         selectedCountry = selectedCountry,
                         onCountrySelected = onCountrySelected,
                         enabled = !isLoading,
-                        allowedCountries = provider.allowedCountries?.toSet()
+                        allowedCountries = provider?.allowedCountries?.toSet()
                     )
                 },
                 onValueChange = {

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreen.kt
@@ -517,6 +517,14 @@ private fun DefaultPhoneAuthContent(
     state: PhoneAuthContentState,
     onCancel: () -> Unit,
 ) {
+    // Keyed on the extracted list rather than on `configuration`, which is a plain class with no
+    // equals and is commonly rebuilt inside composition — keying on it would re-run every pass.
+    val allowedCountries = configuration.providers
+        .filterIsInstance<AuthProvider.Phone>()
+        .firstOrNull()
+        ?.allowedCountries
+    val allowedCountrySet = remember(allowedCountries) { allowedCountries?.toSet() }
+
     when (state.step) {
         PhoneAuthStep.EnterPhoneNumber -> {
             EnterPhoneNumberUI(
@@ -527,11 +535,7 @@ private fun DefaultPhoneAuthContent(
                 onPhoneNumberChange = state.onPhoneNumberChange,
                 onCountrySelected = state.onCountrySelected,
                 onSendCodeClick = state.onSendCodeClick,
-                allowedCountries = configuration.providers
-                    .filterIsInstance<AuthProvider.Phone>()
-                    .firstOrNull()
-                    ?.allowedCountries
-                    ?.toSet(),
+                allowedCountries = allowedCountrySet,
                 onNavigateBack = onCancel
             )
         }

--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreen.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthScreen.kt
@@ -527,6 +527,11 @@ private fun DefaultPhoneAuthContent(
                 onPhoneNumberChange = state.onPhoneNumberChange,
                 onCountrySelected = state.onCountrySelected,
                 onSendCodeClick = state.onSendCodeClick,
+                allowedCountries = configuration.providers
+                    .filterIsInstance<AuthProvider.Phone>()
+                    .firstOrNull()
+                    ?.allowedCountries
+                    ?.toSet(),
                 onNavigateBack = onCancel
             )
         }

--- a/auth/src/test/java/com/firebase/ui/auth/configuration/MfaConfigurationTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/configuration/MfaConfigurationTest.kt
@@ -15,6 +15,7 @@
 package com.firebase.ui.auth.configuration
 
 import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -140,6 +141,46 @@ class MfaConfigurationTest {
     // =============================================================================================
     // MfaFactor Enum Tests
     // =============================================================================================
+
+    // =============================================================================================
+    // allowedCountries validation
+    // =============================================================================================
+
+    @Test
+    fun `allowedCountries accepts alpha-2 codes in either case`() {
+        val config = MfaConfiguration(allowedCountries = listOf("gb", "US"))
+
+        assertThat(config.allowedCountries).containsExactly("gb", "US")
+    }
+
+    /**
+     * A dial code is the trap this validation exists for: `AuthProvider.Phone` accepts one, but
+     * the filter behind `allowedCountries` matches alpha-2 only, so accepting it here would
+     * silently restrict the selector to nothing instead of failing.
+     */
+    @Test
+    fun `allowedCountries rejects a dial code`() {
+        val failure = assertThrows(IllegalArgumentException::class.java) {
+            MfaConfiguration(allowedCountries = listOf("+44"))
+        }
+
+        assertThat(failure).hasMessageThat().contains("+44")
+        assertThat(failure).hasMessageThat().contains("alpha-2")
+    }
+
+    @Test
+    fun `allowedCountries rejects an unknown code`() {
+        val failure = assertThrows(IllegalArgumentException::class.java) {
+            MfaConfiguration(allowedCountries = listOf("GB", "USA"))
+        }
+
+        assertThat(failure).hasMessageThat().contains("USA")
+    }
+
+    @Test
+    fun `allowedCountries defaults to null and stays unvalidated when absent`() {
+        assertThat(MfaConfiguration().allowedCountries).isNull()
+    }
 
     @Test
     fun `MfaFactor enum has exactly two values`() {

--- a/auth/src/test/java/com/firebase/ui/auth/configuration/MfaConfigurationTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/configuration/MfaConfigurationTest.kt
@@ -40,6 +40,7 @@ class MfaConfigurationTest {
 
         assertThat(config.allowedFactors).containsExactly(MfaFactor.Sms, MfaFactor.Totp)
         assertThat(config.requireEnrollment).isFalse()
+        assertThat(config.allowedCountries).isNull()
     }
 
     @Test
@@ -93,6 +94,15 @@ class MfaConfigurationTest {
 
         assertThat(config.allowedFactors).containsExactly(MfaFactor.Sms)
         assertThat(config.requireEnrollment).isTrue()
+    }
+
+    @Test
+    fun `MfaConfiguration with custom allowedCountries`() {
+        val config = MfaConfiguration(
+            allowedCountries = listOf("GB", "DE")
+        )
+
+        assertThat(config.allowedCountries).containsExactly("GB", "DE")
     }
 
     // =============================================================================================

--- a/auth/src/test/java/com/firebase/ui/auth/ui/TestTagsAsResourceIdsTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/TestTagsAsResourceIdsTest.kt
@@ -441,6 +441,7 @@ class TestTagsAsResourceIdsTest {
                 isLoading = false,
                 phoneNumber = "",
                 selectedCountry = CountryUtils.getDefaultCountry(),
+                allowedCountries = null,
                 onPhoneNumberChange = { },
                 onCountrySelected = { },
                 onSendCodeClick = { },

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/mfa/InitialEnrollmentCountryTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/mfa/InitialEnrollmentCountryTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens.mfa
+
+import com.firebase.ui.auth.util.CountryUtils
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.Locale
+
+/**
+ * The country the SMS enrollment step opens on. Asserts on the resolved **dial code**, not just
+ * membership of the selector's list: the picker being filtered is not what a restriction is for
+ * if the number the step sends to still carries an unpermitted prefix.
+ *
+ * @suppress Internal test class
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class InitialEnrollmentCountryTest {
+
+    @Test
+    fun `keeps the device country when the restriction permits it`() {
+        withLocaleCountry("GB") {
+            val country = initialEnrollmentCountry(listOf("GB", "IE"))
+
+            assertThat(country.countryCode).isEqualTo("GB")
+            assertThat(country.dialCode).isEqualTo("+44")
+        }
+    }
+
+    /** The mismatch this exists for: a permitted list that does not contain the device country. */
+    @Test
+    fun `falls back to a permitted country when the device country is not allowed`() {
+        withLocaleCountry("US") {
+            val country = initialEnrollmentCountry(listOf("GB"))
+
+            assertThat(country.countryCode).isEqualTo("GB")
+            assertThat(country.dialCode).isEqualTo("+44")
+            assertThat(country.dialCode).isNotEqualTo(CountryUtils.findByCountryCode("US")!!.dialCode)
+        }
+    }
+
+    @Test
+    fun `resolved dial code always belongs to a permitted country`() {
+        val permitted = listOf("GB", "IE", "FR")
+        withLocaleCountry("US") {
+            val country = initialEnrollmentCountry(permitted)
+
+            val permittedDialCodes = permitted.map { CountryUtils.findByCountryCode(it)!!.dialCode }
+            assertThat(permittedDialCodes).contains(country.dialCode)
+        }
+    }
+
+    @Test
+    fun `a null restriction leaves the device country alone`() {
+        withLocaleCountry("US") {
+            assertThat(initialEnrollmentCountry(null).countryCode).isEqualTo("US")
+        }
+    }
+
+    /** `filterByAllowedCountries` treats empty as "no restriction", so this must not narrow. */
+    @Test
+    fun `an empty restriction leaves the device country alone`() {
+        withLocaleCountry("US") {
+            assertThat(initialEnrollmentCountry(emptyList()).countryCode).isEqualTo("US")
+        }
+    }
+
+    /**
+     * `MfaConfiguration` rejects codes that resolve to nothing, but this helper is also reachable
+     * from a host passing its own list, so it must not return a country outside the restriction
+     * and must not throw.
+     */
+    @Test
+    fun `an unresolvable restriction falls back to the device country rather than throwing`() {
+        withLocaleCountry("US") {
+            assertThat(initialEnrollmentCountry(listOf("ZZ")).countryCode).isEqualTo("US")
+        }
+    }
+
+    private fun withLocaleCountry(countryCode: String, block: () -> Unit) {
+        val original = Locale.getDefault()
+        Locale.setDefault(Locale.Builder().setLanguage("en").setRegion(countryCode).build())
+        try {
+            block()
+        } finally {
+            Locale.setDefault(original)
+        }
+    }
+}

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentCountryReconciliationTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentCountryReconciliationTest.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens.mfa
+
+import android.content.Context
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.core.app.ApplicationProvider
+import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.configuration.MfaConfiguration
+import com.firebase.ui.auth.configuration.MfaFactor
+import com.firebase.ui.auth.configuration.string_provider.DefaultAuthUIStringProvider
+import com.firebase.ui.auth.configuration.string_provider.LocalAuthUIStringProvider
+import com.firebase.ui.auth.mfa.MfaEnrollmentStep
+import com.firebase.ui.auth.util.CountryUtils
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.MultiFactor
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.Locale
+
+/**
+ * A host driving [MfaEnrollmentScreen] itself, the way the README's custom-navigation example
+ * does, with a `flowState` it built **without** passing the restriction.
+ *
+ * [MfaEnrollmentFlowState] seeds its country from the list handed to
+ * [rememberMfaEnrollmentFlowState], which [com.firebase.ui.auth.ui.screens.FirebaseAuthScreen]
+ * supplies. That left the restriction depending on a defaulted argument: a host that omitted it
+ * got a filtered selector and an unpermitted dial code on send. The screen reconciles the country
+ * on entry so omitting it cannot bring that back — the same reason a
+ * `rememberSaveable` restore of a country an earlier configuration allowed cannot either.
+ *
+ * @suppress Internal test class
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class MfaEnrollmentCountryReconciliationTest {
+
+    // The screen requires LocalActivity for SMS verification, so this needs a real Activity.
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Mock
+    private lateinit var mockAuth: FirebaseAuth
+
+    @Mock
+    private lateinit var mockUser: FirebaseUser
+
+    @Mock
+    private lateinit var mockMultiFactor: MultiFactor
+
+    private lateinit var applicationContext: Context
+    private lateinit var authUI: FirebaseAuthUI
+    private lateinit var originalLocale: Locale
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        applicationContext = ApplicationProvider.getApplicationContext()
+        originalLocale = Locale.getDefault()
+        // The device country the restriction below does not permit.
+        Locale.setDefault(Locale.Builder().setLanguage("en").setRegion(DEVICE_COUNTRY).build())
+
+        FirebaseAuthUI.clearInstanceCache()
+        FirebaseApp.getApps(applicationContext).forEach { it.delete() }
+        val app = FirebaseApp.initializeApp(
+            applicationContext,
+            FirebaseOptions.Builder()
+                .setApiKey("fake-api-key")
+                .setApplicationId("fake-app-id")
+                .setProjectId("fake-project-id")
+                .build()
+        )
+        `when`(mockAuth.app).thenReturn(app)
+        `when`(mockAuth.currentUser).thenReturn(mockUser)
+        `when`(mockUser.uid).thenReturn("mfa-reconcile-user")
+        `when`(mockUser.email).thenReturn("user@example.com")
+        `when`(mockUser.isEmailVerified).thenReturn(true)
+        `when`(mockUser.multiFactor).thenReturn(mockMultiFactor)
+        `when`(mockMultiFactor.enrolledFactors).thenReturn(emptyList())
+        authUI = FirebaseAuthUI.create(app, mockAuth)
+    }
+
+    @After
+    fun tearDown() {
+        Locale.setDefault(originalLocale)
+        FirebaseAuthUI.clearInstanceCache()
+        FirebaseApp.getApps(applicationContext).forEach {
+            try {
+                it.delete()
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    /**
+     * The dial code is the assertion, not the selector's list: a filtered picker beside an
+     * unpermitted prefix is the exact mismatch this closes.
+     */
+    @Test
+    fun `entering the SMS step snaps an unpermitted country into the allowed set`() {
+        val flowState = hostScreenWithUnpassedRestriction()
+
+        assertThat(flowState.selectedCountry.value.countryCode).isEqualTo(ALLOWED_COUNTRY)
+        assertThat(flowState.selectedCountry.value.dialCode)
+            .isEqualTo(CountryUtils.findByCountryCode(ALLOWED_COUNTRY)!!.dialCode)
+        assertThat(flowState.selectedCountry.value.dialCode)
+            .isNotEqualTo(CountryUtils.findByCountryCode(DEVICE_COUNTRY)!!.dialCode)
+    }
+
+    /** An unrestricted configuration must not move the device country. */
+    @Test
+    fun `entering the SMS step leaves the country alone when unrestricted`() {
+        val flowState = hostScreenWithUnpassedRestriction(allowedCountries = null)
+
+        assertThat(flowState.selectedCountry.value.countryCode).isEqualTo(DEVICE_COUNTRY)
+    }
+
+    /**
+     * Hosts the step with a `flowState` built the way a host that never passed the restriction
+     * would build it, so the seeding in [rememberMfaEnrollmentFlowState] cannot be what passes
+     * this.
+     */
+    private fun hostScreenWithUnpassedRestriction(
+        allowedCountries: List<String>? = listOf(ALLOWED_COUNTRY),
+    ): MfaEnrollmentFlowState {
+        lateinit var captured: MfaEnrollmentFlowState
+        val step = mutableStateOf(MfaEnrollmentStep.ConfigureSms)
+
+        composeTestRule.setContent {
+            val flowState = rememberMfaEnrollmentFlowState()
+            captured = flowState
+            CompositionLocalProvider(
+                LocalAuthUIStringProvider provides DefaultAuthUIStringProvider(applicationContext)
+            ) {
+                MfaEnrollmentScreen(
+                    user = mockUser,
+                    auth = authUI.auth,
+                    configuration = MfaConfiguration(
+                        allowedFactors = listOf(MfaFactor.Sms),
+                        allowedCountries = allowedCountries,
+                    ),
+                    onComplete = {},
+                    step = step.value,
+                    onNavigateToStep = { step.value = it },
+                    onNavigateBack = {},
+                    flowState = flowState,
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+        return captured
+    }
+
+    private companion object {
+        const val DEVICE_COUNTRY = "US"
+        const val ALLOWED_COUNTRY = "GB"
+    }
+}

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentSmsStepTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentSmsStepTest.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import com.firebase.ui.auth.AuthState
 import com.firebase.ui.auth.FirebaseAuthUI
@@ -36,6 +38,7 @@ import com.firebase.ui.auth.configuration.authUIConfiguration
 import com.firebase.ui.auth.ui.FirebaseAuthTestTags
 import com.firebase.ui.auth.ui.screens.AuthSuccessUiContext
 import com.firebase.ui.auth.ui.screens.FirebaseAuthScreen
+import com.firebase.ui.auth.util.CountryUtils
 import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
 import com.google.firebase.auth.FirebaseAuth
@@ -60,7 +63,8 @@ import org.robolectric.annotation.Config
  * hosting [AuthUIConfiguration]'s phone provider and crashing on a configuration that declares
  * none. SMS is a second factor, configured independently of phone sign-in: Firebase enables it
  * separately, and phone sign-in cannot carry a second factor at all — so an email-only
- * configuration is the ordinary case, not an edge case.
+ * configuration is the ordinary case, not an edge case. The country restriction the step needs
+ * comes from [MfaConfiguration.allowedCountries] instead.
  *
  * @suppress Internal test class
  */
@@ -133,6 +137,28 @@ class MfaEnrollmentSmsStepTest {
             .assertIsDisplayed()
     }
 
+    @Test
+    fun `country selector offers only the countries MfaConfiguration allows`() {
+        enterSmsEnrollment(
+            MfaConfiguration(
+                allowedFactors = listOf(MfaFactor.Sms),
+                allowedCountries = listOf(ALLOWED_COUNTRY_CODE)
+            )
+        )
+
+        composeTestRule
+            .onNodeWithTag(FirebaseAuthTestTags.PhoneNumber.COUNTRY_SELECTOR_BUTTON)
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule
+            .onNodeWithTag(FirebaseAuthTestTags.CountrySelector.COUNTRY_LIST)
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText(countryName(ALLOWED_COUNTRY_CODE)).assertIsDisplayed()
+        // First entry of the unrestricted list, so its absence cannot be a scroll position.
+        composeTestRule.onNodeWithText(FIRST_UNRESTRICTED_COUNTRY_NAME).assertDoesNotExist()
+    }
+
     /**
      * Renders the real screen with the default MFA content, signs in, then enters enrolment
      * through the callback the "Manage MFA" control uses. A single allowed factor starts the flow
@@ -167,6 +193,11 @@ class MfaEnrollmentSmsStepTest {
         composeTestRule.waitForIdle()
     }
 
+    private fun countryName(countryCode: String): String =
+        requireNotNull(CountryUtils.findByCountryCode(countryCode)) {
+            "No country data for $countryCode"
+        }.name
+
     private fun emailOnlyConfiguration(): AuthUIConfiguration = authUIConfiguration {
         context = applicationContext
         providers {
@@ -190,5 +221,9 @@ class MfaEnrollmentSmsStepTest {
 
     private companion object {
         const val AUTHENTICATED_TAG = "authenticated-destination"
+        const val ALLOWED_COUNTRY_CODE = "GB"
+
+        /** First entry of `ALL_COUNTRIES`, so an unrestricted list always renders it. */
+        const val FIRST_UNRESTRICTED_COUNTRY_NAME = "Afghanistan"
     }
 }

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentSmsStepTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/mfa/MfaEnrollmentSmsStepTest.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens.mfa
+
+import android.content.Context
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.togetherWith
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.core.app.ApplicationProvider
+import com.firebase.ui.auth.AuthState
+import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.configuration.AuthUIConfiguration
+import com.firebase.ui.auth.configuration.AuthUITransitions
+import com.firebase.ui.auth.configuration.MfaConfiguration
+import com.firebase.ui.auth.configuration.MfaFactor
+import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.configuration.authUIConfiguration
+import com.firebase.ui.auth.ui.FirebaseAuthTestTags
+import com.firebase.ui.auth.ui.screens.AuthSuccessUiContext
+import com.firebase.ui.auth.ui.screens.FirebaseAuthScreen
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.MultiFactor
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The SMS enrolment step rendered by the **default** MFA content, rather than through a
+ * `mfaEnrollmentContent` slot.
+ *
+ * Every other enrolment test supplies that slot, which is why nothing caught the step reading the
+ * hosting [AuthUIConfiguration]'s phone provider and crashing on a configuration that declares
+ * none. SMS is a second factor, configured independently of phone sign-in: Firebase enables it
+ * separately, and phone sign-in cannot carry a second factor at all — so an email-only
+ * configuration is the ordinary case, not an edge case.
+ *
+ * @suppress Internal test class
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class MfaEnrollmentSmsStepTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Mock
+    private lateinit var mockAuth: FirebaseAuth
+
+    @Mock
+    private lateinit var mockUser: FirebaseUser
+
+    @Mock
+    private lateinit var mockMultiFactor: MultiFactor
+
+    private lateinit var applicationContext: Context
+    private lateinit var authUI: FirebaseAuthUI
+
+    private var uiContext: AuthSuccessUiContext? = null
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        applicationContext = ApplicationProvider.getApplicationContext()
+        FirebaseAuthUI.clearInstanceCache()
+        FirebaseApp.getApps(applicationContext).forEach { it.delete() }
+        val app = FirebaseApp.initializeApp(
+            applicationContext,
+            FirebaseOptions.Builder()
+                .setApiKey("fake-api-key")
+                .setApplicationId("fake-app-id")
+                .setProjectId("fake-project-id")
+                .build()
+        )
+        `when`(mockAuth.app).thenReturn(app)
+        `when`(mockAuth.currentUser).thenReturn(mockUser)
+        `when`(mockUser.uid).thenReturn("mfa-sms-step-user")
+        `when`(mockUser.email).thenReturn("user@example.com")
+        `when`(mockUser.isEmailVerified).thenReturn(true)
+        `when`(mockUser.multiFactor).thenReturn(mockMultiFactor)
+        `when`(mockMultiFactor.enrolledFactors).thenReturn(emptyList())
+        authUI = FirebaseAuthUI.create(app, mockAuth)
+    }
+
+    @After
+    fun tearDown() {
+        uiContext = null
+        FirebaseAuthUI.clearInstanceCache()
+        FirebaseApp.getApps(applicationContext).forEach {
+            try {
+                it.delete()
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    @Test
+    fun `SMS step renders on a configuration that declares no phone provider`() {
+        enterSmsEnrollment(MfaConfiguration(allowedFactors = listOf(MfaFactor.Sms)))
+
+        composeTestRule
+            .onNodeWithTag(FirebaseAuthTestTags.PhoneNumber.PHONE_NUMBER_FIELD)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(FirebaseAuthTestTags.PhoneNumber.SEND_CODE_BUTTON)
+            .assertIsDisplayed()
+    }
+
+    /**
+     * Renders the real screen with the default MFA content, signs in, then enters enrolment
+     * through the callback the "Manage MFA" control uses. A single allowed factor starts the flow
+     * on that factor's configuration step, so this lands directly on SMS.
+     */
+    private fun enterSmsEnrollment(mfaConfiguration: MfaConfiguration) {
+        composeTestRule.setContent {
+            FirebaseAuthScreen(
+                configuration = emailOnlyConfiguration(),
+                authUI = authUI,
+                onSignInSuccess = {},
+                onSignInFailure = {},
+                onSignInCancelled = {},
+                mfaConfiguration = mfaConfiguration,
+                authenticatedContent = { _, context ->
+                    uiContext = context
+                    Text(text = "authenticated", modifier = Modifier.testTag(AUTHENTICATED_TAG))
+                },
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            authUI.updateAuthState(
+                AuthState.Success(result = null, user = mockUser, isNewUser = false)
+            )
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(AUTHENTICATED_TAG).assertIsDisplayed()
+
+        composeTestRule.runOnIdle { requireNotNull(uiContext).onManageMfa() }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun emailOnlyConfiguration(): AuthUIConfiguration = authUIConfiguration {
+        context = applicationContext
+        providers {
+            provider(
+                AuthProvider.Email(
+                    emailLinkActionCodeSettings = null,
+                    passwordValidationRules = emptyList()
+                )
+            )
+        }
+        isCredentialManagerEnabled = false
+        // The default fades would keep the destination being left composed alongside its successor.
+        transitions = AuthUITransitions(
+            transitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+            popTransitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+            predictivePopTransitionSpec = {
+                EnterTransition.None togetherWith ExitTransition.None
+            },
+        )
+    }
+
+    private companion object {
+        const val AUTHENTICATED_TAG = "authenticated-destination"
+    }
+}

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthHostDestinationsTest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/phone/PhoneAuthHostDestinationsTest.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -65,6 +66,7 @@ import com.firebase.ui.auth.ui.screens.popOrNull
 import com.firebase.ui.auth.ui.screens.reauth.ReauthSceneStrategy
 import com.firebase.ui.auth.ui.screens.reauth.reauthDestinations
 import com.firebase.ui.auth.ui.screens.reauth.toReauthSurface
+import com.firebase.ui.auth.util.CountryUtils
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
@@ -447,19 +449,45 @@ class PhoneAuthHostDestinationsTest {
      * is the entry underneath the phone flow and "left the flow" is distinguishable from "stepped
      * back inside it".
      */
-    private fun start() {
-        composeTestRule.setContent { Host() }
+    /**
+     * The country restriction reaches the step through the host, not through the step reading the
+     * configuration itself. Nothing else asserts this: every other `allowedCountries` in either
+     * suite is null, so deleting the host's lookup left both suites green.
+     */
+    @Test
+    fun `country selector offers only the countries the phone provider allows`() {
+        start(restrictedPhoneConfiguration())
+        enterPhoneFlow()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.PhoneNumber.COUNTRY_SELECTOR_BUTTON)
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.CountrySelector.COUNTRY_LIST)
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText(countryName(ALLOWED_COUNTRY_CODE)).assertIsDisplayed()
+        // ALL_COUNTRIES[0]; on screen only if the restriction was dropped.
+        composeTestRule.onAllNodesWithText(FIRST_UNRESTRICTED_COUNTRY_NAME).assertCountEquals(0)
+    }
+
+    private fun countryName(countryCode: String): String =
+        requireNotNull(CountryUtils.findByCountryCode(countryCode)) {
+            "No country data for $countryCode"
+        }.name
+
+    private fun start(configuration: AuthUIConfiguration = emailAndPhoneConfiguration()) {
+        composeTestRule.setContent { Host(configuration) }
         composeTestRule.waitForIdle()
     }
 
     @Composable
-    private fun Host() {
+    private fun Host(configuration: AuthUIConfiguration = emailAndPhoneConfiguration()) {
         val dispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
         SideEffect { pressBack = dispatcher?.let { { it.onBackPressed() } } }
         LaunchedEffect(authUI) { authUI.authStateFlow().collect { observedStates += it } }
 
         FirebaseAuthScreen(
-            configuration = emailAndPhoneConfiguration(),
+            configuration = configuration,
             authUI = authUI,
             onSignInSuccess = {},
             onSignInFailure = {},
@@ -734,6 +762,31 @@ class PhoneAuthHostDestinationsTest {
         )
     }
 
+    /**
+     * As [emailAndPhoneConfiguration], but with the phone provider restricting its countries — the
+     * setting `EnterPhoneNumberUI` no longer reads off the configuration itself.
+     */
+    private fun restrictedPhoneConfiguration(): AuthUIConfiguration = authUIConfiguration {
+        context = applicationContext
+        providers {
+            provider(
+                AuthProvider.Email(
+                    emailLinkActionCodeSettings = null,
+                    passwordValidationRules = emptyList()
+                )
+            )
+            provider(
+                AuthProvider.Phone(
+                    defaultNumber = null,
+                    defaultCountryCode = "US",
+                    allowedCountries = listOf(ALLOWED_COUNTRY_CODE),
+                    timeout = 0L,
+                )
+            )
+        }
+        isCredentialManagerEnabled = false
+    }
+
     /** Phone alone, so the surface's own start step is the phone flow's rather than the picker. */
     private fun phoneReauthConfiguration(): AuthUIConfiguration = authUIConfiguration {
         context = applicationContext
@@ -765,5 +818,9 @@ class PhoneAuthHostDestinationsTest {
         const val FULL_PHONE_NUMBER = "+15555550123"
         const val REQUEST_ID = "reauth-request-id"
         const val REAUTH_UID = "reauth-uid"
+        const val ALLOWED_COUNTRY_CODE = "GB"
+
+        /** First entry of `ALL_COUNTRIES`, so an unrestricted list always renders it. */
+        const val FIRST_UNRESTRICTED_COUNTRY_NAME = "Afghanistan"
     }
 }

--- a/e2eTest/src/test/java/com/firebase/ui/auth/testutil/TestHelpers.kt
+++ b/e2eTest/src/test/java/com/firebase/ui/auth/testutil/TestHelpers.kt
@@ -1,10 +1,18 @@
 package com.firebase.ui.auth.testutil
 
+import android.app.Activity
 import android.os.Looper
 import android.util.Base64
 import com.firebase.ui.auth.FirebaseAuthUI
+import com.google.android.gms.tasks.TaskCompletionSource
+import com.google.firebase.FirebaseException
 import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.PhoneAuthCredential
+import com.google.firebase.auth.PhoneAuthOptions
+import com.google.firebase.auth.PhoneAuthProvider
+import com.google.firebase.auth.PhoneMultiFactorGenerator
 import org.robolectric.Shadows.shadowOf
+import java.util.concurrent.TimeUnit
 
 /**
  * Ensures a fresh user exists in the Firebase emulator with the given credentials.
@@ -100,6 +108,78 @@ fun verifyEmailInEmulator(authUI: FirebaseAuthUI, emulatorApi: EmulatorAuthApi, 
     println("TEST: Email verified successfully for user ${user.uid}")
     println("TEST: User isEmailVerified: ${authUI.auth.currentUser?.isEmailVerified}")
 }
+
+/**
+ * Enrolls [user] in SMS multi-factor authentication, so a test can start from an account that is
+ * challenged for a second factor at sign-in.
+ *
+ * Takes the same three steps [com.firebase.ui.auth.mfa.SmsEnrollmentHandler] does — open a
+ * multi-factor session, verify a phone number against it, enroll the resulting assertion — but
+ * from Tasks this thread can pump with [awaitWithLooper], rather than the handler's suspend
+ * functions, whose callbacks arrive on the paused main looper a `runBlocking` here would occupy.
+ *
+ * The emulator rejects enrollment for a user whose email is unverified (`UNVERIFIED_EMAIL`), so
+ * pair this with [verifyEmailInEmulator], and for an anonymous, phone or custom-token first factor
+ * (`UNSUPPORTED_FIRST_FACTOR`).
+ *
+ * @param phoneNumber The second factor's number in E.164 format (e.g. "+15551234567")
+ */
+fun enrollSmsFactorInEmulator(
+    activity: Activity,
+    authUI: FirebaseAuthUI,
+    emulatorApi: EmulatorAuthApi,
+    user: FirebaseUser,
+    phoneNumber: String,
+) {
+    println("TEST: Enrolling SMS factor $phoneNumber for user ${user.uid}")
+    val session = user.multiFactor.session.awaitWithLooper()
+
+    val verificationId = TaskCompletionSource<String>()
+    val options = PhoneAuthOptions.newBuilder(authUI.auth)
+        .setPhoneNumber(phoneNumber)
+        .setTimeout(SMS_VERIFICATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .setActivity(activity)
+        .setMultiFactorSession(session)
+        .setCallbacks(object : PhoneAuthProvider.OnVerificationStateChangedCallbacks() {
+            // The emulator always answers with a session to redeem a code against, so the
+            // instant-verification callback firing here means the setup no longer matches the
+            // flow it is standing in for.
+            override fun onVerificationCompleted(credential: PhoneAuthCredential) {
+                verificationId.trySetException(
+                    IllegalStateException(
+                        "Emulator auto-verified $phoneNumber instead of sending a code"
+                    )
+                )
+            }
+
+            override fun onVerificationFailed(e: FirebaseException) {
+                verificationId.trySetException(e)
+            }
+
+            override fun onCodeSent(
+                id: String,
+                token: PhoneAuthProvider.ForceResendingToken,
+            ) {
+                verificationId.trySetResult(id)
+            }
+        })
+        .build()
+    PhoneAuthProvider.verifyPhoneNumber(options)
+
+    // onCodeSent carries the emulator's response to the enrollment start, so by the time it lands
+    // the code is already readable — no polling needed.
+    val id = verificationId.task.awaitWithLooper()
+    val code = emulatorApi.fetchVerifyPhoneCode(phoneNumber)
+    println("TEST: Enrollment code for $phoneNumber is $code")
+
+    val credential = PhoneAuthProvider.getCredential(id, code)
+    user.multiFactor.enroll(PhoneMultiFactorGenerator.getAssertion(credential), "SMS")
+        .awaitWithLooper()
+    println("TEST: Enrolled factors: ${user.multiFactor.enrolledFactors.size}")
+}
+
+/** Matches [com.firebase.ui.auth.mfa.SmsEnrollmentHandler.VERIFICATION_TIMEOUT_SECONDS]. */
+private const val SMS_VERIFICATION_TIMEOUT_SECONDS = 60L
 
 fun generateMockGoogleIdToken(
     email: String,

--- a/e2eTest/src/test/java/com/firebase/ui/auth/testutil/TestHelpers.kt
+++ b/e2eTest/src/test/java/com/firebase/ui/auth/testutil/TestHelpers.kt
@@ -119,7 +119,8 @@ fun verifyEmailInEmulator(authUI: FirebaseAuthUI, emulatorApi: EmulatorAuthApi, 
  * functions, whose callbacks arrive on the paused main looper a `runBlocking` here would occupy.
  *
  * The emulator rejects enrollment for a user whose email is unverified (`UNVERIFIED_EMAIL`), so
- * pair this with [verifyEmailInEmulator], and for an anonymous, phone or custom-token first factor
+ * pair this with [verifyEmailInEmulator], and for an anonymous, phone, custom-token or Game
+ * Center first factor
  * (`UNSUPPORTED_FIRST_FACTOR`).
  *
  * @param phoneNumber The second factor's number in E.164 format (e.g. "+15551234567")

--- a/e2eTest/src/test/java/com/firebase/ui/auth/ui/AccessibilityTest.kt
+++ b/e2eTest/src/test/java/com/firebase/ui/auth/ui/AccessibilityTest.kt
@@ -273,6 +273,7 @@ class AccessibilityTest {
                     isLoading = false,
                     phoneNumber = "",
                     selectedCountry = CountryUtils.getDefaultCountry(),
+                    allowedCountries = null,
                     onPhoneNumberChange = {},
                     onCountrySelected = {},
                     onSendCodeClick = {}

--- a/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/MfaChallengeScreenTest.kt
+++ b/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/MfaChallengeScreenTest.kt
@@ -55,12 +55,17 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /**
- * E2E tests for [MfaChallengeScreen].
+ * E2E tests for [MfaChallengeScreen]'s presentation of a challenge — masked number rendering,
+ * resend availability per factor, 6-digit gating — driven against a mocked [MultiFactorResolver]
+ * so each factor's variant can be composed on demand, TOTP included.
  *
- * These tests verify the MFA challenge flow including UI interactions and state transitions.
+ * **These tests deliberately complete no sign-in.** The real SMS challenge happy path, driven
+ * through [com.firebase.ui.auth.ui.screens.FirebaseAuthScreen] against the emulator and asserted
+ * on [com.firebase.ui.auth.AuthState.Success], lives in [MfaSmsFlowTest]; add SMS coverage there
+ * rather than here.
  *
- * Note: Firebase Auth Emulator has limited MFA support, so these tests use mocked
- * MultiFactorResolver to test the UI flow.
+ * The emulator supports SMS MFA in full and does not implement TOTP at all —
+ * [MfaEnrollmentScreenTest] carries the details and the exact TOTP failure.
  */
 @Config(sdk = [34])
 @RunWith(RobolectricTestRunner::class)

--- a/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/MfaEnrollmentScreenTest.kt
+++ b/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/MfaEnrollmentScreenTest.kt
@@ -72,7 +72,8 @@ import org.robolectric.annotation.Config
  *   `mfaSignIn:start`/`:finalize`, and publishes both flows' codes on the same
  *   `verificationCodes` endpoint [com.firebase.ui.auth.testutil.EmulatorAuthApi.fetchVerifyPhoneCode]
  *   already reads for phone auth. It enforces two preconditions: the user's email must be verified
- *   (`UNVERIFIED_EMAIL`), and anonymous, phone and custom-token first factors are rejected
+ *   (`UNVERIFIED_EMAIL`), and anonymous, phone, custom-token and Game Center first factors
+ *   are rejected
  *   (`UNSUPPORTED_FIRST_FACTOR`).
  * - **TOTP does not work.** The emulator's `mfaEnrollment:start` accepts only `phoneEnrollmentInfo`,
  *   so enrollment fails on its very first call — `TotpMultiFactorGenerator.generateSecret` returns

--- a/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/MfaEnrollmentScreenTest.kt
+++ b/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/MfaEnrollmentScreenTest.kt
@@ -58,15 +58,28 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /**
- * E2E tests for [MfaEnrollmentScreen].
+ * E2E tests for [MfaEnrollmentScreen]'s own state machine — step transitions, factor selection and
+ * button enablement — driven against a mocked [FirebaseUser] so each can start on the step it is
+ * about.
  *
- * These tests verify the UI state management and transitions for the MFA enrollment flow.
+ * **These tests deliberately enroll nothing.** The real SMS enrollment happy path, driven through
+ * [com.firebase.ui.auth.ui.screens.FirebaseAuthScreen] against the emulator and asserted on
+ * `user.multiFactor.enrolledFactors`, lives in [MfaSmsFlowTest]; add SMS coverage there rather
+ * than here.
  *
- * **Important Note**: Firebase Auth Emulator has **limited MFA support**, so these tests
- * use mocked Firebase users and focus on UI flow validation. Actual MFA operations
- * (enrollment, verification) will fail with the emulator and are caught/ignored in tests.
- *
- * For full integration testing of MFA functionality, use a real Firebase project.
+ * **Emulator MFA support** (firebase-tools 15.x, verified 2026-09):
+ * - **SMS works end to end.** The emulator implements `mfaEnrollment:start`/`:finalize` and
+ *   `mfaSignIn:start`/`:finalize`, and publishes both flows' codes on the same
+ *   `verificationCodes` endpoint [com.firebase.ui.auth.testutil.EmulatorAuthApi.fetchVerifyPhoneCode]
+ *   already reads for phone auth. It enforces two preconditions: the user's email must be verified
+ *   (`UNVERIFIED_EMAIL`), and anonymous, phone and custom-token first factors are rejected
+ *   (`UNSUPPORTED_FIRST_FACTOR`).
+ * - **TOTP does not work.** The emulator's `mfaEnrollment:start` accepts only `phoneEnrollmentInfo`,
+ *   so enrollment fails on its very first call — `TotpMultiFactorGenerator.generateSecret` returns
+ *   `FirebaseException: An internal error has occurred. [ INVALID_ARGUMENT:((Missing
+ *   phoneEnrollmentInfo.)) ]`. The TOTP request/response types exist in the emulator's OpenAPI spec
+ *   but have no implementation behind them. Testing TOTP needs a real Firebase project; the TOTP
+ *   tests below tolerate the missing secret rather than asserting on it.
  */
 @Config(sdk = [34])
 @RunWith(RobolectricTestRunner::class)

--- a/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/MfaSmsFlowTest.kt
+++ b/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/MfaSmsFlowTest.kt
@@ -59,6 +59,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * E2E happy paths for SMS multi-factor authentication, driven through [FirebaseAuthScreen] against
@@ -71,7 +72,7 @@ import org.robolectric.annotation.Config
  *
  * The two paths the emulator enforces, and that every test here has to satisfy:
  * - Enrollment requires a **verified** email (`UNVERIFIED_EMAIL` otherwise).
- * - Anonymous, phone and custom-token sign-ins cannot carry a second factor
+ * - Anonymous, phone, custom-token and Game Center sign-ins cannot carry a second factor
  *   (`UNSUPPORTED_FIRST_FACTOR`), so the first factor here is always email/password.
  */
 @Config(sdk = [34])
@@ -148,12 +149,13 @@ class MfaSmsFlowTest {
 
         awaitNode(FirebaseAuthTestTags.PhoneNumber.PHONE_NUMBER_FIELD)
             .performTextInput(nationalNumber)
+        val codeBeforeSend = peekPhoneVerificationCode(phoneNumber)
         composeAndroidTestRule.onNodeWithTag(FirebaseAuthTestTags.PhoneNumber.SEND_CODE_BUTTON)
             .performScrollTo()
             .assertIsEnabled()
             .performClick()
 
-        val code = awaitPhoneVerificationCode(phoneNumber)
+        val code = awaitPhoneVerificationCode(phoneNumber, codeBeforeSend)
         awaitNode(FirebaseAuthTestTags.VerificationCode.CODE_FIELD).performTextInput(code)
         composeAndroidTestRule.onNodeWithTag(FirebaseAuthTestTags.VerificationCode.VERIFY_BUTTON)
             .performScrollTo()
@@ -195,6 +197,10 @@ class MfaSmsFlowTest {
         )
         signOut()
 
+        // Enrollment above redeemed its own code, so this is normally null; snapshotting anyway
+        // keeps the wait below honest if the emulator ever holds a leftover for this number.
+        val codeBeforeChallenge = peekPhoneVerificationCode(phoneNumber)
+
         var currentAuthState: AuthState = AuthState.Idle
         composeAndroidTestRule.setContent {
             TestFirebaseAuthScreen(configuration = emailProviderConfiguration())
@@ -213,7 +219,7 @@ class MfaSmsFlowTest {
 
         // The challenge screen requests the code itself on entry, so this is the first code the
         // emulator holds for this number since enrollment redeemed the last one.
-        val code = awaitPhoneVerificationCode(phoneNumber)
+        val code = awaitPhoneVerificationCode(phoneNumber, codeBeforeChallenge)
         awaitNode(FirebaseAuthTestTags.MfaChallenge.CODE_FIELD).performTextInput(code)
         composeAndroidTestRule.onNodeWithTag(FirebaseAuthTestTags.MfaChallenge.VERIFY_BUTTON)
             .performScrollTo()
@@ -271,22 +277,27 @@ class MfaSmsFlowTest {
         assertThat(state()).isInstanceOf(T::class.java)
     }
 
+    /** The code the emulator currently holds for [phoneNumber], or null if it holds none. */
+    private fun peekPhoneVerificationCode(phoneNumber: String): String? =
+        runCatching { emulatorApi.fetchVerifyPhoneCode(phoneNumber) }.getOrNull()
+
     /**
-     * Waits for the emulator to publish an SMS code for [phoneNumber], then returns it.
+     * Waits for the emulator to publish an SMS code for [phoneNumber] that differs from
+     * [previous], then returns it.
      *
      * Both flows under test send their code from a coroutine the paused main looper has to run, so
-     * the wait pumps that looper rather than sleeping the thread that owes the work. Waiting for
-     * the code to appear is also what orders the read after the send, so there is no window in
-     * which an earlier code could be read instead.
+     * the wait pumps that looper rather than sleeping the thread that owes the work. Comparing
+     * against the code held before the send is what makes the wait unambiguous: a stale code left
+     * unredeemed for this number by an earlier test cannot satisfy it.
      */
-    private fun awaitPhoneVerificationCode(phoneNumber: String): String {
+    private fun awaitPhoneVerificationCode(phoneNumber: String, previous: String?): String {
         var code: String? = null
         composeAndroidTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
             shadowOf(Looper.getMainLooper()).idle()
-            code = runCatching { emulatorApi.fetchVerifyPhoneCode(phoneNumber) }.getOrNull()
-            code != null
+            code = peekPhoneVerificationCode(phoneNumber)
+            code != null && code != previous
         }
-        return requireNotNull(code) { "No verification code for $phoneNumber" }
+        return requireNotNull(code) { "No fresh verification code for $phoneNumber" }
     }
 
     @OptIn(ExperimentalTestApi::class)
@@ -301,11 +312,12 @@ class MfaSmsFlowTest {
 
     /**
      * A US number in libphonenumber's valid range — the enrollment step's send button stays
-     * disabled otherwise — varying per run, so the emulator's `verificationCodes` list, which
-     * survives the account wipe between tests, is unlikely to hold another test's code for it.
+     * disabled otherwise — distinct per call. Uses exchange 556 because `PhoneAuthScreenTest`
+     * hardcodes 202555xxxx numbers and the emulator's `verificationCodes` list survives the
+     * account wipe between tests, so a shared number could serve a stale code.
      */
     private fun uniqueNationalNumber(): String =
-        "202555${(System.currentTimeMillis() % 10_000).toString().padStart(4, '0')}"
+        "202556%04d".format(phoneCounter.getAndIncrement() % 10_000)
 
     /**
      * Deliberately passes no `authenticatedContent`: enrollment is reached from the default
@@ -324,5 +336,10 @@ class MfaSmsFlowTest {
                 onSignInCancelled = { },
             )
         }
+    }
+
+    private companion object {
+        /** Monotonic within a run, so two tests here can never draw the same number. */
+        val phoneCounter = AtomicInteger(0)
     }
 }

--- a/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/MfaSmsFlowTest.kt
+++ b/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/MfaSmsFlowTest.kt
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2025 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.firebase.ui.auth.ui.screens
+
+import android.content.Context
+import android.os.Looper
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import com.firebase.ui.auth.AuthState
+import com.firebase.ui.auth.FirebaseAuthUI
+import com.firebase.ui.auth.configuration.AuthUIConfiguration
+import com.firebase.ui.auth.configuration.authUIConfiguration
+import com.firebase.ui.auth.configuration.auth_provider.AuthProvider
+import com.firebase.ui.auth.configuration.string_provider.AuthUIStringProvider
+import com.firebase.ui.auth.configuration.string_provider.DefaultAuthUIStringProvider
+import com.firebase.ui.auth.configuration.string_provider.LocalAuthUIStringProvider
+import com.firebase.ui.auth.testutil.AUTH_STATE_WAIT_TIMEOUT_MS
+import com.firebase.ui.auth.testutil.EmulatorAuthApi
+import com.firebase.ui.auth.testutil.enrollSmsFactorInEmulator
+import com.firebase.ui.auth.testutil.ensureFreshUser
+import com.firebase.ui.auth.testutil.ensureTestFirebaseApp
+import com.firebase.ui.auth.testutil.verifyEmailInEmulator
+import com.firebase.ui.auth.ui.FirebaseAuthTestTags
+import com.firebase.ui.auth.util.CountryUtils
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.auth.PhoneMultiFactorInfo
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * E2E happy paths for SMS multi-factor authentication, driven through [FirebaseAuthScreen] against
+ * the Firebase Auth Emulator.
+ *
+ * The emulator implements SMS MFA in full — enrollment start/finalize and sign-in start/finalize —
+ * and publishes both flows' codes on the same `verificationCodes` endpoint the primary phone auth
+ * flow reads, so these tests assert on real enrolled factors and a real [AuthState.Success] rather
+ * than on the screens' own state. TOTP is a different story: see [MfaEnrollmentScreenTest].
+ *
+ * The two paths the emulator enforces, and that every test here has to satisfy:
+ * - Enrollment requires a **verified** email (`UNVERIFIED_EMAIL` otherwise).
+ * - Anonymous, phone and custom-token sign-ins cannot carry a second factor
+ *   (`UNSUPPORTED_FIRST_FACTOR`), so the first factor here is always email/password.
+ */
+@Config(sdk = [34])
+@RunWith(RobolectricTestRunner::class)
+class MfaSmsFlowTest {
+    @get:Rule
+    val composeAndroidTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private lateinit var applicationContext: Context
+    private lateinit var stringProvider: AuthUIStringProvider
+    private lateinit var authUI: FirebaseAuthUI
+    private lateinit var emulatorApi: EmulatorAuthApi
+
+    @Before
+    fun setUp() {
+        applicationContext = ApplicationProvider.getApplicationContext()
+        stringProvider = DefaultAuthUIStringProvider(applicationContext)
+
+        val firebaseApp = ensureTestFirebaseApp(applicationContext)
+        authUI = FirebaseAuthUI.getInstance()
+
+        emulatorApi = EmulatorAuthApi(
+            projectId = firebaseApp.options.projectId
+                ?: throw IllegalStateException("Project ID is required for emulator interactions"),
+            emulatorHost = "127.0.0.1",
+            emulatorPort = 9099
+        )
+
+        emulatorApi.clearEmulatorData()
+    }
+
+    @After
+    fun tearDown() {
+        // The FirebaseApp is shared across test classes (see ensureTestFirebaseApp), so the
+        // client-side session has to be reset here rather than by app re-creation.
+        authUI.auth.signOut()
+        FirebaseAuthUI.clearInstanceCache()
+
+        emulatorApi.clearEmulatorData()
+    }
+
+    @Test
+    fun `SMS enrollment enrolls a real second factor`() {
+        val email = "mfa-enroll-${System.currentTimeMillis()}@example.com"
+        val password = "test123"
+        val nationalNumber = uniqueNationalNumber()
+        val phoneNumber = "${CountryUtils.getDefaultCountry().dialCode}$nationalNumber"
+
+        val user = requireNotNull(ensureFreshUser(authUI, email, password)) {
+            "Failed to create user"
+        }
+        verifyEmailInEmulator(authUI, emulatorApi, user)
+        signOut()
+
+        var currentAuthState: AuthState = AuthState.Idle
+        composeAndroidTestRule.setContent {
+            TestFirebaseAuthScreen(configuration = emailProviderConfiguration())
+            val authState by authUI.authStateFlow().collectAsState(AuthState.Idle)
+            currentAuthState = authState
+        }
+
+        signIn(email, password)
+        awaitAuthState<AuthState.Success> { currentAuthState }
+
+        assertThat(authUI.auth.currentUser!!.multiFactor.enrolledFactors).isEmpty()
+
+        awaitNodeWithText(stringProvider.manageMfaAction)
+            .assertIsDisplayed()
+            .assertIsEnabled()
+            .performClick()
+
+        // Both factors are offered, so enrollment opens on the picker.
+        awaitNode(FirebaseAuthTestTags.MfaEnrollment.ENROLL_SMS_BUTTON).performClick()
+
+        awaitNode(FirebaseAuthTestTags.PhoneNumber.PHONE_NUMBER_FIELD)
+            .performTextInput(nationalNumber)
+        composeAndroidTestRule.onNodeWithTag(FirebaseAuthTestTags.PhoneNumber.SEND_CODE_BUTTON)
+            .performScrollTo()
+            .assertIsEnabled()
+            .performClick()
+
+        val code = awaitPhoneVerificationCode(phoneNumber)
+        awaitNode(FirebaseAuthTestTags.VerificationCode.CODE_FIELD).performTextInput(code)
+        composeAndroidTestRule.onNodeWithTag(FirebaseAuthTestTags.VerificationCode.VERIFY_BUTTON)
+            .performScrollTo()
+            .assertIsEnabled()
+            .performClick()
+
+        // The factor landing on the account is the assertion; the screen leaving enrollment is not.
+        composeAndroidTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
+            shadowOf(Looper.getMainLooper()).idle()
+            authUI.auth.currentUser?.multiFactor?.enrolledFactors?.isNotEmpty() == true
+        }
+
+        val enrolled = authUI.auth.currentUser!!.multiFactor.enrolledFactors
+        assertThat(enrolled).hasSize(1)
+        val factor = enrolled.single()
+        assertThat(factor).isInstanceOf(PhoneMultiFactorInfo::class.java)
+        assertThat((factor as PhoneMultiFactorInfo).phoneNumber).endsWith(phoneNumber.takeLast(4))
+
+        // Completing enrollment leaves the flow, back to the signed-in screen it was entered from.
+        awaitNodeWithText(stringProvider.manageMfaAction).assertIsDisplayed()
+    }
+
+    @Test
+    fun `SMS challenge completes sign-in`() {
+        val email = "mfa-challenge-${System.currentTimeMillis()}@example.com"
+        val password = "test123"
+        val phoneNumber = "${CountryUtils.getDefaultCountry().dialCode}${uniqueNationalNumber()}"
+
+        val user = requireNotNull(ensureFreshUser(authUI, email, password)) {
+            "Failed to create user"
+        }
+        verifyEmailInEmulator(authUI, emulatorApi, user)
+        enrollSmsFactorInEmulator(
+            activity = composeAndroidTestRule.activity,
+            authUI = authUI,
+            emulatorApi = emulatorApi,
+            user = requireNotNull(authUI.auth.currentUser) { "User signed out during setup" },
+            phoneNumber = phoneNumber,
+        )
+        signOut()
+
+        var currentAuthState: AuthState = AuthState.Idle
+        composeAndroidTestRule.setContent {
+            TestFirebaseAuthScreen(configuration = emailProviderConfiguration())
+            val authState by authUI.authStateFlow().collectAsState(AuthState.Idle)
+            currentAuthState = authState
+        }
+
+        signIn(email, password)
+
+        // The password alone does not sign the user in any more.
+        awaitAuthState<AuthState.RequiresMfa> { currentAuthState }
+        assertThat(authUI.auth.currentUser).isNull()
+
+        val hint = (currentAuthState as AuthState.RequiresMfa).resolver.hints.single()
+        assertThat(hint).isInstanceOf(PhoneMultiFactorInfo::class.java)
+
+        // The challenge screen requests the code itself on entry, so this is the first code the
+        // emulator holds for this number since enrollment redeemed the last one.
+        val code = awaitPhoneVerificationCode(phoneNumber)
+        awaitNode(FirebaseAuthTestTags.MfaChallenge.CODE_FIELD).performTextInput(code)
+        composeAndroidTestRule.onNodeWithTag(FirebaseAuthTestTags.MfaChallenge.VERIFY_BUTTON)
+            .performScrollTo()
+            .assertIsEnabled()
+            .performClick()
+
+        awaitAuthState<AuthState.Success> { currentAuthState }
+
+        val signedIn = requireNotNull(authUI.auth.currentUser) { "No user after MFA sign-in" }
+        assertThat(signedIn.email).isEqualTo(email)
+        assertThat(signedIn.uid).isEqualTo(user.uid)
+        assertThat(signedIn.multiFactor.enrolledFactors).hasSize(1)
+    }
+
+    private fun emailProviderConfiguration(): AuthUIConfiguration = authUIConfiguration {
+        context = applicationContext
+        providers {
+            provider(
+                AuthProvider.Email(
+                    emailLinkActionCodeSettings = null,
+                    passwordValidationRules = emptyList()
+                )
+            )
+        }
+        isCredentialManagerEnabled = false
+        isMfaEnabled = true
+    }
+
+    private fun signOut() {
+        authUI.auth.signOut()
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    private fun signIn(email: String, password: String) {
+        composeAndroidTestRule.waitForIdle()
+        composeAndroidTestRule.onNodeWithText(stringProvider.emailHint)
+            .performScrollTo()
+            .performTextInput(email)
+        composeAndroidTestRule.onNodeWithText(stringProvider.passwordHint)
+            .performScrollTo()
+            .performTextInput(password)
+        composeAndroidTestRule.onNodeWithText(stringProvider.signInDefault.uppercase())
+            .performScrollTo()
+            .assertIsEnabled()
+            .performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    private inline fun <reified T : AuthState> awaitAuthState(crossinline state: () -> AuthState) {
+        composeAndroidTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
+            shadowOf(Looper.getMainLooper()).idle()
+            state() is T
+        }
+        shadowOf(Looper.getMainLooper()).idle()
+        assertThat(state()).isInstanceOf(T::class.java)
+    }
+
+    /**
+     * Waits for the emulator to publish an SMS code for [phoneNumber], then returns it.
+     *
+     * Both flows under test send their code from a coroutine the paused main looper has to run, so
+     * the wait pumps that looper rather than sleeping the thread that owes the work. Waiting for
+     * the code to appear is also what orders the read after the send, so there is no window in
+     * which an earlier code could be read instead.
+     */
+    private fun awaitPhoneVerificationCode(phoneNumber: String): String {
+        var code: String? = null
+        composeAndroidTestRule.waitUntil(timeoutMillis = AUTH_STATE_WAIT_TIMEOUT_MS) {
+            shadowOf(Looper.getMainLooper()).idle()
+            code = runCatching { emulatorApi.fetchVerifyPhoneCode(phoneNumber) }.getOrNull()
+            code != null
+        }
+        return requireNotNull(code) { "No verification code for $phoneNumber" }
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    private fun awaitNode(testTag: String) = composeAndroidTestRule
+        .apply { waitUntilAtLeastOneExists(hasTestTag(testTag), AUTH_STATE_WAIT_TIMEOUT_MS) }
+        .onNodeWithTag(testTag)
+
+    @OptIn(ExperimentalTestApi::class)
+    private fun awaitNodeWithText(text: String) = composeAndroidTestRule
+        .apply { waitUntilAtLeastOneExists(hasText(text), AUTH_STATE_WAIT_TIMEOUT_MS) }
+        .onNodeWithText(text)
+
+    /**
+     * A US number in libphonenumber's valid range — the enrollment step's send button stays
+     * disabled otherwise — varying per run, so the emulator's `verificationCodes` list, which
+     * survives the account wipe between tests, is unlikely to hold another test's code for it.
+     */
+    private fun uniqueNationalNumber(): String =
+        "202555${(System.currentTimeMillis() % 10_000).toString().padStart(4, '0')}"
+
+    /**
+     * Deliberately passes no `authenticatedContent`: enrollment is reached from the default
+     * signed-in screen's own "manage MFA" action, which a custom slot would replace.
+     */
+    @Composable
+    private fun TestFirebaseAuthScreen(configuration: AuthUIConfiguration) {
+        CompositionLocalProvider(
+            LocalAuthUIStringProvider provides DefaultAuthUIStringProvider(applicationContext)
+        ) {
+            FirebaseAuthScreen(
+                configuration = configuration,
+                authUI = authUI,
+                onSignInSuccess = { },
+                onSignInFailure = { },
+                onSignInCancelled = { },
+            )
+        }
+    }
+}

--- a/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/PhoneAuthScreenTest.kt
+++ b/e2eTest/src/test/java/com/firebase/ui/auth/ui/screens/PhoneAuthScreenTest.kt
@@ -579,6 +579,13 @@ class PhoneAuthScreenTest {
                                 isLoading = state.isLoading,
                                 phoneNumber = state.phoneNumber,
                                 selectedCountry = state.selectedCountry,
+                                // A custom content slot now supplies this itself; the step no
+                                // longer reads it off the configuration.
+                                allowedCountries = configuration.providers
+                                    .filterIsInstance<AuthProvider.Phone>()
+                                    .firstOrNull()
+                                    ?.allowedCountries
+                                    ?.toSet(),
                                 onPhoneNumberChange = state.onPhoneNumberChange,
                                 onCountrySelected = state.onCountrySelected,
                                 onSendCodeClick = state.onSendCodeClick,


### PR DESCRIPTION
The SMS enrolment step read its country restriction off the hosting configuration's `AuthProvider.Phone`, and `EnterPhoneNumberUI` took `.first()` of that list, so opening SMS enrolment from a configuration without a phone provider crashed with `NoSuchElementException`. That is the ordinary case rather than an edge case — Firebase enables SMS second factors separately from phone sign-in, and phone sign-in cannot carry a second factor at all.

The restriction now comes from `MfaConfiguration.allowedCountries` and `EnterPhoneNumberUI` takes it as a parameter, so the step no longer resolves a provider at all. That option takes ISO 3166-1 alpha-2 codes and validates them — a dial code throws rather than silently restricting the selector to nothing — and the step opens on a permitted country instead of the device's own when the two disagree. `AuthProvider.Phone.allowedCountries` is unchanged and still drives phone sign-in. `AuthProvider.Phone.smsCodeLength` is removed — nothing read it, both flows validate against a hardcoded 6, and Firebase exposes no SMS code length setting for it to mirror.

Also adds the first genuine end-to-end MFA coverage: `MfaSmsFlowTest` enrols an SMS factor and completes an MFA challenge against the Auth emulator, asserting on `user.multiFactor.enrolledFactors` and `AuthState.Success` rather than on screen state. The emulator supports SMS MFA in full — the two mocked MFA test files claimed it could not, and are corrected, TOTP's exact failure included. `MfaEnrollmentSmsStepTest` covers the crash, verified failing on the old code.

## ⚠️ Breaking Changes

- `AuthProvider.Phone.smsCodeLength` is removed. Nothing read it, so nothing behaves differently without it.
- `EnterPhoneNumberUI` gained a **required** `allowedCountries` parameter and no longer resolves a phone provider from the configuration. Callers stop compiling until they supply it, deliberately: with a default, a host driving this step from a custom `phoneAuthContent` would have silently lost the restriction it used to get implicitly. Derive it from your own provider — `configuration.providers.filterIsInstance<AuthProvider.Phone>().firstOrNull()?.allowedCountries?.toSet()` — or pass `null` for no restriction.

## Usage

```kotlin
FirebaseAuthScreen(
    configuration = configuration,
    mfaConfiguration = MfaConfiguration(
        allowedFactors = listOf(MfaFactor.Sms),
        allowedCountries = listOf("GB", "IE"),
    ),
    onSignInSuccess = { },
    onSignInFailure = { },
    onSignInCancelled = { },
)
```

---
Maintainer note: Fixes internal CPRN-423

