### PR TITLE
sample(app): drop the comments that restate the code in the auth demos

### DIFF
--- a/app/src/main/java/com/firebaseui/android/demo/auth/AuthChooserActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/AuthChooserActivity.kt
@@ -78,6 +78,7 @@ fun AuthChooserScreen(
         verticalArrangement = Arrangement.spacedBy(24.dp)
     ) {
         Spacer(modifier = Modifier.height(16.dp))
+
         Text(
             text = "Firebase Auth UI Compose",
             style = MaterialTheme.typography.headlineLarge,

--- a/app/src/main/java/com/firebaseui/android/demo/auth/AuthChooserActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/AuthChooserActivity.kt
@@ -78,7 +78,6 @@ fun AuthChooserScreen(
         verticalArrangement = Arrangement.spacedBy(24.dp)
     ) {
         Spacer(modifier = Modifier.height(16.dp))
-        // Header
         Text(
             text = "Firebase Auth UI Compose",
             style = MaterialTheme.typography.headlineLarge,
@@ -92,7 +91,6 @@ fun AuthChooserScreen(
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
 
-        // Emulator Mode Warning
         if (isEmulatorMode) {
             Card(
                 modifier = Modifier.fillMaxWidth(),
@@ -121,7 +119,6 @@ fun AuthChooserScreen(
             }
         }
 
-        // High-Level API Card
         Card(
             modifier = Modifier.fillMaxWidth(),
             onClick = onHighLevelApiClick
@@ -157,7 +154,6 @@ fun AuthChooserScreen(
             }
         }
 
-        // Low-Level API Card
         Card(
             modifier = Modifier.fillMaxWidth(),
             onClick = onLowLevelApiClick
@@ -193,7 +189,6 @@ fun AuthChooserScreen(
             }
         }
 
-        // Custom Slots & Theming Card
         Card(
             modifier = Modifier.fillMaxWidth(),
             onClick = onCustomSlotsClick
@@ -229,7 +224,6 @@ fun AuthChooserScreen(
             }
         }
 
-        // Credential Linking Card
         Card(
             modifier = Modifier.fillMaxWidth(),
             onClick = onCredentialLinkingClick
@@ -257,7 +251,6 @@ fun AuthChooserScreen(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Info card
         Card(
             modifier = Modifier.fillMaxWidth(),
             colors = CardDefaults.cardColors(

--- a/app/src/main/java/com/firebaseui/android/demo/auth/AuthFlowControllerDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/AuthFlowControllerDemoActivity.kt
@@ -27,27 +27,22 @@ import com.google.firebase.auth.actionCodeSettings
 import kotlinx.coroutines.launch
 
 /**
- * Demo activity showcasing the AuthFlowController API for managing
- * Firebase authentication with lifecycle-safe control.
+ * Drives the auth flow from an Activity with [AuthFlowController], instead of composing
+ * `FirebaseAuthScreen` directly.
  *
- * This demonstrates:
- * - Creating an AuthFlowController with configuration
- * - Starting the auth flow using ActivityResultLauncher
- * - Observing auth state changes
- * - Handling results (success, cancelled, error)
- * - Proper lifecycle management with dispose()
+ * The flow runs in its own Activity, so its result arrives through an `ActivityResultLauncher`
+ * rather than a callback. The controller owns a coroutine scope that nothing in the composition
+ * will clean up, so `onDestroy` has to dispose it.
  */
 class AuthFlowControllerDemoActivity : ComponentActivity() {
 
     private lateinit var authController: AuthFlowController
 
-    // Modern ActivityResultLauncher for auth flow
     private val authLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
         when (result.resultCode) {
             Activity.RESULT_OK -> {
-                // Get user data from result
                 val userId = result.data?.getStringExtra(FirebaseAuthActivity.EXTRA_USER_ID)
                 val isNewUser = result.data?.getBooleanExtra(
                     FirebaseAuthActivity.EXTRA_IS_NEW_USER,
@@ -71,10 +66,8 @@ class AuthFlowControllerDemoActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // Initialize FirebaseAuthUI
         val authUI = FirebaseAuthUI.getInstance()
 
-        // Create auth configuration
         val configuration = AuthUIConfiguration(
             context = applicationContext,
             providers = listOf(
@@ -112,7 +105,6 @@ class AuthFlowControllerDemoActivity : ComponentActivity() {
             privacyPolicyUrl = "https://policies.google.com/privacy?hl=en-NG&fg=1"
         )
 
-        // Create AuthFlowController
         authController = authUI.createAuthFlow(configuration)
 
         setContent {
@@ -133,7 +125,6 @@ class AuthFlowControllerDemoActivity : ComponentActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        // Clean up resources
         authController.dispose()
     }
 
@@ -163,7 +154,6 @@ fun AuthFlowDemo(
     val authState by authController.authStateFlow.collectAsState(AuthState.Idle)
     var currentUser by remember { mutableStateOf(FirebaseAuth.getInstance().currentUser) }
 
-    // Observe Firebase auth state changes
     DisposableEffect(Unit) {
         val authStateListener = FirebaseAuth.AuthStateListener { auth ->
             currentUser = auth.currentUser
@@ -204,7 +194,6 @@ fun AuthFlowDemo(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Current Auth State Card
         Card(
             modifier = Modifier.fillMaxWidth(),
             colors = CardDefaults.cardColors(
@@ -242,7 +231,6 @@ fun AuthFlowDemo(
             }
         }
 
-        // Current User Card
         currentUser?.let { user ->
             Card(
                 modifier = Modifier.fillMaxWidth(),
@@ -273,7 +261,6 @@ fun AuthFlowDemo(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Action Buttons
         if (currentUser == null) {
             Button(
                 onClick = onStartAuth,
@@ -301,7 +288,6 @@ fun AuthFlowDemo(
             }
         }
 
-        // Info Card
         Card(
             modifier = Modifier.fillMaxWidth()
         ) {

--- a/app/src/main/java/com/firebaseui/android/demo/auth/AuthFlowControllerDemoActivity.kt
+++ b/app/src/main/java/com/firebaseui/android/demo/auth/AuthFlowControllerDemoActivity.kt
@@ -30,9 +30,10 @@ import kotlinx.coroutines.launch
  * Drives the auth flow from an Activity with [AuthFlowController], instead of composing
  * `FirebaseAuthScreen` directly.
  *
- * The flow runs in its own Activity, so its result arrives through an `ActivityResultLauncher`
- * rather than a callback. The controller owns a coroutine scope that nothing in the composition
- * will clean up, so `onDestroy` has to dispose it.
+ * The flow runs in its own Activity, so its outcome arrives as an Activity result. That result
+ * only reports that the flow ended, which is why the demo also collects `authStateFlow` and
+ * registers an `AuthStateListener` beside it — those are what report progress and the signed-in
+ * user. Disposing the controller in `onDestroy` is the contract [AuthFlowController] documents.
  */
 class AuthFlowControllerDemoActivity : ComponentActivity() {
 


### PR DESCRIPTION
Every `//` comment in `AuthFlowControllerDemoActivity` and `AuthChooserActivity` was a label restating the line beneath it - `// Initialize FirebaseAuthUI` above `FirebaseAuthUI.getInstance()`, `// Clean up resources` above `dispose()`, `// Header` above a header. Eighteen of them, and not one explaining why anything was done. The newer demos (`EmailAuthSlotDemoActivity`, `PhoneAuthSlotDemoActivity`, `HighLevelApiDemoActivity`) all carry a reason instead, so these two were the odd ones out.

The class KDoc also used a `This demonstrates:` bullet list where every other demo uses prose. It now says what is actually distinctive about the Activity route: the flow runs in its own Activity, so the result arrives through an `ActivityResultLauncher` rather than a callback, and the controller owns a coroutine scope nothing in the composition will clean up.

Comments only. `:app:assembleDebug` and `checkstyle` both clean.

---
Maintainer note: Refs internal CPRN-427
