### PR TITLE
refactor(auth): deduplicate the sign-up and email-link offered rules

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/SignInUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/ui/screens/email/SignInUI.kt
@@ -94,7 +94,6 @@ fun SignInUI(
     isEmailLocked: Boolean = false,
 ) {
     val context = LocalContext.current
-    val provider = configuration.providers.filterIsInstance<AuthProvider.Email>().first()
     val stringProvider = LocalAuthUIStringProvider.current
     val emailValidator = remember { EmailValidator(stringProvider) }
     val passwordValidator = remember {
@@ -110,14 +109,9 @@ fun SignInUI(
         }
     }
 
-    val isSignUpOffered = provider.isNewAccountsAllowed &&
-            configuration.isNewEmailAccountsAllowed &&
-            !configuration.isReauthenticationMode
+    val isSignUpOffered = configuration.isEmailSignUpOffered()
 
-    // An email link reopens the app with no request outstanding, so completing it reports an interruption
-    // instead of the operation; a reset email leaves the reauth sheet and its request intact.
-    val isEmailLinkSignInOffered =
-        provider.isEmailLinkSignInEnabled && !configuration.isReauthenticationMode
+    val isEmailLinkSignInOffered = configuration.isEmailLinkSignInOffered()
 
     // Retrieve saved credentials when in SignIn mode
     val credentialRetrievalAttempted = remember { mutableStateOf(false) }

--- a/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/SignInUITest.kt
+++ b/auth/src/test/java/com/firebase/ui/auth/ui/screens/email/SignInUITest.kt
@@ -524,6 +524,49 @@ class SignInUITest {
             .assertExists()
     }
 
+    /**
+     * The negative of the control above: the toggle is gated on the provider's own
+     * `isEmailLinkSignInEnabled` as well as on reauthentication mode, so leaving it off keeps the
+     * affordance hidden in an ordinary sign-in too.
+     */
+    @Test
+    fun `email link sign-in is not offered when the provider disables it`() {
+        val configuration = authUIConfiguration {
+            context = applicationContext
+            providers { provider(emailProvider(isEmailLinkSignInEnabled = false)) }
+        }
+
+        setStatefulSignInUIContent(configuration, initialEmail = "")
+
+        composeTestRule.onNodeWithText(stringProvider.troubleSigningIn).assertExists()
+        composeTestRule
+            .onNode(hasText(stringProvider.signInWithEmailLink.uppercase()) and hasClickAction())
+            .assertDoesNotExist()
+    }
+
+    /**
+     * [SignInUI] is public API and [AuthUIConfiguration] has a public constructor whose `providers`
+     * defaults to empty, so a caller really can reach this. Reading
+     * `providers.filterIsInstance<AuthProvider.Email>().first()` unconditionally at the top of the
+     * composable threw `NoSuchElementException` here; the offer helpers short-circuit instead, and
+     * both email affordances simply go unoffered.
+     */
+    @Test
+    fun `no email provider hides sign up and email link sign-in instead of throwing`() {
+        setStatefulSignInUIContent(
+            AuthUIConfiguration(context = applicationContext),
+            initialEmail = "",
+        )
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(FirebaseAuthTestTags.SignIn.SIGN_IN_BUTTON).assertExists()
+        composeTestRule.onNode(hasText(stringProvider.signupPageTitle.uppercase()) and hasClickAction())
+            .assertDoesNotExist()
+        composeTestRule
+            .onNode(hasText(stringProvider.signInWithEmailLink.uppercase()) and hasClickAction())
+            .assertDoesNotExist()
+    }
+
     /** The notice is specific to reauthentication and must not appear in a normal sign-in. */
     @Test
     fun `no password requirement notice outside reauthentication`() {


### PR DESCRIPTION
`SignInUI` computed the sign-up and email-link "offered" rules itself, while `AuthUIConfiguration.isEmailSignUpOffered()` and `isEmailLinkSignInOffered()` already encoded the same two rules for `EmailAuthScreen` and the email destinations — so each rule lived in two places and only one of them moved when the rule changed. Worse, the inline copies decided whether to *render* buttons whose navigation the shared copy would then refuse, so any drift showed up as a visible dead button.

This folds `SignInUI` onto the shared helpers and drops the provider lookup it no longer needs. Both helpers are `internal` and `SignInUI`'s signature is unchanged, so nothing public moves. Behaviour is identical except when no email provider is configured, where the old `.first()` threw during composition and the screen now renders with both controls hidden.

- Added `no email provider hides sign up and email link sign-in instead of throwing` and `email link sign-in is not offered when the provider disables it` to `SignInUITest` — the first was verified to fail on the old code with `NoSuchElementException`.

---
Maintainer note: Fixes internal CPRN-412
