### PR TITLE
docs(auth): correct the auth KDoc against the current API

### DIFF
--- a/auth/src/main/java/com/firebase/ui/auth/AuthFlowController.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthFlowController.kt
@@ -52,10 +52,11 @@ import java.util.concurrent.atomic.AtomicBoolean
  *
  *         val authUI = FirebaseAuthUI.getInstance()
  *         val configuration = authUIConfiguration {
- *             providers = listOf(
- *                 AuthProvider.Email(),
- *                 AuthProvider.Google(...)
- *             )
+ *             context = applicationContext
+ *             providers {
+ *                 provider(AuthProvider.Email(...))
+ *                 provider(AuthProvider.Google(...))
+ *             }
  *         }
  *
  *         authController = authUI.createAuthFlow(configuration)
@@ -228,17 +229,10 @@ class AuthFlowController internal constructor(
     }
 
     /**
-     * Disposes the controller and releases all resources.
+     * Cancels the controller's coroutines and state collection, and marks it disposed.
      *
-     * This method:
-     * - Cancels all coroutines in the controller scope
-     * - Stops listening to auth state changes
-     * - Marks the controller as disposed
-     *
-     * Call this method in your Activity's `onDestroy()` to prevent memory leaks.
-     *
-     * **Important:** Once disposed, this controller cannot be reused. Create a new
-     * controller if you need to start another auth flow.
+     * Call this from your Activity's `onDestroy()`. Disposing twice is harmless, but a
+     * disposed controller cannot be reused — create a new one to start another flow.
      *
      * **Example:**
      * ```kotlin
@@ -247,8 +241,6 @@ class AuthFlowController internal constructor(
      *     authController.dispose()
      * }
      * ```
-     *
-     * @throws IllegalStateException if already disposed (when called multiple times)
      */
     fun dispose() {
         if (isDisposed.compareAndSet(false, true)) {

--- a/auth/src/main/java/com/firebase/ui/auth/AuthState.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/AuthState.kt
@@ -513,20 +513,12 @@ abstract class AuthState private constructor() {
     /**
      * Phone number verification requires manual code entry.
      *
-     * This state is emitted when Firebase Phone Authentication cannot instantly verify
-     * the phone number and sends an SMS code that the user must manually enter. This is
-     * the normal flow when automatic SMS retrieval is not available or fails.
+     * Emitted when instant verification is unavailable or fails, so the code has to be typed
+     * in. `PhoneAuthScreen` holds both properties in its flow state and hands them back when
+     * submitting a code or resending.
      *
-     * **Resending codes:**
-     * To allow users to resend the verification code (if they didn't receive it),
-     * call [FirebaseAuthUI.verifyPhoneNumber] again with:
-     * - `isForceResendingTokenEnabled = true`
-     * - `forceResendingToken` from this state
-     *
-     * @property verificationId The verification ID to use when submitting the code.
-     *                          This must be passed to [FirebaseAuthUI.submitVerificationCode].
-     * @property forceResendingToken Token that can be used to resend the SMS code if needed
-     *
+     * @property verificationId Identifies the verification the submitted code belongs to.
+     * @property forceResendingToken Resends the SMS without restarting the verification.
      */
     class PhoneNumberVerificationRequired(
         val verificationId: String,

--- a/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthActivity.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthActivity.kt
@@ -48,10 +48,14 @@ import java.util.concurrent.ConcurrentHashMap
  * ```kotlin
  * val authUI = FirebaseAuthUI.getInstance()
  * val configuration = authUIConfiguration {
- *     providers = listOf(AuthProvider.Email(), AuthProvider.Google(...))
+ *     context = applicationContext
+ *     providers {
+ *         provider(AuthProvider.Email(...))
+ *         provider(AuthProvider.Google(...))
+ *     }
  * }
  * val controller = authUI.createAuthFlow(configuration)
- * val intent = controller.createIntent(context)
+ * val intent = controller.createIntent(this)
  * launcher.launch(intent)
  * ```
  *

--- a/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/FirebaseAuthUI.kt
@@ -183,10 +183,11 @@ class FirebaseAuthUI private constructor(
      *
      *         val authUI = FirebaseAuthUI.getInstance()
      *         val configuration = authUIConfiguration {
-     *             providers = listOf(
-     *                 AuthProvider.Email(),
-     *                 AuthProvider.Google(...)
-     *             )
+     *             context = applicationContext
+     *             providers {
+     *                 provider(AuthProvider.Email(...))
+     *                 provider(AuthProvider.Google(...))
+     *             }
      *         }
      *
      *         authController = authUI.createAuthFlow(configuration)

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProvider+FirebaseAuthUI.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import com.firebase.ui.auth.AuthFlowScope
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
-import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/AnonymousAuthProvider+FirebaseAuthUI.kt
@@ -43,72 +43,10 @@ internal fun AuthFlowScope.rememberAnonymousSignInHandler(
 }
 
 /**
- * Signs in a user anonymously with Firebase Authentication.
+ * Signs the user in anonymously.
  *
- * This method creates a temporary anonymous user account that can be used for testing
- * or as a starting point for users who want to try the app before creating a permanent
- * account. Anonymous users can later be upgraded to permanent accounts by linking
- * credentials (email/password, social providers, phone, etc.).
- *
- * **Flow:**
- * 1. Updates auth state to loading with "Signing in anonymously..." message
- * 2. Calls Firebase Auth's `signInAnonymously()` method
- * 3. Updates auth state to idle on success
- * 4. Handles cancellation and converts exceptions to [AuthException] types
- *
- * **Anonymous Account Benefits:**
- * - No user data collection required
- * - Immediate access to app features
- * - Can be upgraded to permanent account later
- * - Useful for guest users and app trials
- *
- * **Account Upgrade:**
- * Anonymous accounts can be upgraded to permanent accounts by calling methods like:
- * - [signInAndLinkWithCredential] with email/password or social credentials
- * - [createOrLinkUserWithEmailAndPassword] for email/password accounts
- * - [signInWithPhoneAuthCredential] for phone authentication
- *
- * **Example: Basic anonymous sign-in**
- * ```kotlin
- * try {
- *     firebaseAuthUI.signInAnonymously()
- *     // User is now signed in anonymously
- *     // Show app content or prompt for account creation
- * } catch (e: AuthException.AuthCancelledException) {
- *     // User cancelled the sign-in process
- * } catch (e: AuthException.NetworkException) {
- *     // Network error occurred
- * }
- * ```
- *
- * **Example: Anonymous sign-in with upgrade flow**
- * ```kotlin
- * // Step 1: Sign in anonymously
- * firebaseAuthUI.signInAnonymously()
- * 
- * // Step 2: Later, upgrade to permanent account
- * try {
- *     firebaseAuthUI.createOrLinkUserWithEmailAndPassword(
- *         context = context,
- *         config = authUIConfig,
- *         provider = emailProvider,
- *         name = "John Doe",
- *         email = "john@example.com",
- *         password = "SecurePass123!"
- *     )
- *     // Anonymous account upgraded to permanent email/password account
- * } catch (e: AuthException.AccountLinkingRequiredException) {
- *     // Email already exists - show account linking UI
- * }
- * ```
- *
- * @throws AuthException.AuthCancelledException if the coroutine is cancelled
- * @throws AuthException.NetworkException if a network error occurs
- * @throws AuthException.UnknownException for other authentication errors
- *
- * @see signInAndLinkWithCredential for upgrading anonymous accounts
- * @see createOrLinkUserWithEmailAndPassword for email/password upgrade
- * @see signInWithPhoneAuthCredential for phone authentication upgrade
+ * The account is temporary: linking a credential to it later upgrades it in place, which is
+ * what anonymous upgrade does for every other provider.
  */
 internal suspend fun AuthFlowScope.signInAnonymously() {
     try {

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/EmailAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/EmailAuthProvider+FirebaseAuthUI.kt
@@ -510,10 +510,13 @@ internal suspend fun AuthFlowScope.signInAndLinkWithCredential(
  * Sends a passwordless sign-in link to [email].
  *
  * The link's continue URL carries a session id, the anonymous user's id when upgrading, and the
- * force-same-device flag; the same values are persisted so [signInWithEmailLink] can validate
- * the link when it comes back. [credentialForLinking] is stored alongside them, which is how a
- * social credential that collided with an existing email-link account is linked once the user
- * follows the link.
+ * force-same-device flag; the email and session are persisted so [signInWithEmailLink] can
+ * validate the link when it comes back.
+ *
+ * [credentialForLinking] only adds the provider id to that URL — it is **not** persisted here. A
+ * caller linking a collided social credential must save it itself, via
+ * `EmailLinkPersistenceManager.saveCredentialForLinking`, before calling this; that is what
+ * [signInWithEmailLink] later picks up.
  */
 internal suspend fun AuthFlowScope.sendSignInLinkToEmail(
     context: Context,
@@ -574,7 +577,16 @@ internal suspend fun AuthFlowScope.sendSignInLinkToEmail(
  * On the same device the address and session id come from storage and the user is signed in
  * without further input. When the session id does not match — a different device, or storage
  * cleared — an empty [email] raises [AuthException.EmailLinkPromptForEmailException]; call again
- * with the address the user supplies.
+ * with the address the user supplies. On the same-device path an empty [email] instead means the
+ * stored address is gone, and raises [AuthException.EmailMismatchException].
+ *
+ * @throws AuthException.EmailLinkWrongDeviceException if the link requires the originating device
+ * — force-same-device, or an anonymous upgrade — and was opened elsewhere.
+ * @throws AuthException.EmailLinkCrossDeviceLinkingException if a link carrying a social
+ * credential to link is opened on another device.
+ * @throws AuthException.EmailLinkDifferentAnonymousUserException if the anonymous uid in the link
+ * is not the uid signed in now.
+ * @throws AuthException.InvalidEmailLinkException if the link is not a sign-in link.
  */
 internal suspend fun AuthFlowScope.signInWithEmailLink(
     context: Context,

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/EmailAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/EmailAuthProvider+FirebaseAuthUI.kt
@@ -66,75 +66,15 @@ internal suspend fun AuthFlowScope.signInOrReauth(
 }
 
 /**
- * Creates an email/password account or links the credential to an anonymous user.
+ * Creates an email/password account, or links the credential to the signed-in anonymous user.
  *
- * Mirrors the legacy email sign-up handler: validates password strength, validates custom
- * password rules, checks if new accounts are allowed, chooses between
- * `createUserWithEmailAndPassword` and `linkWithCredential`, merges the supplied display name
- * into the Firebase profile, and throws [AuthException.AccountLinkingRequiredException] when
- * anonymous upgrade encounters an existing account for the email.
+ * Validates the password against [AuthProvider.Email.minimumPasswordLength] and
+ * [AuthProvider.Email.passwordValidationRules], refuses a new account when the provider
+ * disallows one, then either links to the anonymous user or creates a fresh account and merges
+ * [name] into the profile.
  *
- * **Flow:**
- * 1. Check if new accounts are allowed (for non-upgrade flows)
- * 2. Validate password length against [AuthProvider.Email.minimumPasswordLength]
- * 3. Validate password against custom [AuthProvider.Email.passwordValidationRules]
- * 4. If upgrading anonymous user: link credential to existing anonymous account
- * 5. Otherwise: create new account with `createUserWithEmailAndPassword`
- * 6. Merge display name into user profile
- *
- * @param context Android [Context] for localized strings
- * @param config Auth UI configuration describing provider settings
- * @param provider Email provider configuration
- * @param name Optional display name collected during sign-up
- * @param email Email address for the new account
- * @param password Password for the new account
- *
- * @return [AuthResult] containing the newly created or linked user, or null if failed
- *
- * @throws AuthException.UserNotFoundException if new accounts are not allowed
- * @throws AuthException.WeakPasswordException if the password fails validation rules
- * @throws AuthException.InvalidCredentialsException if the email or password is invalid
- * @throws AuthException.EmailAlreadyInUseException if the email already exists
- * @throws AuthException.AuthCancelledException if the coroutine is cancelled
- * @throws AuthException.NetworkException for network-related failures
- *
- * **Example: Normal sign-up**
- * ```kotlin
- * try {
- *     val result = firebaseAuthUI.createOrLinkUserWithEmailAndPassword(
- *         context = context,
- *         config = authUIConfig,
- *         provider = emailProvider,
- *         name = "John Doe",
- *         email = "john@example.com",
- *         password = "SecurePass123!"
- *     )
- *     // User account created successfully
- * } catch (e: AuthException.WeakPasswordException) {
- *     // Password doesn't meet validation rules
- * } catch (e: AuthException.EmailAlreadyInUseException) {
- *     // Email already exists - redirect to sign-in
- * }
- * ```
- *
- * **Example: Anonymous user upgrade**
- * ```kotlin
- * // User is currently signed in anonymously
- * try {
- *     val result = firebaseAuthUI.createOrLinkUserWithEmailAndPassword(
- *         context = context,
- *         config = authUIConfig,
- *         provider = emailProvider,
- *         name = "Jane Smith",
- *         email = "jane@example.com",
- *         password = "MyPassword456"
- *     )
- *     // Anonymous account upgraded to permanent email/password account
- * } catch (e: AuthException.AccountLinkingRequiredException) {
- *     // Email already exists - show account linking UI
- *     // User needs to sign in with existing account to link
- * }
- * ```
+ * @throws AuthException.AccountLinkingRequiredException when an anonymous upgrade meets an
+ * account that already owns [email] — the host must sign that account in to link.
  */
 internal suspend fun AuthFlowScope.createOrLinkUserWithEmailAndPassword(
     context: Context,
@@ -259,85 +199,12 @@ internal suspend fun AuthFlowScope.createOrLinkUserWithEmailAndPassword(
 }
 
 /**
- * Signs in a user with email and password, optionally linking a social credential.
+ * Signs in with email and password, optionally linking a social credential afterwards.
  *
- * This method handles both normal sign-in and anonymous upgrade flows. In anonymous upgrade
- * scenarios, it validates credentials in a scratch auth instance before throwing
- * [AuthException.AccountLinkingRequiredException].
- *
- * **Flow:**
- * 1. If anonymous upgrade:
- *    - Create scratch auth instance to validate credential
- *    - If linking social provider: sign in with email, then link social credential (safe link)
- *    - Otherwise: just validate email credential
- *    - Throw [AuthException.AccountLinkingRequiredException] after successful validation
- * 2. If normal sign-in:
- *    - Sign in with email/password
- *    - If credential provided: link it and merge profile
- *
- * @param context Android [Context] for creating scratch auth instance
- * @param config Auth UI configuration describing provider settings
- * @param email Email address for sign-in
- * @param password Password for sign-in
- * @param credentialForLinking Optional social provider credential to link after sign-in
- *
- * @return [AuthResult] containing the signed-in user, or null if validation-only (anonymous upgrade)
- *
- * @throws AuthException.InvalidCredentialsException if email or password is incorrect
- * @throws AuthException.UserNotFoundException if the user doesn't exist
- * @throws AuthException.AuthCancelledException if the operation is cancelled
- * @throws AuthException.NetworkException for network-related failures
- *
- * **Example: Normal sign-in**
- * ```kotlin
- * try {
- *     val result = firebaseAuthUI.signInWithEmailAndPassword(
- *         context = context,
- *         config = authUIConfig,
- *         provider = emailProvider,
- *         email = "user@example.com",
- *         password = "password123"
- *     )
- *     // User signed in successfully
- * } catch (e: AuthException.InvalidCredentialsException) {
- *     // Wrong password
- * }
- * ```
- *
- * **Example: Sign-in with social credential linking**
- * ```kotlin
- * // User tried to sign in with Google, but account exists with email/password
- * // Prompt for password, then link Google credential
- * val googleCredential = GoogleAuthProvider.getCredential(idToken, null)
- *
- * val result = firebaseAuthUI.signInWithEmailAndPassword(
- *     context = context,
- *     config = authUIConfig,
- *     provider = emailProvider,
- *     email = "user@example.com",
- *     password = "password123",
- *     credentialForLinking = googleCredential
- * )
- * // User signed in with email/password AND Google is now linked
- * // Profile updated with Google display name and photo
- * ```
- *
- * **Example: Anonymous upgrade validation**
- * ```kotlin
- * // User is anonymous, wants to upgrade with existing email/password account
- * try {
- *     firebaseAuthUI.signInWithEmailAndPassword(
- *         context = context,
- *         config = authUIConfig,
- *         provider = emailProvider,
- *         email = "existing@example.com",
- *         password = "password123"
- *     )
- * } catch (e: AuthException.AccountLinkingRequiredException) {
- *     // Account linking required - UI shows account linking screen
- *     // User needs to sign in with existing account to link anonymous account
- * }
- * ```
+ * An anonymous upgrade never signs the anonymous user out: the credentials are validated in a
+ * scratch auth instance first, and only then is [AuthException.AccountLinkingRequiredException]
+ * thrown for the host to resolve. A normal sign-in links [credentialForLinking], when given,
+ * and merges its profile.
  */
 internal suspend fun AuthFlowScope.signInWithEmailAndPassword(
     context: Context,
@@ -556,87 +423,11 @@ private fun SignInMethodQueryResult?.toSignInMethods(): List<String> =
     this?.signInMethods?.filter { it.isNotBlank() } ?: emptyList()
 
 /**
- * Signs in with a credential or links it to an existing anonymous user.
+ * Signs in with [credential], or links it to the signed-in anonymous user when upgrade is on.
  *
- * This method handles both normal sign-in and anonymous upgrade flows. After successful
- * authentication, it merges profile information (display name and photo URL) into the
- * Firebase user profile if provided.
- *
- * **Flow:**
- * 1. Check if user is anonymous and upgrade is enabled
- * 2. If yes: Link credential to anonymous user
- * 3. If no: Sign in with credential
- * 4. Merge profile information (name, photo) into Firebase user
- * 5. Handle collision exceptions by throwing [AuthException.AccountLinkingRequiredException]
- *
- * @param config The [AuthUIConfiguration] containing authentication settings
- * @param credential The [AuthCredential] to use for authentication. Can be from any provider.
- * @param displayName Optional display name from the provider to merge into the user profile
- * @param photoUrl Optional photo URL from the provider to merge into the user profile
- *
- * @return [AuthResult] containing the authenticated user
- *
- * @throws AuthException.InvalidCredentialsException if credential is invalid or expired
- * @throws AuthException.EmailAlreadyInUseException if linking and email is already in use
- * @throws AuthException.AuthCancelledException if the operation is cancelled
- * @throws AuthException.NetworkException if a network error occurs
- *
- * **Example: Google Sign-In**
- * ```kotlin
- * val googleCredential = GoogleAuthProvider.getCredential(idToken, null)
- * val displayName = "John Doe"  // From Google profile
- * val photoUrl = Uri.parse("https://...")  // From Google profile
- *
- * val result = firebaseAuthUI.signInAndLinkWithCredential(
- *     config = authUIConfig,
- *     credential = googleCredential,
- *     displayName = displayName,
- *     photoUrl = photoUrl
- * )
- * // User signed in with Google AND profile updated with Google data
- * ```
- *
- * **Example: Phone Auth**
- * ```kotlin
- * val phoneCredential = PhoneAuthProvider.getCredential(verificationId, code)
- *
- * val result = firebaseAuthUI.signInAndLinkWithCredential(
- *     config = authUIConfig,
- *     credential = phoneCredential
- * )
- * // User signed in with phone number
- * ```
- *
- * **Example: Phone Auth with Collision (Anonymous Upgrade)**
- * ```kotlin
- * // User is currently anonymous, trying to link a phone number
- * val phoneCredential = PhoneAuthProvider.getCredential(verificationId, code)
- *
- * try {
- *     firebaseAuthUI.signInAndLinkWithCredential(
- *         config = authUIConfig,
- *         credential = phoneCredential
- *     )
- * } catch (e: AuthException.AccountLinkingRequiredException) {
- *     // Phone number already exists on another account
- *     // Account linking required - UI can show account linking screen
- *     // User needs to sign in with existing account to link
- * }
- * ```
- *
- * **Example: Email Link Sign-In**
- * ```kotlin
- * val emailLinkCredential = EmailAuthProvider.getCredentialWithLink(
- *     email = "user@example.com",
- *     emailLink = emailLink
- * )
- *
- * val result = firebaseAuthUI.signInAndLinkWithCredential(
- *     config = authUIConfig,
- *     credential = emailLinkCredential
- * )
- * // User signed in with email link (passwordless)
- * ```
+ * Merges [displayName] and [photoUrl] into the Firebase profile once authenticated. A collision
+ * surfaces as [AuthException.AccountLinkingRequiredException] rather than the raw Firebase
+ * exception, so the host can drive the linking flow.
  */
 internal suspend fun AuthFlowScope.signInAndLinkWithCredential(
     credential: AuthCredential,
@@ -716,118 +507,13 @@ internal suspend fun AuthFlowScope.signInAndLinkWithCredential(
 }
 
 /**
- * Sends a passwordless sign-in link to the specified email address.
+ * Sends a passwordless sign-in link to [email].
  *
- * This method initiates the email-link (passwordless) authentication flow by sending
- * an email containing a magic link. The link includes session information for validation
- * and security.
- *
- * **How it works:**
- * 1. Generates a unique session ID for same-device validation
- * 2. Retrieves anonymous user ID if upgrading anonymous account
- * 3. Enriches the [ActionCodeSettings] URL with session data (session ID, anonymous user ID, force same-device flag)
- * 4. Sends the email via [com.google.firebase.auth.FirebaseAuth.sendSignInLinkToEmail]
- * 5. Saves session data to DataStore for validation when the user clicks the link
- * 6. User receives email with a magic link containing the session information
- * 7. When user clicks link, app opens via deep link and calls [signInWithEmailLink] to complete authentication
- *
- * **Account Linking Support:**
- * If a user tries to sign in with a social provider (Google, Facebook) but an email link
- * account already exists with that email, the social provider implementation should:
- * 1. Catch the [FirebaseAuthUserCollisionException] from the sign-in attempt
- * 2. Call [EmailLinkPersistenceManager.default.saveCredentialForLinking] with the provider tokens
- * 3. Call this method to send the email link
- * 4. When [signInWithEmailLink] completes, it automatically retrieves and links the saved credential
- *
- * **Session Security:**
- * - **Session ID**: Random 10-character string for same-device validation
- * - **Anonymous User ID**: Stored if upgrading anonymous account to prevent account hijacking
- * - **Force Same Device**: Can be configured via [AuthProvider.Email.isEmailLinkForceSameDeviceEnabled]
- * - All session data is validated in [signInWithEmailLink] before completing authentication
- *
- * @param context Android [Context] for DataStore access
- * @param config The [AuthUIConfiguration] containing authentication settings
- * @param provider The [AuthProvider.Email] configuration with [ActionCodeSettings]
- * @param email The email address to send the sign-in link to
- * @param credentialForLinking Optional [AuthCredential] from a social provider to link after email sign-in.
- *                             If provided, the credential is saved to DataStore and automatically linked
- *                             when [signInWithEmailLink] completes. Used for account linking flows.
- *
- * @throws AuthException.InvalidCredentialsException if email is invalid
- * @throws AuthException.AuthCancelledException if the operation is cancelled
- * @throws AuthException.NetworkException if a network error occurs
- * @throws IllegalStateException if ActionCodeSettings is not configured
- *
- * **Example 1: Basic email link sign-in**
- * ```kotlin
- * // Send the email link
- * firebaseAuthUI.sendSignInLinkToEmail(
- *     context = context,
- *     config = authUIConfig,
- *     provider = emailProvider,
- *     email = "user@example.com"
- * )
- * // Show "Check your email" UI to user
- *
- * // Later, when user clicks the link in their email:
- * // (In your deep link handling Activity)
- * val emailLink = intent.data.toString()
- * firebaseAuthUI.signInWithEmailLink(
- *     context = context,
- *     config = authUIConfig,
- *     provider = emailProvider,
- *     email = "user@example.com",
- *     emailLink = emailLink
- * )
- * // User is now signed in
- * ```
- *
- * **Example 2: Anonymous user upgrade**
- * ```kotlin
- * // User is currently signed in anonymously
- * // Send email link to upgrade anonymous account to permanent email account
- * firebaseAuthUI.sendSignInLinkToEmail(
- *     context = context,
- *     config = authUIConfig,
- *     provider = emailProvider,
- *     email = "user@example.com"
- * )
- * // Session includes anonymous user ID for validation
- * // When user clicks link, anonymous account is upgraded to permanent account
- * ```
- *
- * **Example 3: Social provider linking**
- * ```kotlin
- * try {
- *     // Try to sign in with Google
- *     authUI.signInWithGoogle(...)
- * } catch (e: FirebaseAuthUserCollisionException) {
- *     // Email already exists with email-link provider
- *     val googleCredential = e.updatedCredential
- *     
- *     // Save credential for linking
- *     EmailLinkPersistenceManager.default.saveCredentialForLinking(
- *         context = context,
- *         providerType = "google.com",
- *         idToken = (googleCredential as GoogleAuthCredential).idToken,
- *         accessToken = null
- *     )
- *     
- *     // Send email link with credential
- *     firebaseAuthUI.sendSignInLinkToEmail(
- *         context = context,
- *         config = authUIConfig,
- *         provider = emailProvider,
- *         email = e.email!!,
- *         credentialForLinking = googleCredential
- *     )
- *     // When user clicks link and signs in, Google is automatically linked
- * }
- * ```
- *
- * @see signInWithEmailLink
- * @see EmailLinkPersistenceManager
- * @see com.google.firebase.auth.FirebaseAuth.sendSignInLinkToEmail
+ * The link's continue URL carries a session id, the anonymous user's id when upgrading, and the
+ * force-same-device flag; the same values are persisted so [signInWithEmailLink] can validate
+ * the link when it comes back. [credentialForLinking] is stored alongside them, which is how a
+ * social credential that collided with an existing email-link account is linked once the user
+ * follows the link.
  */
 internal suspend fun AuthFlowScope.sendSignInLinkToEmail(
     context: Context,
@@ -883,108 +569,12 @@ internal suspend fun AuthFlowScope.sendSignInLinkToEmail(
 }
 
 /**
- * Signs in a user using an email link (passwordless authentication).
+ * Completes a passwordless sign-in from the link the user followed.
  *
- * This method completes the email link sign-in flow after the user clicks the magic link
- * sent to their email. It validates the link, extracts session information, and either
- * signs in the user normally or upgrades an anonymous account based on configuration.
- *
- * **Flow:**
- * 1. User receives email with magic link
- * 2. User clicks link, app opens via deep link
- * 3. Activity extracts emailLink from Intent.data
- * 4. This method validates and completes sign-in
- *
- * **Same-Device Flow:**
- * - Email is retrieved from DataStore automatically
- * - Session ID from link matches stored session ID
- * - User is signed in immediately without additional input
- *
- * **Cross-Device Flow:**
- * - Session ID from link doesn't match (or no local session exists)
- * - If [email] is empty: throws [AuthException.EmailLinkPromptForEmailException]
- * - User must provide their email address
- * - Call this method again with user-provided email to complete sign-in
- *
- * @param context Android [Context] for DataStore access
- * @param config The [AuthUIConfiguration] containing authentication settings
- * @param provider The [AuthProvider.Email] configuration with email-link settings
- * @param email The email address of the user. On same-device, retrieved from DataStore.
- *              On cross-device first call, pass empty string to trigger validation.
- *              On cross-device second call, pass user-provided email.
- * @param emailLink The complete deep link URL received from the Intent.
- * @param persistenceManager Optional [PersistenceManager] for testing. Defaults to [EmailLinkPersistenceManager.default]
- *
- * This URL contains:
- * - Firebase action code (oobCode) for authentication
- * - Session ID (ui_sid) for same-device validation
- * - Anonymous user ID (ui_auid) if upgrading anonymous account
- * - Force same-device flag (ui_sd) for security enforcement
- * - Provider ID (ui_pid) if linking social provider credential
- *
- * Example:
- * `https://yourapp.page.link/__/auth/action?oobCode=ABC123&continueUrl=https://yourapp.com?ui_sid=123456&ui_auid=anon-uid`
- *
- * @return [AuthResult] containing the signed-in user, or null if cross-device validation is required
- *
- * @throws AuthException.InvalidEmailLinkException if the email link is invalid or expired
- * @throws AuthException.EmailLinkPromptForEmailException if cross-device and email is empty
- * @throws AuthException.EmailLinkWrongDeviceException if force same-device is enabled on different device
- * @throws AuthException.EmailLinkCrossDeviceLinkingException if trying to link provider on different device
- * @throws AuthException.EmailLinkDifferentAnonymousUserException if anonymous user ID doesn't match
- * @throws AuthException.EmailMismatchException if email is empty on same-device flow
- * @throws AuthException.AuthCancelledException if the operation is cancelled
- * @throws AuthException.NetworkException if a network error occurs
- * @throws AuthException.UnknownException for other errors
- *
- * **Example 1: Same-device sign-in (automatic)**
- * ```kotlin
- * // In your deep link handler Activity:
- * val emailLink = intent.data.toString()
- * val savedEmail = EmailLinkPersistenceManager.default.retrieveSessionRecord(context)?.email
- *
- * if (savedEmail != null) {
- *     // Same device - email and session are stored
- *     val result = firebaseAuthUI.signInWithEmailLink(
- *         context = context,
- *         config = authUIConfig,
- *         provider = emailProvider,
- *         email = savedEmail,
- *         emailLink = emailLink
- *     )
- *     // User is signed in automatically
- * }
- * ```
- *
- * **Example 2: Cross-device sign-in (with email prompt)**
- * ```kotlin
- * // First call with empty email to validate link
- * try {
- *     firebaseAuthUI.signInWithEmailLink(
- *         context = context,
- *         config = authUIConfig,
- *         provider = emailProvider,
- *         email = "", // Empty email on different device
- *         emailLink = emailLink
- *     )
- * } catch (e: AuthException.EmailLinkPromptForEmailException) {
- *     // Show dialog asking user to enter their email
- *     val userEmail = showEmailInputDialog()
- *     
- *     // Second call with user-provided email
- *     val result = firebaseAuthUI.signInWithEmailLink(
- *         context = context,
- *         config = authUIConfig,
- *         provider = emailProvider,
- *         email = userEmail, // User provided email
- *         emailLink = emailLink
- *     )
- *     // User is now signed in
- * }
- * ```
- *
- * @see sendSignInLinkToEmail for sending the initial email link
- * @see EmailLinkPersistenceManager for session data management
+ * On the same device the address and session id come from storage and the user is signed in
+ * without further input. When the session id does not match — a different device, or storage
+ * cleared — an empty [email] raises [AuthException.EmailLinkPromptForEmailException]; call again
+ * with the address the user supplies.
  */
 internal suspend fun AuthFlowScope.signInWithEmailLink(
     context: Context,
@@ -1199,68 +789,9 @@ private suspend fun AuthFlowScope.handleEmailLinkCredentialLinkingFlow(
 }
 
 /**
- * Sends a password reset email to the specified email address.
+ * Sends a password reset email to [email] and emits [AuthState.PasswordResetLinkSent].
  *
- * This method initiates the "forgot password" flow by sending an email to the user
- * with a link to reset their password. The user will receive an email from Firebase
- * containing a link that allows them to set a new password for their account.
- *
- * **Flow:**
- * 1. Validate the email address exists in Firebase Auth
- * 2. Send password reset email to the user
- * 3. Emit [AuthState.PasswordResetLinkSent] state
- * 4. User clicks link in email to reset password
- * 5. User is redirected to Firebase-hosted password reset page (or custom URL if configured)
- *
- * **Error Handling:**
- * - If the email doesn't exist: throws [AuthException.UserNotFoundException]
- * - If the email is invalid: throws [AuthException.InvalidCredentialsException]
- * - If network error occurs: throws [AuthException.NetworkException]
- *
- * @param email The email address to send the password reset email to
- * @param actionCodeSettings Optional [ActionCodeSettings] to configure the password reset link.
- *                           Use this to customize the continue URL, dynamic link domain, and other settings.
- *
- * @throws AuthException.UserNotFoundException if no account exists with this email
- * @throws AuthException.InvalidCredentialsException if the email format is invalid
- * @throws AuthException.NetworkException if a network error occurs
- * @throws AuthException.AuthCancelledException if the operation is cancelled
- * @throws AuthException.UnknownException for other errors
- *
- * **Example 1: Basic password reset**
- * ```kotlin
- * try {
- *     firebaseAuthUI.sendPasswordResetEmail(
- *         email = "user@example.com"
- *     )
- *     // Show success message: "Password reset email sent to $email"
- * } catch (e: AuthException.UserNotFoundException) {
- *     // Show error: "No account exists with this email"
- * } catch (e: AuthException.InvalidCredentialsException) {
- *     // Show error: "Invalid email address"
- * }
- * ```
- *
- * **Example 2: Custom password reset with ActionCodeSettings**
- * ```kotlin
- * val actionCodeSettings = ActionCodeSettings.newBuilder()
- *     .setUrl("https://myapp.com/resetPassword")  // Continue URL after reset
- *     .setHandleCodeInApp(false)  // Use Firebase-hosted reset page
- *     .setAndroidPackageName(
- *         "com.myapp",
- *         true,  // Install if not available
- *         null   // Minimum version
- *     )
- *     .build()
- *
- * firebaseAuthUI.sendPasswordResetEmail(
- *     email = "user@example.com",
- *     actionCodeSettings = actionCodeSettings
- * )
- * // User receives email with custom continue URL
- * ```
- *
- * @see com.google.firebase.auth.ActionCodeSettings
+ * [actionCodeSettings] points the link at your own page instead of the Firebase-hosted one.
  */
 internal suspend fun AuthFlowScope.sendPasswordResetEmail(
     email: String,

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/FacebookAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/FacebookAuthProvider+FirebaseAuthUI.kt
@@ -47,7 +47,6 @@ import kotlinx.coroutines.launch
  * linking when an email collision occurs.
  *
  * @param context Android context for DataStore access when saving credentials for linking
- * @param config The [AuthUIConfiguration] containing authentication settings
  * @param provider The [AuthProvider.Facebook] configuration with scopes and credential provider
  * @param loginManagerProvider Provides logout operations to clear stale Facebook sessions
  * @param onSignInFailure Callback invoked with the resulting [AuthException] on failure
@@ -144,7 +143,6 @@ internal fun AuthFlowScope.rememberSignInWithFacebookLauncher(
  * for linking and throwing [AuthException.AccountLinkingRequiredException].
  *
  * @param context Android context for DataStore access when saving credentials for linking
- * @param config The [AuthUIConfiguration] containing authentication settings
  * @param provider The [AuthProvider.Facebook] configuration
  * @param accessToken The Facebook [AccessToken] from successful login
  * @param credentialProvider Creates Firebase credentials from Facebook tokens

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/FacebookAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/FacebookAuthProvider+FirebaseAuthUI.kt
@@ -33,7 +33,6 @@ import com.facebook.login.LoginResult
 import com.firebase.ui.auth.AuthFlowScope
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
-import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.util.EmailLinkPersistenceManager
 import com.firebase.ui.auth.util.SignInPreferenceManager
 import kotlinx.coroutines.CancellationException

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProvider+FirebaseAuthUI.kt
@@ -21,38 +21,9 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
 /**
- * Creates a remembered callback for Google Sign-In that can be invoked from UI components.
+ * Remembers a callback that runs [signInWithGoogle] in the composition's scope.
  *
- * This Composable function returns a lambda that, when invoked, initiates the Google Sign-In
- * flow using [signInWithGoogle]. The callback is rebuilt on every recomposition so it always
- * captures the latest parameters, and handles coroutine scoping and error state management.
- *
- * **Usage:**
- * ```kotlin
- * val onSignInWithGoogle = authUI.rememberGoogleSignInHandler(
- *     context = context,
- *     config = configuration,
- *     provider = googleProvider
- * )
- *
- * Button(onClick = onSignInWithGoogle) {
- *     Text("Sign in with Google")
- * }
- * ```
- *
- * **Error Handling:**
- * - Catches all exceptions and converts them to [AuthException]
- * - Automatically updates [AuthState.Error] on failures
- * - Logs errors for debugging purposes
- *
- * @param context Android context for Credential Manager
- * @param config Authentication UI configuration
- * @param provider Google provider configuration with server client ID and optional scopes
- * @param onSignInFailure Callback invoked with the resulting [AuthException] on failure
- * @return A callback function that initiates Google Sign-In when invoked
- *
- * @see signInWithGoogle
- * @see AuthProvider.Google
+ * Rebuilt on every recomposition, so it always captures the latest parameters.
  */
 @Composable
 internal fun AuthFlowScope.rememberGoogleSignInHandler(
@@ -78,41 +49,11 @@ internal fun AuthFlowScope.rememberGoogleSignInHandler(
 }
 
 /**
- * Signs in with Google using Credential Manager and optionally requests OAuth scopes.
+ * Signs in with Google through Credential Manager.
  *
- * This function implements Google Sign-In using Android's Credential Manager API with
- * comprehensive error handling.
- *
- * **Flow:**
- * 1. If [AuthProvider.Google.scopes] are specified, requests OAuth authorization first
- * 2. Attempts sign-in using Credential Manager
- * 3. Creates Firebase credential and calls [signInAndLinkWithCredential]
- *
- * **Scopes Behavior:**
- * - If [AuthProvider.Google.scopes] is not empty, requests OAuth authorization before sign-in
- * - Basic profile, email, and ID token are always included automatically
- * - Scopes are requested using the AuthorizationClient API
- *
- * **Error Handling:**
- * - [GoogleIdTokenParsingException]: Library version mismatch
- * - [NoCredentialException]: No Google accounts on device
- * - [GetCredentialCancellationException]: User dismissed the Credential Manager sheet -
- *   updates [AuthState.Cancelled] and does not throw
- * - [GetCredentialException]: Configuration errors or no credentials
- * - Configuration errors trigger detailed developer guidance logs
- *
- * @param context Android context for Credential Manager
- * @param config Authentication UI configuration
- * @param provider Google provider configuration with optional scopes
- * @param authorizationProvider Provider for OAuth scopes authorization (for testing)
- * @param credentialManagerProvider Provider for Credential Manager flow (for testing)
- *
- * @throws AuthException.InvalidCredentialsException if token parsing fails
- * @throws AuthException.AuthCancelledException if user cancels or no accounts found
- * @throws AuthException if sign-in or linking fails
- *
- * @see AuthProvider.Google
- * @see signInAndLinkWithCredential
+ * Requests OAuth authorization first when [AuthProvider.Google.scopes] is non-empty, then hands
+ * the credential to [signInAndLinkWithCredential], which owns anonymous upgrade and collision
+ * handling.
  */
 internal suspend fun AuthFlowScope.signInWithGoogle(
     context: Context,

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/GoogleAuthProvider+FirebaseAuthUI.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.credentials.CredentialManager
 import androidx.credentials.exceptions.GetCredentialCancellationException
-import androidx.credentials.exceptions.GetCredentialException
 import androidx.credentials.exceptions.NoCredentialException
 import com.firebase.ui.auth.AuthFlowScope
 import com.firebase.ui.auth.AuthException
@@ -16,7 +15,6 @@ import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.util.EmailLinkPersistenceManager
 import com.firebase.ui.auth.util.SignInPreferenceManager
 import com.google.android.gms.common.api.Scope
-import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
@@ -54,6 +52,9 @@ internal fun AuthFlowScope.rememberGoogleSignInHandler(
  * Requests OAuth authorization first when [AuthProvider.Google.scopes] is non-empty, then hands
  * the credential to [signInAndLinkWithCredential], which owns anonymous upgrade and collision
  * handling.
+ *
+ * Dismissing the Credential Manager sheet is not an error: it emits [AuthState.Cancelled] and
+ * returns normally rather than throwing, so the flow stays open on the method picker.
  */
 internal suspend fun AuthFlowScope.signInWithGoogle(
     context: Context,
@@ -210,7 +211,7 @@ internal suspend fun AuthFlowScope.signInWithGoogle(
  * - Before allowing user to select a different Google account
  * - When switching between accounts
  *
- * **Note:** This does not sign out from Firebase Auth itself. Call [FirebaseAuthUI.signOut]
+ * **Note:** This does not sign out from Firebase Auth itself. Call [com.firebase.ui.auth.FirebaseAuthUI.signOut]
  * separately if you need to sign out from Firebase.
  *
  * @param context Android context for Credential Manager

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
@@ -18,36 +18,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 
 /**
- * Creates a Composable handler for OAuth provider sign-in.
+ * Remembers a callback that runs [signInWithProvider] in the composition's scope.
  *
- * This function creates a sign-in handler, rebuilt on every recomposition so it always
- * captures the latest parameters, that can be invoked from button clicks or other UI events.
- * It automatically handles:
- * - Activity retrieval from LocalActivity
- * - Coroutine scope management
- * - Error handling and state updates
- *
- * **Usage:**
- * ```kotlin
- * val onSignInWithGitHub = authUI.rememberOAuthSignInHandler(
- *     config = configuration,
- *     provider = githubProvider
- * )
- *
- * Button(onClick = onSignInWithGitHub) {
- *     Text("Sign in with GitHub")
- * }
- * ```
- *
- * @param config Authentication UI configuration
- * @param provider OAuth provider configuration
- * @param onSignInFailure Callback invoked with the resulting [AuthException] on failure
- *
- * @return Lambda that triggers OAuth sign-in when invoked
- *
- * @throws IllegalStateException if LocalActivity.current is null
- *
- * @see signInWithProvider
+ * Rebuilt on every recomposition so it always captures the latest parameters, and resolves the
+ * host Activity itself.
  */
 @Composable
 internal fun AuthFlowScope.rememberOAuthSignInHandler(
@@ -83,44 +57,11 @@ internal fun AuthFlowScope.rememberOAuthSignInHandler(
 }
 
 /**
- * Signs in with an OAuth provider (GitHub, Microsoft, Yahoo, Apple, Twitter).
+ * Signs in with an OAuth provider — GitHub, Microsoft, Yahoo, Apple, Twitter, or a custom
+ * OIDC/SAML provider.
  *
- * This function implements OAuth provider authentication using Firebase's native OAuthProvider.
- * It handles both normal sign-in flow and anonymous user upgrade flow.
- *
- * **Supported Providers:**
- * - GitHub (github.com)
- * - Microsoft (microsoft.com)
- * - Yahoo (yahoo.com)
- * - Apple (apple.com)
- * - Twitter (twitter.com)
- *
- * **Flow:**
- * 1. Checks for pending auth results (e.g., from app restart during OAuth flow)
- * 2. If anonymous upgrade is enabled and user is anonymous, links credential to anonymous account
- * 3. Otherwise, performs normal sign-in
- * 4. Updates auth state to Idle on success
- *
- * **Anonymous Upgrade:**
- * If [AuthUIConfiguration.isAnonymousUpgradeEnabled] is true and a user is currently signed in
- * anonymously, this will attempt to link the OAuth credential to the anonymous account instead
- * of creating a new account.
- *
- * **Error Handling:**
- * - [AuthException.AuthCancelledException]: User cancelled OAuth flow
- * - [AuthException.AccountLinkingRequiredException]: Account collision (email already exists)
- * - [AuthException]: Other authentication errors
- *
- * @param config Authentication UI configuration
- * @param activity Activity for OAuth flow
- * @param provider OAuth provider configuration with scopes and custom parameters
- *
- * @throws AuthException.AuthCancelledException if user cancels
- * @throws AuthException.AccountLinkingRequiredException if account collision occurs
- * @throws AuthException if OAuth flow or sign-in fails
- *
- * @see AuthProvider.OAuth
- * @see signInAndLinkWithCredential
+ * Uses Firebase's native OAuth flow, then hands the credential to
+ * [signInAndLinkWithCredential], which owns anonymous upgrade and collision handling.
  */
 internal suspend fun AuthFlowScope.signInWithProvider(
     context: Context,

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/OAuthProvider+FirebaseAuthUI.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import com.firebase.ui.auth.AuthFlowScope
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
-import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.configuration.auth_provider.AuthProvider.Companion.canUpgradeAnonymous
 import com.firebase.ui.auth.util.SignInPreferenceManager
 import com.google.firebase.auth.FirebaseAuthUserCollisionException
@@ -20,8 +19,10 @@ import kotlinx.coroutines.tasks.await
 /**
  * Remembers a callback that runs [signInWithProvider] in the composition's scope.
  *
- * Rebuilt on every recomposition so it always captures the latest parameters, and resolves the
- * host Activity itself.
+ * Rebuilt on every recomposition so it always captures the latest parameters.
+ *
+ * @throws IllegalStateException if [activity] is null. This is raised while composing, not when
+ * the returned callback runs, so a host that cannot supply an Activity fails at first composition.
  */
 @Composable
 internal fun AuthFlowScope.rememberOAuthSignInHandler(
@@ -60,8 +61,10 @@ internal fun AuthFlowScope.rememberOAuthSignInHandler(
  * Signs in with an OAuth provider — GitHub, Microsoft, Yahoo, Apple, Twitter, or a custom
  * OIDC/SAML provider.
  *
- * Uses Firebase's native OAuth flow, then hands the credential to
- * [signInAndLinkWithCredential], which owns anonymous upgrade and collision handling.
+ * Runs Firebase's native OAuth activity flow and handles upgrade and collision itself: an
+ * eligible anonymous user is linked via `startActivityForLinkWithProvider`, and a collision
+ * becomes [AuthException.AccountLinkingRequiredException]. [signInAndLinkWithCredential] is used
+ * only to finish a `pendingAuthResult` left behind when the process died mid-flow.
  */
 internal suspend fun AuthFlowScope.signInWithProvider(
     context: Context,

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/PhoneAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/PhoneAuthProvider+FirebaseAuthUI.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import com.firebase.ui.auth.AuthFlowScope
 import com.firebase.ui.auth.AuthException
 import com.firebase.ui.auth.AuthState
-import com.firebase.ui.auth.configuration.AuthUIConfiguration
 import com.firebase.ui.auth.util.SignInPreferenceManager
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.MultiFactorSession

--- a/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/PhoneAuthProvider+FirebaseAuthUI.kt
+++ b/auth/src/main/java/com/firebase/ui/auth/configuration/auth_provider/PhoneAuthProvider+FirebaseAuthUI.kt
@@ -14,101 +14,19 @@ import com.google.firebase.auth.PhoneAuthProvider
 import kotlinx.coroutines.CancellationException
 
 /**
- * Initiates phone number verification with Firebase Phone Authentication.
+ * Starts phone verification for [phoneNumber].
  *
- * This method starts the phone verification flow, which can complete in two ways:
- * 1. **Instant verification** (auto): Firebase SDK automatically retrieves and verifies
- *    the SMS code without user interaction. This happens when Google Play services can
- *    detect the incoming SMS automatically.
- * 2. **Manual verification**: SMS code is sent to the user's device, and the user must
- *    manually enter the code via [submitVerificationCode].
+ * Firebase may verify instantly, emitting [AuthState.SMSAutoVerified] with a ready credential,
+ * or fall back to SMS and emit [AuthState.PhoneNumberVerificationRequired] for code entry.
+ * Passing [forceResendingToken] from that state resends the code.
  *
- * **Flow:**
- * - Call this method with the phone number
- * - Firebase SDK attempts instant verification
- * - If instant verification succeeds:
- *   - Emits [AuthState.SMSAutoVerified] with the credential
- *   - UI should observe this state and call [signInWithPhoneAuthCredential]
- * - If instant verification fails:
- *   - Emits [AuthState.PhoneNumberVerificationRequired] with verification details
- *   - UI should show code entry screen
- *   - User enters code → call [submitVerificationCode]
- *
- * **Lifecycle:** Firebase reports verification progress as a stream, so this call does not
- * return once the code is sent - on the SMS path it keeps collecting until the auto-retrieval
- * window expires, verification fails, or the caller is cancelled. A credential auto-retrieved
- * after [AuthState.PhoneNumberVerificationRequired] is therefore still emitted, as
- * [AuthState.SMSAutoVerified]. On the instant-verification path Firebase reports no terminal
- * callback at all, so only cancellation ends the call. Callers should cancel a superseded
- * attempt before starting a new one.
- *
- * **Resending codes:**
- * To resend a verification code, call this method again with:
- * - `forceResendingToken` = the token from [AuthState.PhoneNumberVerificationRequired]
- *
- * **Example: Basic phone verification**
- * ```kotlin
- * // Step 1: Start verification
- * firebaseAuthUI.verifyPhoneNumber(
- *     provider = phoneProvider,
- *     phoneNumber = "+1234567890",
- * )
- *
- * // Step 2: Observe AuthState
- * authUI.authStateFlow().collect { state ->
- *     when (state) {
- *         is AuthState.SMSAutoVerified -> {
- *             // Instant verification succeeded!
- *             showToast("Phone number verified automatically")
- *             // Now sign in with the credential
- *             firebaseAuthUI.signInWithPhoneAuthCredential(
- *                 config = authUIConfig,
- *                 credential = state.credential
- *             )
- *         }
- *         is AuthState.PhoneNumberVerificationRequired -> {
- *             // Show code entry screen
- *             showCodeEntryScreen(
- *                 verificationId = state.verificationId,
- *                 forceResendingToken = state.forceResendingToken
- *             )
- *         }
- *         is AuthState.Error -> {
- *             // Handle error
- *             showError(state.exception.message)
- *         }
- *     }
- * }
- *
- * // Step 3: When user enters code
- * firebaseAuthUI.submitVerificationCode(
- *     config = authUIConfig,
- *     verificationId = verificationId,
- *     code = userEnteredCode
- * )
- * ```
- *
- * **Example: Resending verification code**
- * ```kotlin
- * // User didn't receive the code, wants to resend
- * firebaseAuthUI.verifyPhoneNumber(
- *     provider = phoneProvider,
- *     phoneNumber = "+1234567890",
- *     forceResendingToken = savedToken  // From PhoneNumberVerificationRequired state
- * )
- * ```
- *
- * @param provider The [AuthProvider.Phone] configuration containing timeout and other settings
- * @param phoneNumber The phone number to verify in E.164 format (e.g., "+1234567890")
- * @param multiFactorSession Optional [MultiFactorSession] for MFA enrollment. When provided,
- * this initiates phone verification for enrolling a second factor rather than primary sign-in.
- * Obtain this from `FirebaseUser.multiFactor.session` when enrolling MFA.
- * @param forceResendingToken Optional token from previous verification for resending SMS
- *
- * @throws AuthException.InvalidCredentialsException if the phone number is invalid
- * @throws AuthException.TooManyRequestsException if SMS quota is exceeded
- * @throws AuthException.NetworkException if a network error occurs
- * @throws kotlinx.coroutines.CancellationException if the caller's coroutine is cancelled
+ * Firebase reports progress as a stream, so this call does not return when the code is sent. On
+ * the SMS path it keeps collecting until the auto-retrieval window expires, verification fails,
+ * or the caller is cancelled — so a credential auto-retrieved after
+ * [AuthState.PhoneNumberVerificationRequired] still arrives, and a host already on code entry
+ * must handle the late [AuthState.SMSAutoVerified]. On the instant path Firebase reports no
+ * terminal callback at all, so only cancellation ends the call: cancel a superseded attempt
+ * before starting a new one.
  */
 internal suspend fun AuthFlowScope.verifyPhoneNumber(
     provider: AuthProvider.Phone,
@@ -158,51 +76,13 @@ internal suspend fun AuthFlowScope.verifyPhoneNumber(
 }
 
 /**
- * Submits a verification code entered by the user and signs them in.
+ * Builds a credential from [verificationId] and the [code] the user typed, then signs in.
  *
- * This method is called after [verifyPhoneNumber] emits [AuthState.PhoneNumberVerificationRequired],
- * indicating that manual code entry is needed. It creates a [PhoneAuthCredential] from the
- * verification ID and user-entered code, then signs in the user by calling
- * [signInWithPhoneAuthCredential].
+ * Follows [AuthState.PhoneNumberVerificationRequired], which carries the verification id.
+ * Signing in goes through [signInWithPhoneAuthCredential], so anonymous upgrade is handled
+ * there rather than here.
  *
- * **Flow:**
- * 1. User receives SMS with 6-digit code
- * 2. User enters code in UI
- * 3. UI calls this method with the code
- * 4. Credential is created and used to sign in
- * 5. Returns [AuthResult] with signed-in user
- *
- * This method handles both normal sign-in and anonymous account upgrade scenarios based
- * on the [AuthUIConfiguration] settings.
- *
- * **Example: Manual code entry flow*
- * ```
- * val userEnteredCode = "123456"
- * try {
- *     val result = firebaseAuthUI.submitVerificationCode(
- *         config = authUIConfig,
- *         verificationId = savedVerificationId!!,
- *         code = userEnteredCode
- *     )
- *     // User is now signed in
- * } catch (e: AuthException.InvalidCredentialsException) {
- *     // Wrong code entered
- *     showError("Invalid verification code")
- * } catch (e: AuthException.SessionExpiredException) {
- *     // Code expired
- *     showError("Verification code expired. Please request a new one.")
- * }
- * ```
- *
- * @param config The [AuthUIConfiguration] containing authentication settings
- * @param verificationId The verification ID from [AuthState.PhoneNumberVerificationRequired]
- * @param code The 6-digit verification code entered by the user
- *
- * @return [AuthResult] containing the signed-in user
- *
- * @throws AuthException.InvalidCredentialsException if the code is incorrect or expired
- * @throws AuthException.AuthCancelledException if the operation is cancelled
- * @throws AuthException.NetworkException if a network error occurs
+ * @throws AuthException.InvalidCredentialsException when the code is wrong or has expired.
  */
 internal suspend fun AuthFlowScope.submitVerificationCode(
     context: Context,
@@ -235,65 +115,11 @@ internal suspend fun AuthFlowScope.submitVerificationCode(
 }
 
 /**
- * Signs in a user with a phone authentication credential.
+ * Signs in with a verified [PhoneAuthCredential], from either verification path.
  *
- * This method is the final step in the phone authentication flow. It takes a
- * [PhoneAuthCredential] (either from instant verification or manual code entry) and
- * signs in the user. The method handles both normal sign-in and anonymous account
- * upgrade scenarios by delegating to [signInAndLinkWithCredential].
- *
- * **When to call this:**
- * - After [verifyPhoneNumber] emits [AuthState.SMSAutoVerified] (instant verification)
- * - Called internally by [submitVerificationCode] (manual verification)
- *
- * The method automatically handles:
- * - Normal sign-in for new or returning users
- * - Linking phone credential to anonymous accounts (if enabled in config)
- * - Throwing [AuthException.AccountLinkingRequiredException] if phone number already exists on another account
- *
- * **Example: Sign in after instant verification**
- * ```kotlin
- * authUI.authStateFlow().collect { state ->
- *     when (state) {
- *         is AuthState.SMSAutoVerified -> {
- *             // Phone was instantly verified
- *             showToast("Phone verified automatically!")
- *
- *             // Now sign in with the credential
- *             val result = firebaseAuthUI.signInWithPhoneAuthCredential(
- *                 config = authUIConfig,
- *                 credential = state.credential
- *             )
- *             // User is now signed in
- *         }
- *     }
- * }
- * ```
- *
- * **Example: Anonymous upgrade with collision**
- * ```kotlin
- * // User is currently anonymous
- * try {
- *     firebaseAuthUI.signInWithPhoneAuthCredential(
- *         config = authUIConfig,
- *         credential = phoneCredential
- *     )
- * } catch (e: AuthException.AccountLinkingRequiredException) {
- *     // Phone number already exists on another account
- *     // Account linking required - show account linking screen
- *     // User needs to sign in with existing account to link
- * }
- * ```
- *
- * @param config The [AuthUIConfiguration] containing authentication settings
- * @param credential The [PhoneAuthCredential] to use for signing in
- *
- * @return [AuthResult] containing the signed-in user, or null if anonymous upgrade collision occurred
- *
- * @throws AuthException.InvalidCredentialsException if the credential is invalid or expired
- * @throws AuthException.EmailAlreadyInUseException if phone number is linked to another account
- * @throws AuthException.AuthCancelledException if the operation is cancelled
- * @throws AuthException.NetworkException if a network error occurs
+ * Delegates to [signInAndLinkWithCredential], so anonymous upgrade and the
+ * [AuthException.AccountLinkingRequiredException] raised when the number already belongs to
+ * another account behave as they do for every other provider.
  */
 internal suspend fun AuthFlowScope.signInWithPhoneAuthCredential(
     context: Context,


### PR DESCRIPTION
The auth KDoc had drifted from the API it documents. Thirteen internal functions still documented a `config` parameter that moved onto `AuthFlowScope`, `AuthState.PhoneNumberVerificationRequired` pointed at two `FirebaseAuthUI` methods that don't exist and an `isForceResendingTokenEnabled` flag that appears nowhere in the repo, `AuthFlowController.dispose()` claimed an `IllegalStateException` it can't throw, and three `authUIConfiguration {}` examples assigned `providers = listOf(...)`, which the builder's private setter rejects.

Fourteen internal helpers also carried 30-114 line KDocs whose examples called them on the wrong receiver, with the removed `config` parameter, and named types like `GoogleAuthCredential` that don't exist. Those are cut back to the claim. The one non-obvious behaviour worth keeping survives: `verifyPhoneNumber` doesn't return when the code is sent, so a host already on code entry still has to handle a late `SMSAutoVerified`.

Comments only - 91 insertions, 927 deletions, nothing changed outside a KDoc block. `:auth` unit suite green (78 classes, 985 tests) and checkstyle clean.

---
Maintainer note: Refs internal CPRN-427
