### PR TITLE
docs(auth): correct the 10.0 upgrade guide against the current API

### DIFF
--- a/docs/upgrade-to-10.0.md
+++ b/docs/upgrade-to-10.0.md
@@ -50,10 +50,10 @@ dependencies {
     // FirebaseUI Auth
     // Check Maven Central for the latest version:
     // https://central.sonatype.com/artifact/com.firebaseui/firebase-ui-auth/versions
-    implementation("com.firebaseui:firebase-ui-auth:10.0.0-beta02")
+    implementation("com.firebaseui:firebase-ui-auth:10.0.0-beta04")
 
     // Required: Jetpack Compose
-    implementation(platform("androidx.compose:compose-bom:2024.01.00"))
+    implementation(platform("androidx.compose:compose-bom:2026.06.01"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.material3:material3")
 }
@@ -107,10 +107,11 @@ class MainActivity : ComponentActivity() {
         setContent {
             MyAppTheme {
                 val configuration = authUIConfiguration {
-                    providers = listOf(
-                        AuthProvider.Email(),
-                        AuthProvider.Google()
-                    )
+                    context = applicationContext
+                    providers {
+                        provider(AuthProvider.Email())
+                        provider(AuthProvider.Google())
+                    }
                     theme = AuthUITheme.fromMaterialTheme()
                 }
 
@@ -151,18 +152,17 @@ List<AuthUI.IdpConfig> providers = Arrays.asList(
 **New (10.x):**
 ```kotlin
 val configuration = authUIConfiguration {
-    providers = listOf(
-        AuthProvider.Email(
-            isDisplayNameRequired = true
-        ),
-        AuthProvider.Google(
-            scopes = listOf("email"),
-            serverClientId = "YOUR_CLIENT_ID"
-        ),
-        AuthProvider.Phone(
-            defaultCountryCode = "US"
+    context = applicationContext
+    providers {
+        provider(AuthProvider.Email(isDisplayNameRequired = true))
+        provider(
+            AuthProvider.Google(
+                scopes = listOf("email"),
+                serverClientId = "YOUR_CLIENT_ID"
+            )
         )
-    )
+        provider(AuthProvider.Phone(defaultCountryCode = "US"))
+    }
 }
 ```
 
@@ -184,7 +184,8 @@ val configuration = authUIConfiguration {
 **New (10.x) - Material 3:**
 ```kotlin
 val configuration = authUIConfiguration {
-    providers = listOf(AuthProvider.Email())
+    context = applicationContext
+    providers { provider(AuthProvider.Email()) }
     theme = AuthUITheme(
         colorScheme = lightColorScheme(
             primary = Color(0xFF6200EE),
@@ -199,7 +200,8 @@ Or inherit from your app theme:
 ```kotlin
 MyAppTheme {
     val configuration = authUIConfiguration {
-        providers = listOf(AuthProvider.Email())
+        context = applicationContext
+        providers { provider(AuthProvider.Email()) }
         theme = AuthUITheme.fromMaterialTheme()
     }
 
@@ -360,31 +362,29 @@ If you have an existing Activity-based app and want to keep using Activities:
 class AuthActivity : ComponentActivity() {
     private lateinit var controller: AuthFlowController
 
+    private val authLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            startActivity(Intent(this, MainActivity::class.java))
+            finish()
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         val authUI = FirebaseAuthUI.getInstance()
         val configuration = authUIConfiguration {
-            providers = listOf(AuthProvider.Email(), AuthProvider.Google())
+            context = applicationContext
+            providers {
+                provider(AuthProvider.Email())
+                provider(AuthProvider.Google())
+            }
         }
 
         controller = authUI.createAuthFlow(configuration)
-
-        lifecycleScope.launch {
-            val state = controller.start()
-            when (state) {
-                is AuthState.Success -> {
-                    startActivity(Intent(this, MainActivity::class.java))
-                    finish()
-                }
-                is AuthState.Error -> {
-                    // Handle error
-                }
-                else -> {
-                    // Handle other states
-                }
-            }
-        }
+        authLauncher.launch(controller.createIntent(this))
     }
 
     override fun onDestroy() {
@@ -393,6 +393,11 @@ class AuthActivity : ComponentActivity() {
     }
 }
 ```
+
+The flow runs in its own Activity, so the outcome arrives as an Activity result rather than a
+return value. To follow it in more detail — loading, errors, MFA — collect
+`controller.authStateFlow` alongside the launcher. Dispose the controller in `onDestroy`; it owns
+a coroutine scope nothing else will clean up.
 
 ## Common Issues and Solutions
 
@@ -467,6 +472,8 @@ A back-stack key must be `@Serializable` to survive process death, so add the
 **Solution:** Convert XML themes to Kotlin code using `AuthUITheme`:
 ```kotlin
 val configuration = authUIConfiguration {
+    context = applicationContext
+    providers { provider(AuthProvider.Email()) }
     theme = AuthUITheme(
         colorScheme = lightColorScheme(
             primary = Color(0xFF6200EE),
@@ -488,7 +495,7 @@ val configuration = authUIConfiguration {
 
 ## Checklist
 
-- [ ] Updated dependency to `firebase-ui-auth:10.0.0-beta01`
+- [ ] Updated dependency to `firebase-ui-auth:10.0.0-beta04`
 - [ ] Migrated to Jetpack Compose
 - [ ] Converted Activities to ComponentActivities with `setContent {}`
 - [ ] Replaced `createSignInIntentBuilder()` with `authUIConfiguration {}`

--- a/docs/upgrade-to-10.0.md
+++ b/docs/upgrade-to-10.0.md
@@ -106,13 +106,16 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             MyAppTheme {
-                val configuration = authUIConfiguration {
-                    context = applicationContext
-                    providers {
-                        provider(AuthProvider.Email())
-                        provider(AuthProvider.Google())
+                val authTheme = AuthUITheme.fromMaterialTheme()
+                val configuration = remember(authTheme) {
+                    authUIConfiguration {
+                        context = applicationContext
+                        providers {
+                            provider(AuthProvider.Email())
+                            provider(AuthProvider.Google())
+                        }
+                        theme = authTheme
                     }
-                    theme = AuthUITheme.fromMaterialTheme()
                 }
 
                 FirebaseAuthScreen(
@@ -199,10 +202,14 @@ val configuration = authUIConfiguration {
 Or inherit from your app theme:
 ```kotlin
 MyAppTheme {
-    val configuration = authUIConfiguration {
-        context = applicationContext
-        providers { provider(AuthProvider.Email()) }
-        theme = AuthUITheme.fromMaterialTheme()
+    val localContext = LocalContext.current
+    val authTheme = AuthUITheme.fromMaterialTheme()
+    val configuration = remember(localContext, authTheme) {
+        authUIConfiguration {
+            context = localContext
+            providers { provider(AuthProvider.Email()) }
+            theme = authTheme
+        }
     }
 
     FirebaseAuthScreen(configuration = configuration, ...)

--- a/docs/upgrade-to-10.0.md
+++ b/docs/upgrade-to-10.0.md
@@ -153,6 +153,10 @@ List<AuthUI.IdpConfig> providers = Arrays.asList(
 ```
 
 **New (10.x):**
+
+`context` is required — the builder throws without it. `applicationContext` is an Activity
+property; from a composable use `LocalContext.current.applicationContext` instead.
+
 ```kotlin
 val configuration = authUIConfiguration {
     context = applicationContext
@@ -281,7 +285,10 @@ FirebaseAuth.getInstance().addAuthStateListener(firebaseAuth -> {
 @Composable
 fun AuthGate() {
     val authUI = remember { FirebaseAuthUI.getInstance() }
-    val authState by authUI.authStateFlow().collectAsState(initial = AuthState.Idle)
+    // remember the flow: authStateFlow() builds a new one per call, and without this every
+    // recomposition would restart collection and re-register the underlying Firebase listener.
+    val authStateFlow = remember(authUI) { authUI.authStateFlow() }
+    val authState by authStateFlow.collectAsState(initial = AuthState.Idle)
 
     when (authState) {
         is AuthState.Success -> {
@@ -391,7 +398,12 @@ class AuthActivity : ComponentActivity() {
         }
 
         controller = authUI.createAuthFlow(configuration)
-        authLauncher.launch(controller.createIntent(this))
+
+        // Only on a fresh start. Launching unguarded would start a second flow every time the
+        // Activity is recreated — a rotation, or a restore after process death.
+        if (savedInstanceState == null) {
+            authLauncher.launch(controller.createIntent(this))
+        }
     }
 
     override fun onDestroy() {
@@ -402,9 +414,10 @@ class AuthActivity : ComponentActivity() {
 ```
 
 The flow runs in its own Activity, so the outcome arrives as an Activity result rather than a
-return value. To follow it in more detail — loading, errors, MFA — collect
-`controller.authStateFlow` alongside the launcher. Dispose the controller in `onDestroy`; it owns
-a coroutine scope nothing else will clean up.
+return value. That result only says the flow ended, so to follow it in detail — loading, errors,
+MFA — collect `controller.authStateFlow` alongside the launcher. Dispose the controller in
+`onDestroy`: a disposed controller cannot be reused, and disposal is the contract its other
+members are documented against.
 
 ## Common Issues and Solutions
 
@@ -417,7 +430,9 @@ import com.firebase.ui.auth.configuration.authUIConfiguration
 
 ### Issue: "ActivityResultLauncher is deprecated"
 
-**Solution:** In 10.x, you no longer need `ActivityResultLauncher`. Use direct callbacks with `FirebaseAuthScreen` or `AuthFlowController`.
+**Solution:** Compose `FirebaseAuthScreen` and use its callbacks — no `ActivityResultLauncher`
+needed. The exception is the Activity-based route above: `AuthFlowController` hands you an Intent,
+so that one still launches through a result contract.
 
 ### Issue: "How do I customize the UI?"
 
@@ -509,7 +524,8 @@ val configuration = authUIConfiguration {
 - [ ] Updated all provider configurations
 - [ ] Converted XML themes to `AuthUITheme`
 - [ ] Updated error handling from result codes to exceptions
-- [ ] Removed `ActivityResultLauncher` code
+- [ ] Replaced `ActivityResultLauncher` with `FirebaseAuthScreen` callbacks (Activity-based apps
+      keep one, for `AuthFlowController.createIntent()`)
 - [ ] Updated sign-out to use suspend functions
 - [ ] Updated account deletion to use suspend functions
 - [ ] Tested all authentication flows


### PR DESCRIPTION
The 9.x-to-10.x guide had drifted from the API it documents, and the Low-Level API section was the worst of it: it showed `val state = controller.start()` returning an `AuthState` from a coroutine. No such method has ever existed - the real `start()` takes an Activity and a request code, returns `Unit`, and is deprecated. That section now registers an `ActivityResultLauncher` and launches `controller.createIntent(this)`, which is what `AuthFlowControllerDemoActivity` already does.

Every `authUIConfiguration {}` example also assigned `providers = listOf(...)`, which the builder rejects - its setter is private and the only entry point is the `providers { }` block. And none of the six config examples set `context`, which `build()` requires via `requireNotNull`, so each one threw at runtime as written.

Versions were inconsistent three ways: the dependency snippet said `beta02`, its own checklist said `beta01`, and the published version is `beta04`. The Compose BOM was pinned to `2024.01.00` against `2026.06.01` in `gradle/libs.versions.toml`.

Markdown only.

---
Maintainer note: Refs internal CPRN-427
